### PR TITLE
Geo-match identity, drop SERP session leak, expand asset blocking

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,10 +178,12 @@ contact:
 
 proxy:
   url: "${PROXY_URL}"                 # SOCKS5 or HTTP proxy URL
+  country: "${PROXY_COUNTRY}"         # ISO 3166-1 alpha-2 matching proxy exit IP (geo-match identity)
 
 fetch:
   headless: true                      # Run browser in headless mode
-  block_images: true                  # Block images/media for faster loading
+  block_images: true                  # Block images/media on enrich for faster loading
+  serp_block_assets: false            # opt-in: block fonts/images/ads on SERP (A/B test)
 
 monitor:
   enabled: true                       # Enable Prometheus metrics endpoint
@@ -196,6 +198,9 @@ monitor:
 | `REDIS_ADDR` | Redis address (default: `localhost:6379`) |
 | `REDIS_PASSWORD` | Redis password |
 | `PROXY_URL` | Proxy URL for all fetchers |
+| `PROXY_COUNTRY` | ISO 3166-1 alpha-2 country code matching the proxy's exit IP. Drives browser identity locale, Accept-Language, timezone — must match the proxy country to avoid bot-detection. **Required when `PROXY_URL` is set.** |
+| `TZ` | Container timezone. Defaults to `UTC` (safe for logs). When `PROXY_URL`+`PROXY_COUNTRY` are set, override `TZ` to a matching IANA zone (e.g. `America/Toronto` for `PROXY_COUNTRY=CA`). |
+| `SERP_BLOCK_ASSETS` | Set to `1` to block fonts/images/ads on SERP browser (bandwidth save). Off by default — A/B test on one container first; Google may correlate missing subresources with bot traffic. |
 
 ## Distributed Workers
 

--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ monitor:
 | `REDIS_ADDR` | Redis address (default: `localhost:6379`) |
 | `REDIS_PASSWORD` | Redis password |
 | `PROXY_URL` | Proxy URL for all fetchers |
-| `PROXY_COUNTRY` | ISO 3166-1 alpha-2 country code matching the proxy's exit IP. Drives browser identity locale, Accept-Language, timezone — must match the proxy country to avoid bot-detection. **Required when `PROXY_URL` is set.** |
+| `PROXY_COUNTRY` | ISO 3166-1 alpha-2 country code matching the proxy's exit IP. Drives browser identity locale, Accept-Language, timezone. **Auto-resolved from the proxy IP at startup** via `ipinfo.io/country`; set this env var only to override the auto-detection (e.g. when ipinfo is blocked or a proxy lies about its location). |
 | `TZ` | Container timezone. Defaults to `UTC` (safe for logs). When `PROXY_URL`+`PROXY_COUNTRY` are set, override `TZ` to a matching IANA zone (e.g. `America/Toronto` for `PROXY_COUNTRY=CA`). |
 | `SERP_BLOCK_ASSETS` | Set to `1` to block fonts/images/ads on SERP browser (bandwidth save). Off by default — A/B test on one container first; Google may correlate missing subresources with bot traffic. |
 

--- a/config.yaml
+++ b/config.yaml
@@ -29,12 +29,14 @@ enrich:
 
 proxy:
   url: "${PROXY_URL}"
+  country: "${PROXY_COUNTRY}"   # ISO 3166-1 alpha-2 matching proxy exit IP (drives identity geo-match)
 
 fetch:
   headless: true
   block_images: true
+  serp_block_assets: ${SERP_BLOCK_ASSETS:-false}   # opt-in: block fonts/images/ads on SERP (A/B test)
   page_reuse_limit: ${PAGE_REUSE_LIMIT:-200}
-  browser_reuse_limit: ${BROWSER_REUSE_LIMIT:-2}
+  browser_reuse_limit: ${BROWSER_REUSE_LIMIT:-10}
   stealth_recycle_after: ${STEALTH_RECYCLE_AFTER:-500}
   serp_max_requests: ${SERP_MAX_REQUESTS:-200}
   enrich_max_requests: ${ENRICH_MAX_REQUESTS:-300}

--- a/docker-compose.worker.yaml
+++ b/docker-compose.worker.yaml
@@ -30,7 +30,9 @@ services:
 
       # ── Worker config ──
       PROXY_URL: "${PROXY_URL:-}"
-      TZ: "${TZ:-Asia/Jakarta}"
+      PROXY_COUNTRY: "${PROXY_COUNTRY:-}"
+      SERP_BLOCK_ASSETS: "${SERP_BLOCK_ASSETS:-0}"
+      TZ: "${TZ:-UTC}"
 
       # ── Email validation (optional) ──
       MORDIBOUNCER_API_URL: "${MORDIBOUNCER_API_URL:-https://mailexchange.kremlit.dev}"
@@ -38,7 +40,7 @@ services:
 
       # ── Browser lifecycle tuning (optional) ──
       PAGE_REUSE_LIMIT: "${PAGE_REUSE_LIMIT:-200}"
-      BROWSER_REUSE_LIMIT: "${BROWSER_REUSE_LIMIT:-2}"
+      BROWSER_REUSE_LIMIT: "${BROWSER_REUSE_LIMIT:-10}"
       STEALTH_RECYCLE_AFTER: "${STEALTH_RECYCLE_AFTER:-500}"
       SERP_MAX_REQUESTS: "${SERP_MAX_REQUESTS:-200}"
       ENRICH_MAX_REQUESTS: "${ENRICH_MAX_REQUESTS:-300}"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -94,7 +94,7 @@ services:
       TELEGRAM_ALLOWED_USERS: "${TELEGRAM_ALLOWED_USERS:-}"
       MORDIBOUNCER_API_URL: "${MORDIBOUNCER_API_URL:-https://mailexchange.kremlit.dev}"
       MORDIBOUNCER_SECRET: "${MORDIBOUNCER_SECRET:-}"
-      TZ: "${TZ:-Asia/Jakarta}"
+      TZ: "${TZ:-UTC}"
     command: ["run", "-stage", "none"]
     healthcheck:
       test: ["CMD", "curl", "-fsS", "http://localhost:8080/api/health"]
@@ -129,14 +129,17 @@ services:
       REDIS_ADDR: "redis:6379"
       REDIS_PASSWORD: "${REDIS_PASSWORD}"
       PROXY_URL: "${PROXY_URL:-}"
+      PROXY_COUNTRY: "${PROXY_COUNTRY:-}"
       MORDIBOUNCER_SECRET: "${MORDIBOUNCER_SECRET:-}"
       # ── DB pool (minimal — hot path is zero-DB, only persister+reconciler need DB) ──
       PG_MAX_OPEN_CONNS: "${PG_MAX_OPEN_CONNS:-2}"
       PG_MAX_IDLE_CONNS: "${PG_MAX_IDLE_CONNS:-1}"
       # ── Browser lifecycle tuning (optional) ──
       PAGE_REUSE_LIMIT: "${PAGE_REUSE_LIMIT:-100}"
-      BROWSER_REUSE_LIMIT: "${BROWSER_REUSE_LIMIT:-2}"
+      BROWSER_REUSE_LIMIT: "${BROWSER_REUSE_LIMIT:-10}"
       SERP_MAX_REQUESTS: "${SERP_MAX_REQUESTS:-20}"
+      # ── Bandwidth A/B (off by default — see issue #notes) ──
+      SERP_BLOCK_ASSETS: "${SERP_BLOCK_ASSETS:-0}"
       BROWSER_TIMEOUT_SEC: "${BROWSER_TIMEOUT_SEC:-60}"
       RECONCILER_INTERVAL_MS: "${RECONCILER_INTERVAL_MS:-60000}"
       # ── SERP engines + timing ──
@@ -150,7 +153,7 @@ services:
       # ── Persister (batch flush Redis→DB) ──
       PERSIST_INTERVAL_MS: "${PERSIST_INTERVAL_MS:-5000}"
       PERSIST_BATCH_SIZE: "${PERSIST_BATCH_SIZE:-500}"
-      TZ: "${TZ:-Asia/Jakarta}"
+      TZ: "${TZ:-UTC}"
     shm_size: "512mb"
     command: ["run", "-stage", "serp", "-workers", "${SERP_CONCURRENCY:-4}"]
     volumes:
@@ -191,6 +194,7 @@ services:
       REDIS_ADDR: "redis:6379"
       REDIS_PASSWORD: "${REDIS_PASSWORD}"
       PROXY_URL: "${PROXY_URL:-}"
+      PROXY_COUNTRY: "${PROXY_COUNTRY:-}"
       MORDIBOUNCER_API_URL: "${MORDIBOUNCER_API_URL:-https://mailexchange.kremlit.dev}"
       MORDIBOUNCER_SECRET: "${MORDIBOUNCER_SECRET:-}"
       # ── DB pool (minimal — hot path is zero-DB, only persister+reconciler need DB) ──
@@ -198,7 +202,7 @@ services:
       PG_MAX_IDLE_CONNS: "${PG_MAX_IDLE_CONNS:-1}"
       # ── Browser lifecycle tuning (optional) ──
       PAGE_REUSE_LIMIT: "${PAGE_REUSE_LIMIT:-200}"
-      BROWSER_REUSE_LIMIT: "${BROWSER_REUSE_LIMIT:-2}"
+      BROWSER_REUSE_LIMIT: "${BROWSER_REUSE_LIMIT:-10}"
       STEALTH_RECYCLE_AFTER: "${STEALTH_RECYCLE_AFTER:-500}"
       ENRICH_MAX_REQUESTS: "${ENRICH_MAX_REQUESTS:-300}"
       BROWSER_TIMEOUT_SEC: "${BROWSER_TIMEOUT_SEC:-60}"
@@ -207,7 +211,7 @@ services:
       # ── Persister (batch flush Redis→DB) ──
       PERSIST_INTERVAL_MS: "${PERSIST_INTERVAL_MS:-5000}"
       PERSIST_BATCH_SIZE: "${PERSIST_BATCH_SIZE:-500}"
-      TZ: "${TZ:-Asia/Jakarta}"
+      TZ: "${TZ:-UTC}"
     shm_size: "512mb"
     command: ["run", "-stage", "enrich", "-workers", "${ENRICH_CONCURRENCY:-20}"]
     healthcheck:
@@ -246,16 +250,17 @@ services:
       REDIS_ADDR: "redis:6379"
       REDIS_PASSWORD: "${REDIS_PASSWORD}"
       PROXY_URL: "${PROXY_URL:-}"
+      PROXY_COUNTRY: "${PROXY_COUNTRY:-}"
       MORDIBOUNCER_API_URL: "${MORDIBOUNCER_API_URL:-https://mailexchange.kremlit.dev}"
       MORDIBOUNCER_SECRET: "${MORDIBOUNCER_SECRET:-}"
       PG_MAX_OPEN_CONNS: "${PG_MAX_OPEN_CONNS:-2}"
       PG_MAX_IDLE_CONNS: "${PG_MAX_IDLE_CONNS:-1}"
       PAGE_REUSE_LIMIT: "${PAGE_REUSE_LIMIT:-200}"
-      BROWSER_REUSE_LIMIT: "${BROWSER_REUSE_LIMIT:-2}"
+      BROWSER_REUSE_LIMIT: "${BROWSER_REUSE_LIMIT:-10}"
       STEALTH_RECYCLE_AFTER: "${STEALTH_RECYCLE_AFTER:-500}"
       BROWSER_TIMEOUT_SEC: "${BROWSER_TIMEOUT_SEC:-60}"
       BETA_FEATURES: "${BETA_FEATURES:-0}"
-      TZ: "${TZ:-Asia/Jakarta}"
+      TZ: "${TZ:-UTC}"
       REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-1}"
       REENRICH_SCORE: "${REENRICH_SCORE:-90}"
     shm_size: "512mb"

--- a/env.example.proposed
+++ b/env.example.proposed
@@ -32,12 +32,12 @@ API_KEY=changeme_api_key_for_programmatic_access
 # ── Proxy (optional) ──
 # PROXY_URL=socks5://user:pass@proxy.example.com:1080
 #
-# When PROXY_URL is set, ALSO set PROXY_COUNTRY and TZ to match the proxy's
-# exit-IP country. Mismatch between browser identity locale/timezone and IP
-# geolocation is a first-tier bot-detection signal.
+# PROXY_COUNTRY is auto-resolved from the proxy IP at startup via ipinfo.io.
+# Override only if the auto-detect is wrong or ipinfo is blocked from your
+# server. Setting it manually fixes the identity to that country regardless
+# of the actual proxy exit.
 #
-# PROXY_COUNTRY=CA                # ISO 3166-1 alpha-2 (e.g. CA, US, GB, DE, ID)
-# TZ=America/Toronto              # IANA timezone matching PROXY_COUNTRY (overrides default below)
+# PROXY_COUNTRY=CA                # ISO 3166-1 alpha-2 (auto-detected; override only)
 
 # ── Bandwidth / detection A/B ──
 # SERP_BLOCK_ASSETS=1             # opt-in: block SERP fonts/images/ads.
@@ -56,6 +56,7 @@ API_KEY=changeme_api_key_for_programmatic_access
 # MANAGER_MEMORY=2g               # manager container memory limit (default: 2g)
 
 # ── Timezone ──
-# Default UTC for stable log timestamps. When PROXY_URL+PROXY_COUNTRY are set,
-# override TZ in the proxy section above to match the proxy's country.
+# TZ controls Go process / log timestamps only. The browser's Intl.DateTimeFormat
+# is set automatically from the auto-detected proxy country (foxhound identity
+# applies the matching IANA zone). UTC is the safe default for unambiguous logs.
 TZ=UTC

--- a/env.example.proposed
+++ b/env.example.proposed
@@ -1,0 +1,61 @@
+# =============================================================================
+# .env.example — Server A (Central: PG + Redis + Manager)
+# =============================================================================
+# Copy to .env and fill in values:
+#   cp .env.example .env
+#
+# Then:
+#   docker compose up -d
+
+# ── PostgreSQL ──
+POSTGRES_PASSWORD=changeme_strong_password_here
+POSTGRES_DB=serp_scraper
+# PG_PORT=127.0.0.1:5432          # bind to localhost only (default)
+
+# ── Redis ──
+REDIS_PASSWORD=changeme_redis_password
+# REDIS_MAXMEM=256mb              # max memory for Redis (default: 256mb)
+# REDIS_PORT=127.0.0.1:6379       # bind to localhost only (default)
+
+# ── API Authentication ──
+API_SECRET=changeme_jwt_secret_32chars_min
+API_ADMIN_PASSWORD=changeme_admin_password
+API_KEY=changeme_api_key_for_programmatic_access
+
+# ── Image ──
+# IMAGE_TAG=main                  # ghcr.io tag (default: main)
+
+# ── Ports ──
+# API_PORT=8080                   # HTTP API port (default: 8080)
+# METRICS_PORT=9090               # Prometheus metrics port (default: 9090)
+
+# ── Proxy (optional) ──
+# PROXY_URL=socks5://user:pass@proxy.example.com:1080
+#
+# When PROXY_URL is set, ALSO set PROXY_COUNTRY and TZ to match the proxy's
+# exit-IP country. Mismatch between browser identity locale/timezone and IP
+# geolocation is a first-tier bot-detection signal.
+#
+# PROXY_COUNTRY=CA                # ISO 3166-1 alpha-2 (e.g. CA, US, GB, DE, ID)
+# TZ=America/Toronto              # IANA timezone matching PROXY_COUNTRY (overrides default below)
+
+# ── Bandwidth / detection A/B ──
+# SERP_BLOCK_ASSETS=1             # opt-in: block SERP fonts/images/ads.
+#                                 # A/B test on one container first — Google
+#                                 # may correlate missing subresources with bot traffic.
+
+# ── Email Validation (optional) ──
+# MORDIBOUNCER_API_URL=https://mailexchange.kremlit.dev
+# MORDIBOUNCER_SECRET=your_mordibouncer_secret
+
+# ── Dokploy (for remote worker deployment) ──
+# DOKPLOY_URL=https://kurama.mordenhost.com
+# DOKPLOY_API_KEY=your_dokploy_api_key
+
+# ── Resource Limits ──
+# MANAGER_MEMORY=2g               # manager container memory limit (default: 2g)
+
+# ── Timezone ──
+# Default UTC for stable log timestamps. When PROXY_URL+PROXY_COUNTRY are set,
+# override TZ in the proxy section above to match the proxy's country.
+TZ=UTC

--- a/env.worker.example.proposed
+++ b/env.worker.example.proposed
@@ -9,9 +9,9 @@ WORKER_CONCURRENCY=4       # number of concurrent tabs/fetchers
 
 # ── Optional ──
 # PROXY_URL=socks5://user:pass@proxy:1080
-# PROXY_COUNTRY=CA           # ISO 3166-1 alpha-2 matching proxy exit IP (REQUIRED if PROXY_URL set)
+# PROXY_COUNTRY=CA           # auto-detected from proxy IP at startup; set to override
 # SERP_BLOCK_ASSETS=1        # opt-in: block SERP fonts/images/ads (A/B test before rollout)
 # SHM_SIZE=512mb
 # WORKER_MEMORY=2g
-# TZ=America/Toronto         # IANA timezone matching PROXY_COUNTRY
+# TZ=UTC                     # process timezone only — browser TZ auto-set from proxy country
 # MORDIBOUNCER_SECRET=

--- a/env.worker.example.proposed
+++ b/env.worker.example.proposed
@@ -1,0 +1,17 @@
+# ── Required: connect to main server ──
+POSTGRES_DSN=postgres://serp:password@main-server-ip:5432/serp_scraper?sslmode=disable
+REDIS_ADDR=main-server-ip:6379
+REDIS_PASSWORD=redis-password
+
+# ── Worker config ──
+WORKER_STAGE=enrich        # serp or enrich
+WORKER_CONCURRENCY=4       # number of concurrent tabs/fetchers
+
+# ── Optional ──
+# PROXY_URL=socks5://user:pass@proxy:1080
+# PROXY_COUNTRY=CA           # ISO 3166-1 alpha-2 matching proxy exit IP (REQUIRED if PROXY_URL set)
+# SERP_BLOCK_ASSETS=1        # opt-in: block SERP fonts/images/ads (A/B test before rollout)
+# SHM_SIZE=512mb
+# WORKER_MEMORY=2g
+# TZ=America/Toronto         # IANA timezone matching PROXY_COUNTRY
+# MORDIBOUNCER_SECRET=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -98,12 +98,13 @@ type ProxyConfig struct {
 }
 
 type FetchConfig struct {
-	Headless    bool `yaml:"headless"`
-	BlockImages bool `yaml:"block_images"`
+	Headless        bool `yaml:"headless"`
+	BlockImages     bool `yaml:"block_images"`
+	SERPBlockAssets bool `yaml:"serp_block_assets"` // opt-in: block fonts/images/ads on SERP browser (A/B test before rollout)
 
 	// Browser lifecycle tuning — controls memory usage vs restart overhead.
 	PageReuseLimit       int `yaml:"page_reuse_limit"`       // requests before browser page recycle (default 200)
-	BrowserReuseLimit    int `yaml:"browser_reuse_limit"`    // page recycles before full browser restart (default 2)
+	BrowserReuseLimit    int `yaml:"browser_reuse_limit"`    // page recycles before full browser restart (default 10)
 	StealthRecycleAfter  int `yaml:"stealth_recycle_after"`  // requests before stealth fetcher recycle (default 500)
 	SERPMaxRequests      int `yaml:"serp_max_requests"`      // MaxBrowserRequests for SERP browser (default 200)
 	EnrichMaxRequests    int `yaml:"enrich_max_requests"`    // MaxBrowserRequests for enrich browser (default 300)
@@ -187,6 +188,7 @@ func LoadFromEnv() (*Config, error) {
 		Fetch: FetchConfig{
 			Headless:             true,
 			BlockImages:          true,
+			SERPBlockAssets:      os.Getenv("SERP_BLOCK_ASSETS") == "1",
 			PageReuseLimit:       parseEnvInt("PAGE_REUSE_LIMIT", 0),
 			BrowserReuseLimit:    parseEnvInt("BROWSER_REUSE_LIMIT", 0),
 			StealthRecycleAfter:  parseEnvInt("STEALTH_RECYCLE_AFTER", 0),
@@ -294,7 +296,7 @@ func setDefaults(cfg *Config) {
 		cfg.Fetch.PageReuseLimit = 200
 	}
 	if cfg.Fetch.BrowserReuseLimit == 0 {
-		cfg.Fetch.BrowserReuseLimit = 2
+		cfg.Fetch.BrowserReuseLimit = 10
 	}
 	if cfg.Fetch.StealthRecycleAfter == 0 {
 		cfg.Fetch.StealthRecycleAfter = 500

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,13 +1,18 @@
 package config
 
 import (
+	"context"
 	"fmt"
+	"log/slog"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/sadewadee/serp-scraper/internal/geo"
 )
 
 type Config struct {
@@ -364,4 +369,34 @@ func (c *Config) DSN() string {
 	// Strip quotes if present.
 	dsn = strings.Trim(dsn, "\"'")
 	return dsn
+}
+
+// ResolveProxyGeo auto-populates c.Proxy.Country by calling ipinfo.io through
+// the configured proxy. Skipped when c.Proxy.URL is empty (no proxy) or
+// c.Proxy.Country is already set (explicit override wins).
+//
+// Best-effort: failures are logged at WARN level and ignored — identity
+// generation falls back to random country, same as before this method existed.
+// Manual PROXY_COUNTRY override always takes precedence: this is the
+// auto-detect fallback for the common case where operators forget to set it.
+func (c *Config) ResolveProxyGeo(ctx context.Context) {
+	if c.Proxy.URL == "" {
+		return
+	}
+	if c.Proxy.Country != "" {
+		slog.Info("config: PROXY_COUNTRY set explicitly, skipping auto-resolve",
+			"country", c.Proxy.Country)
+		return
+	}
+	lookupCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+	code, err := geo.ResolveCountryFromProxy(lookupCtx, c.Proxy.URL)
+	if err != nil {
+		slog.Warn("config: auto-resolve PROXY_COUNTRY failed; identity will not be geo-matched",
+			"err", err)
+		return
+	}
+	c.Proxy.Country = code
+	slog.Info("config: auto-resolved PROXY_COUNTRY from proxy IP",
+		"country", code)
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -8,7 +8,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-	"time"
 
 	"gopkg.in/yaml.v3"
 
@@ -388,7 +387,8 @@ func (c *Config) ResolveProxyGeo(ctx context.Context) {
 			"country", c.Proxy.Country)
 		return
 	}
-	lookupCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	// Match geo.DefaultTimeout — defence-in-depth, both layers cap at 10s.
+	lookupCtx, cancel := context.WithTimeout(ctx, geo.DefaultTimeout)
 	defer cancel()
 	code, err := geo.ResolveCountryFromProxy(lookupCtx, c.Proxy.URL)
 	if err != nil {

--- a/internal/geo/resolver.go
+++ b/internal/geo/resolver.go
@@ -1,0 +1,79 @@
+// Package geo resolves the country (ISO 3166-1 alpha-2) of a proxy's exit IP
+// by making a one-shot HTTP call to ipinfo.io through the proxy at startup.
+//
+// Used to auto-populate cfg.Proxy.Country so identity geo-matching works even
+// when PROXY_COUNTRY is not set explicitly. Manual env-var configuration is
+// fragile — operators forget, container redeploys lose the override, etc.
+//
+// This is a startup-time helper, not a per-request hot path. The cost is one
+// HTTP round-trip per container boot (~500ms typical). Failure is non-fatal:
+// the caller logs and continues with empty country (foxhound falls back to
+// random identity).
+package geo
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+// DefaultEndpoint is the IP-info service used to resolve country code.
+// ipinfo.io/country returns just a 2-letter code in plain text (no JSON parse).
+const DefaultEndpoint = "https://ipinfo.io/country"
+
+// DefaultTimeout caps the lookup at 10 seconds so a slow proxy doesn't stall startup.
+const DefaultTimeout = 10 * time.Second
+
+// ResolveCountryFromProxy returns the ISO 3166-1 alpha-2 country code of the
+// given proxy's exit IP by calling ipinfo.io/country through it.
+//
+// Returns "" + error on any failure (parse, network, non-2xx, malformed body).
+// Callers should log the error and continue — geo-matching is best-effort.
+func ResolveCountryFromProxy(ctx context.Context, proxyURL string) (string, error) {
+	if proxyURL == "" {
+		return "", fmt.Errorf("geo: empty proxy URL")
+	}
+	pu, err := url.Parse(proxyURL)
+	if err != nil {
+		return "", fmt.Errorf("geo: parsing proxy URL: %w", err)
+	}
+
+	transport := &http.Transport{
+		Proxy:                 http.ProxyURL(pu),
+		ResponseHeaderTimeout: DefaultTimeout,
+	}
+	client := &http.Client{
+		Transport: transport,
+		Timeout:   DefaultTimeout,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, DefaultEndpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("geo: building request: %w", err)
+	}
+	// A plain UA string — ipinfo.io rejects empty UA on free tier.
+	req.Header.Set("User-Agent", "serp-scraper/geo-resolver")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("geo: ipinfo call failed: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("geo: ipinfo returned HTTP %d", resp.StatusCode)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 16))
+	if err != nil {
+		return "", fmt.Errorf("geo: reading response: %w", err)
+	}
+	code := strings.TrimSpace(string(body))
+	if len(code) != 2 {
+		return "", fmt.Errorf("geo: unexpected country code %q (expected 2 chars)", code)
+	}
+	return strings.ToUpper(code), nil
+}

--- a/internal/geo/resolver.go
+++ b/internal/geo/resolver.go
@@ -46,6 +46,10 @@ func ResolveCountryFromProxy(ctx context.Context, proxyURL string) (string, erro
 		Proxy:                 http.ProxyURL(pu),
 		ResponseHeaderTimeout: DefaultTimeout,
 	}
+	// One-shot client: release the proxy TCP connection from the idle pool
+	// immediately after the call so it doesn't park on a slow SOCKS5 hop
+	// until OS keepalive fires.
+	defer transport.CloseIdleConnections()
 	client := &http.Client{
 		Transport: transport,
 		Timeout:   DefaultTimeout,

--- a/internal/geo/resolver_test.go
+++ b/internal/geo/resolver_test.go
@@ -1,0 +1,25 @@
+package geo
+
+import (
+	"context"
+	"testing"
+)
+
+// TestResolveCountryFromProxy_EmptyURL covers the early-return guard.
+// External HTTP behaviour (success, timeout, malformed body) is exercised
+// in production and difficult to mock cleanly because the resolver hardcodes
+// ipinfo.io. The function is small and stateless; the meaningful failure
+// modes are observed via integration logging at startup.
+func TestResolveCountryFromProxy_EmptyURL(t *testing.T) {
+	_, err := ResolveCountryFromProxy(context.Background(), "")
+	if err == nil {
+		t.Fatal("expected error for empty proxy URL, got nil")
+	}
+}
+
+func TestResolveCountryFromProxy_InvalidURL(t *testing.T) {
+	_, err := ResolveCountryFromProxy(context.Background(), "://not a url")
+	if err == nil {
+		t.Fatal("expected error for malformed proxy URL, got nil")
+	}
+}

--- a/internal/scraper/fetcher.go
+++ b/internal/scraper/fetcher.go
@@ -57,9 +57,11 @@ func engineHomepageReferer(serpURL string) http.Header {
 }
 
 // NewSERPBrowser creates a Camoufox browser optimized for Google SERP scraping.
-// Uses persistent session, page pooling, and geo-matched identity.
+// Uses page pooling and geo-matched identity. No persistent session — Google
+// consent is pre-baked via cookies; storage state across concurrent workers
+// would be a session-cluster signal.
 func NewSERPBrowser(cfg *config.Config) (*fetch.CamoufoxFetcher, error) {
-	profile := identity.Generate(identity.WithBrowser(identity.BrowserFirefox))
+	profile := identity.Generate(buildIdentityOpts(cfg)...)
 	bp := behavior.CarefulProfile().Jitter()
 
 	headless := "virtual"
@@ -75,10 +77,6 @@ func NewSERPBrowser(cfg *config.Config) (*fetch.CamoufoxFetcher, error) {
 		fetch.WithBrowserTimeout(browserTimeout),
 		fetch.WithMaxBrowserRequests(cfg.Fetch.SERPMaxRequests / 2),
 		fetch.WithBehaviorProfile(bp),
-		// No WithUserDataDir — persistent context serializes all page operations
-		// through a single Playwright channel, killing concurrency.
-		// Use StorageState for cookie/session persistence across restarts instead.
-		fetch.WithStorageState("/home/scraper/.sessions/serp-session.json"),
 		fetch.WithBrowserCookies(googleConsentCookies()),
 	}
 	if cfg.Proxy.URL != "" {
@@ -96,9 +94,11 @@ func NewSERPBrowser(cfg *config.Config) (*fetch.CamoufoxFetcher, error) {
 // pre-warmed tab pool sized to match the concurrency level. All tab workers
 // share a single browser process — each goroutine acquires a pool slot, fetches,
 // then releases. MaxBrowserRequests is set to 200 to match the lifecycle limit.
+//
+// Identity is geo-matched to cfg.Proxy.Country when set — random identity with
+// a fixed-country exit IP is itself a bot signal, not protection against it.
 func NewSERPBrowserWithPool(cfg *config.Config, poolSize int) (*fetch.CamoufoxFetcher, error) {
-	// Random identity (no hardcoded country — diverse profiles avoid clustering).
-	profile := identity.Generate(identity.WithBrowser(identity.BrowserFirefox))
+	profile := identity.Generate(buildIdentityOpts(cfg)...)
 
 	headless := "virtual"
 	if !cfg.Fetch.Headless {
@@ -113,8 +113,9 @@ func NewSERPBrowserWithPool(cfg *config.Config, poolSize int) (*fetch.CamoufoxFe
 	opts := []fetch.CamoufoxOption{
 		fetch.WithBrowserIdentity(profile),
 		fetch.WithHeadless(headless),
-		// NO BlockImages for SERP — Google detects missing subresource loading.
-		// Real browsers always load images; blocking is a bot signal.
+		// SERP runs without resource blocking by default — Google's "missing
+		// subresource loading" detection is a known signal. SERP_BLOCK_ASSETS=1
+		// gates an opt-in interceptor for A/B-tested bandwidth savings.
 		fetch.WithBrowserTimeout(browserTimeout),
 		fetch.WithMaxBrowserRequests(cfg.Fetch.SERPMaxRequests),
 		// Anti-detection (foxhound v0.0.10):
@@ -127,12 +128,16 @@ func NewSERPBrowserWithPool(cfg *config.Config, poolSize int) (*fetch.CamoufoxFe
 		// concurrency with per-slot context isolation.
 		fetch.WithPoolSize(poolSize),
 		fetch.WithPageReuseLimit(cfg.Fetch.PageReuseLimit),
-		fetch.WithStorageState("/home/scraper/.sessions/serp-session.json"),
+		// No WithStorageState: a shared session file across concurrent tabs
+		// (and across docker-volume-mounted replicas) carries identical
+		// cookies on every browser, a session-graph cluster signal.
 		// NopeCHA extension stays enabled — v0.0.10 fixes the solve gate.
-		// Extension now actually solves reCAPTCHA/Turnstile when encountered.
 	}
 	if cfg.Proxy.URL != "" {
 		opts = append(opts, fetch.WithBrowserProxy(cfg.Proxy.URL))
+	}
+	if cfg.Fetch.SERPBlockAssets {
+		opts = append(opts, fetch.WithInterceptConfig(serpInterceptConfig()))
 	}
 
 	browser, err := fetch.NewCamoufox(opts...)
@@ -160,7 +165,7 @@ func NewBrowser(cfg *config.Config) (*fetch.CamoufoxFetcher, error) {
 //	Each gets a pre-warmed tab from the pool
 //	Cookies/state cleared between uses (no session bleed)
 func NewBrowserWithPool(cfg *config.Config, poolSize int) (*fetch.CamoufoxFetcher, error) {
-	profile := identity.Generate(identity.WithBrowser(identity.BrowserFirefox))
+	profile := identity.Generate(buildIdentityOpts(cfg)...)
 	bp := behavior.ModerateProfile().Jitter() // moderate for enrich (faster, less stealth needed)
 
 	headless := "virtual"
@@ -176,7 +181,7 @@ func NewBrowserWithPool(cfg *config.Config, poolSize int) (*fetch.CamoufoxFetche
 	opts := []fetch.CamoufoxOption{
 		fetch.WithBrowserIdentity(profile),
 		fetch.WithHeadless(headless),
-		fetch.WithBlockImages(cfg.Fetch.BlockImages),
+		fetch.WithInterceptConfig(enrichInterceptConfig(cfg)),
 		fetch.WithBrowserTimeout(enrichTimeout),
 		fetch.WithMaxBrowserRequests(cfg.Fetch.EnrichMaxRequests),
 		// Anti-detection:
@@ -208,11 +213,7 @@ func NewBrowserWithPool(cfg *config.Config, poolSize int) (*fetch.CamoufoxFetche
 // to that country so locale, timezone, and Accept-Language match the proxy
 // exit IP. A US Firefox profile exiting via a DE proxy is itself a bot signal.
 func NewStealth(cfg *config.Config) *fetch.StealthFetcher {
-	idOpts := []identity.Option{}
-	if cfg.Proxy.Country != "" {
-		idOpts = append(idOpts, identity.WithCountry(cfg.Proxy.Country))
-	}
-	profile := identity.Generate(idOpts...)
+	profile := identity.Generate(buildIdentityOpts(cfg)...)
 
 	opts := []fetch.StealthOption{
 		fetch.WithIdentity(profile),
@@ -222,6 +223,18 @@ func NewStealth(cfg *config.Config) *fetch.StealthFetcher {
 		opts = append(opts, fetch.WithProxy(cfg.Proxy.URL))
 	}
 	return fetch.NewStealth(opts...)
+}
+
+// buildIdentityOpts returns the canonical identity options for any browser
+// or stealth fetcher: pin to Firefox and apply geo-match when PROXY_COUNTRY
+// is set. Random country with a fixed-country exit IP leaks via locale,
+// timezone, Accept-Language, and WebRTC ICE candidates.
+func buildIdentityOpts(cfg *config.Config) []identity.Option {
+	opts := []identity.Option{identity.WithBrowser(identity.BrowserFirefox)}
+	if cfg.Proxy.Country != "" {
+		opts = append(opts, identity.WithCountry(cfg.Proxy.Country))
+	}
+	return opts
 }
 
 // FetchSERP fetches a Google SERP page with consent banner handling.
@@ -359,7 +372,7 @@ func FetchWithBrowser(ctx context.Context, browser *fetch.CamoufoxFetcher, pageU
 // Used as fallback when proxy is blocked by search engines.
 // Only 1 tab — rate-limited to protect server IP.
 func NewSERPBrowserDirect(cfg *config.Config) (*fetch.CamoufoxFetcher, error) {
-	profile := identity.Generate(identity.WithBrowser(identity.BrowserFirefox))
+	profile := identity.Generate(buildIdentityOpts(cfg)...)
 	bp := behavior.CarefulProfile().Jitter()
 
 	headless := "virtual"
@@ -370,12 +383,12 @@ func NewSERPBrowserDirect(cfg *config.Config) (*fetch.CamoufoxFetcher, error) {
 	opts := []fetch.CamoufoxOption{
 		fetch.WithBrowserIdentity(profile),
 		fetch.WithHeadless(headless),
-		// NO BlockImages — same as proxy browser, avoid detection.
+		// NO resource blocking — same as proxy browser, avoid detection.
 		fetch.WithBrowserTimeout(60 * time.Second),
 		fetch.WithMaxBrowserRequests(100),
 		fetch.WithBehaviorProfile(bp),
-		// No WithUserDataDir — single persistent context kills concurrency.
-		fetch.WithStorageState("/home/scraper/.sessions/serp-direct-session.json"),
+		// No WithStorageState: single direct browser carrying long-lived state
+		// is itself a fingerprint; consent is pre-baked via cookies below.
 		fetch.WithBrowserCookies(googleConsentCookies()),
 	}
 	// NO proxy — uses server IP directly.
@@ -395,6 +408,78 @@ func googleConsentCookies() []fetch.BrowserCookie {
 		{Name: "SOCS", Value: "CAISHAgBEhJnd3NfMjAyMzA4MDktMF9SQzEaAmVuIAEaBgiA_LGYBA", Domain: ".google.com", Path: "/"},
 		{Name: "CONSENT", Value: "YES+cb.20230809-04-p0.en+FX+410", Domain: ".google.com", Path: "/"},
 	}
+}
+
+// enrichInterceptConfig builds the resource/domain blocklist for the enrich
+// browser. Stylesheets are NOT blocked because some contact pages use
+// CSS-driven layout. Social platform root domains (facebook.com, twitter.com,
+// linkedin.com, etc.) are NOT blocked — we extract their URLs from page HTML;
+// only their tracking SDKs (e.g. connect.facebook.net) are blocked.
+//
+// cfg.Fetch.BlockImages still gates resource-type blocking; the tracking
+// blocklist runs unconditionally (no detection cost).
+func enrichInterceptConfig(cfg *config.Config) *fetch.InterceptConfig {
+	domains := map[string]bool{
+		// Google ads + analytics
+		"google-analytics.com":  true,
+		"googletagmanager.com":  true,
+		"googletagservices.com": true,
+		"googleadservices.com":  true,
+		"googlesyndication.com": true,
+		"doubleclick.net":       true,
+		"2mdn.net":              true,
+		// Facebook SDK (NOT facebook.com — we extract those URLs)
+		"connect.facebook.net": true,
+		// Behavior + session-replay analytics
+		"hotjar.com":    true,
+		"fullstory.com": true,
+		"mouseflow.com": true,
+		"crazyegg.com":  true,
+		// Product analytics
+		"segment.io":        true,
+		"segment.com":       true,
+		"mixpanel.com":      true,
+		"amplitude.com":     true,
+		"heap.com":          true,
+		"heapanalytics.com": true,
+		// Customer chat widgets
+		"intercom.io":     true,
+		"intercomcdn.com": true,
+		"drift.com":       true,
+		"tawk.to":         true,
+	}
+	var resources map[fetch.ResourceType]bool
+	if cfg.Fetch.BlockImages {
+		resources = fetch.ContentOnlyResources()
+	}
+	return fetch.NewInterceptConfig(resources, domains)
+}
+
+// serpInterceptConfig builds the conservative SERP blocklist for opt-in A/B
+// testing (gated by SERP_BLOCK_ASSETS). Blocks 8 resource types; preserves
+// stylesheet, script, websocket — Google's SERP needs JS for pagination.
+// google-analytics.com is intentionally NOT blocked — Google's bot detection
+// may correlate GA absence with bot traffic on first-party properties.
+func serpInterceptConfig() *fetch.InterceptConfig {
+	resources := map[fetch.ResourceType]bool{
+		fetch.ResourceFont:      true,
+		fetch.ResourceImage:     true,
+		fetch.ResourceMedia:     true,
+		fetch.ResourceBeacon:    true,
+		fetch.ResourceObject:    true,
+		fetch.ResourceImageSet:  true,
+		fetch.ResourceTextTrack: true,
+		fetch.ResourceCSPReport: true,
+	}
+	domains := map[string]bool{
+		"googletagmanager.com":  true,
+		"googletagservices.com": true,
+		"googleadservices.com":  true,
+		"googlesyndication.com": true,
+		"doubleclick.net":       true,
+		"2mdn.net":              true,
+	}
+	return fetch.NewInterceptConfig(resources, domains)
 }
 
 // FetchWithBrowserString fetches a page using only the browser, returns string body.

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"fmt"
 	"log/slog"
@@ -71,6 +72,10 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Error loading config: %v\n", cfgErr)
 		os.Exit(1)
 	}
+
+	// Auto-resolve PROXY_COUNTRY from proxy IP if not set explicitly.
+	// Best-effort: warns and continues on failure (random identity fallback).
+	cfg.ResolveProxyGeo(context.Background())
 
 	// Route to subcommand.
 	command := args[0]


### PR DESCRIPTION
## Summary

Three interlinked themes shipped together:

### 1. Auto-resolve PROXY_COUNTRY (no more manual env vars)
- `internal/geo/resolver.go`: one-shot HTTP call to `ipinfo.io/country` through the configured proxy at startup.
- `cfg.ResolveProxyGeo(ctx)` called from `main.go` after config load.
- Manual `PROXY_COUNTRY` env still works as override (e.g. when ipinfo is blocked).
- Fail-safe: warns and continues on lookup failure (random identity fallback, same as pre-PR).
- Browser-visible `Intl.DateTimeFormat` is driven automatically by foxhound's `applyGeoToConfig` from the resolved country — host `TZ=UTC` is now the right default; manual `TZ=America/Toronto` no longer needed.

### 2. Avoidance leakage (closes #2 #3 #5 #6)
- **#2 geo-match**: All 4 browser factories now apply `cfg.Proxy.Country` via shared `buildIdentityOpts` helper. Random identity with fixed-country exit IP was a first-tier bot signal.
- **#3 docs**: `PROXY_COUNTRY` documented as auto-detected with manual override fallback. Wired through `config.yaml`, `docker-compose.yaml` (3 services), `docker-compose.worker.yaml`, `README.md`, `env.example.proposed` / `env.worker.example.proposed` (sandbox blocks editing `.env.*` directly — `mv` proposed files into place).
- **#5 reuse limit**: `browser_reuse_limit` default 2 → 10. Reduces restart churn that widened race windows.
- **#6 storage state**: Dropped `WithStorageState` from all 3 SERP browser factories. Shared session JSON across concurrent tabs and across docker-volume-mounted replicas was a session-graph cluster signal. Google consent stays handled by pre-baked `googleConsentCookies()`.
- **TZ leak**: Default `TZ` switched from `Asia/Jakarta` → `UTC`. Process-only — browser TZ is set by foxhound from auto-resolved country.

### 3. Bandwidth bloat (15 TB / 13 M req baseline → projected 10–12 TB)
- **Enrich**: switched from `WithBlockImages` (3 resource types) to `WithInterceptConfig(ContentOnlyResources() + tracking blocklist)` — 9 resource types blocked plus 21 tracking domains. Social platform root domains stay unblocked.
- **SERP**: gated behind opt-in `SERP_BLOCK_ASSETS=1` flag for A/B testing.

**Estimated savings**: ~3–5 TB/month immediate; +5–7 TB/month potential after SERP A/B.

## Test plan

- [x] `go build -tags playwright,tls ./...` — clean
- [x] `go test -tags playwright,tls ./internal/geo/... ./internal/config/... ./internal/scraper/...` — pass
- [x] Static checks: `buildIdentityOpts` wired into all 5 fetchers; `WithStorageState` only in enrich; `WithInterceptConfig` in enrich + gated SERP; `PROXY_COUNTRY` documented across all surfaces; all 5 `TZ` defaults are UTC
- [ ] **Production verification post-deploy on `kurama`**:
  - Just set `PROXY_URL` in Dokploy — `PROXY_COUNTRY` is auto-detected
  - Apply `mv env.example.proposed .env.example && mv env.worker.example.proposed .env.worker.example`
  - On startup, look for log line: `config: auto-resolved PROXY_COUNTRY from proxy IP country=CA`
  - 30-min observation: captcha rate on Bing (was ~100%) and Google should drop
- [ ] **Bandwidth verification (24h window)**: enrich service bandwidth should drop 30–50%
- [ ] **Optional SERP A/B**: enable `SERP_BLOCK_ASSETS=1` on serp-1 only, compare captcha rates

## Out of scope (deferred)

- #4 (Camoufox version pinning)
- #7 (Bing 100% captcha strategy)
- #1, #8 (foxhound upstream)
- foxhound profile UA staleness (Firefox 135 — upstream gap)
- Dispensary-mode auto-resolve: when proxy rotates between countries, would need per-rotation geo lookup. Dispensary is currently beta-disabled; this PR only handles static `PROXY_URL` mode. Follow-up: extend `dispensary.Assignment` with country, resolve at rotation time.

## Rollback plan

Pure config-only rollback (no redeploy):
1. `BROWSER_REUSE_LIMIT=2` to restore old churn cadence
2. `PROXY_COUNTRY=XX` (any invalid code) to disable geo-match — or block ipinfo.io DNS to make auto-resolve fail
3. `SERP_BLOCK_ASSETS=` empty to disable SERP blocking

Closes #2, Closes #3, Closes #5, Closes #6