### PR TITLE
Pin Camoufox/NopeCHA versions + startup Firefox staleness check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,15 @@
 #     -e POSTGRES_DSN="postgres://..." \
 #     -e REDIS_ADDR="100.x.x.1:6379" \
 #     ghcr.io/sadewadee/foxhound-serp-scraper run -stage enrich -workers 20
+#
+# Pinned dependency versions (bump deliberately, not on every build):
+#   CAMOUFOX_VERSION — pip package; `python3 -m camoufox fetch` pulls the matching
+#                      browser binary from GitHub releases.  Verify the Firefox base
+#                      shipped by a new version before bumping (see internal/health/startup.go).
+#   NOPECHA_TAG      — NopeCHA Firefox extension GitHub release tag.
+#   PWGO_VER         — read from go.mod at build time (no separate ARG needed).
+ARG CAMOUFOX_VERSION=0.4.11
+ARG NOPECHA_TAG=0.5.6
 
 # ---------------------------------------------------------------------------
 # Stage 1: builder
@@ -50,8 +59,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     libxcomposite1 libxdamage1 libxrandr2 \
     && rm -rf /var/lib/apt/lists/*
 
-# Camoufox browser binary.
-RUN pip3 install --break-system-packages camoufox \
+# Camoufox browser binary (pinned — see ARG at top of file).
+ARG CAMOUFOX_VERSION
+RUN pip3 install --break-system-packages camoufox==${CAMOUFOX_VERSION} \
     && python3 -m camoufox fetch
 
 # Playwright Firefox driver (version from go.mod).
@@ -64,12 +74,14 @@ RUN apt-get update && apt-get install -y --no-install-recommends golang unzip \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/* /root/go/pkg /tmp/go.mod
 
-# Pre-cache NopeCHA extension (auto-solve captcha).
+# Pre-cache NopeCHA extension (pinned release — see ARG at top of file).
+# Using a pinned tag instead of /releases/latest avoids surprise breakage when
+# NopeCHA ships a release that changes extension manifest structure.
+ARG NOPECHA_TAG
 RUN mkdir -p /root/.cache/foxhound/extensions/nopecha \
-    && RELEASE_URL=$(curl -fsSL https://api.github.com/repos/NopeCHALLC/nopecha-extension/releases/latest \
-       | grep -o '"browser_download_url": *"[^"]*firefox\.zip"' \
-       | head -1 | cut -d'"' -f4) \
-    && curl -fsSL "$RELEASE_URL" -o /tmp/nopecha.zip \
+    && curl -fsSL \
+       "https://github.com/NopeCHALLC/nopecha-extension/releases/download/${NOPECHA_TAG}/firefox.zip" \
+       -o /tmp/nopecha.zip \
     && unzip -q /tmp/nopecha.zip -d /root/.cache/foxhound/extensions/nopecha \
     && rm /tmp/nopecha.zip
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,6 +15,7 @@ import (
 	"github.com/sadewadee/serp-scraper/internal/config"
 	"github.com/sadewadee/serp-scraper/internal/db"
 	"github.com/sadewadee/serp-scraper/internal/dedup"
+	"github.com/sadewadee/serp-scraper/internal/health"
 	"github.com/sadewadee/serp-scraper/internal/monitor"
 	"github.com/sadewadee/serp-scraper/internal/pipeline"
 	"github.com/sadewadee/serp-scraper/internal/reconciler"
@@ -65,6 +66,10 @@ func RunPipeline(cfg *config.Config, stageName string, workers int) error {
 		slog.Info("received signal, shutting down", "signal", sig)
 		cancel()
 	}()
+
+	// Startup diagnostics: check that Camoufox's embedded Firefox base is not
+	// too far behind upstream.  Best-effort — does not block startup.
+	go health.CheckCamoufoxStaleness(ctx, dd.Client())
 
 	// Start Prometheus metrics server.
 	if cfg.Monitor.Enabled {

--- a/internal/health/startup.go
+++ b/internal/health/startup.go
@@ -1,0 +1,209 @@
+// Package health provides startup diagnostics for the serp-scraper process.
+// It checks that browser dependencies (Camoufox Firefox base, NopeCHA) are
+// reasonably current and logs a WARN when they drift too far behind upstream.
+package health
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"os/exec"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+const (
+	// mozVersionURL is the Mozilla product-details endpoint for current Firefox versions.
+	mozVersionURL = "https://product-details.mozilla.org/1.0/firefox_versions.json"
+
+	// mozVersionCacheKey is the Redis key where the fetched Firefox version is cached.
+	mozVersionCacheKey = "health:firefox_latest_version"
+
+	// mozVersionCacheTTL is how long the fetched Firefox version is cached in Redis.
+	// 24 h is sufficient — Firefox releases are not more frequent than weekly.
+	mozVersionCacheTTL = 24 * time.Hour
+
+	// staleDays is the threshold in calendar days beyond which a Camoufox Firefox
+	// base is considered stale relative to the current upstream Firefox release.
+	staleDays = 30
+
+	// httpTimeout is the maximum time to spend fetching the Mozilla endpoint.
+	httpTimeout = 10 * time.Second
+)
+
+// mozVersionsResponse is the relevant subset of the Mozilla product-details JSON.
+type mozVersionsResponse struct {
+	LatestFirefoxVersion string `json:"LATEST_FIREFOX_VERSION"`
+}
+
+// CheckCamoufoxStaleness detects the Camoufox browser's embedded Firefox version,
+// fetches the current upstream Firefox release (cached in Redis for 24 h), and
+// logs an INFO or WARN message at startup.
+//
+// It is best-effort: any error (Mozilla endpoint down, camoufox not installed,
+// Redis unavailable) is logged at DEBUG and execution continues normally.
+//
+// Call this once from cmd/run.go after Redis is ready.
+func CheckCamoufoxStaleness(ctx context.Context, rdb *redis.Client) {
+	localFF, err := detectCamoufoxFirefoxVersion(ctx)
+	if err != nil {
+		slog.Debug("health: cannot detect Camoufox Firefox version", "error", err)
+		return
+	}
+
+	upstreamFF, err := currentFirefoxVersion(ctx, rdb)
+	if err != nil {
+		// Best-effort: log what we know, skip the comparison.
+		slog.Info("health: Camoufox Firefox base detected (upstream check unavailable)",
+			"camoufox_ff", localFF,
+			"error", err,
+		)
+		return
+	}
+
+	localMajor := parseMajor(localFF)
+	upstreamMajor := parseMajor(upstreamFF)
+
+	if localMajor == 0 || upstreamMajor == 0 {
+		slog.Info("health: Camoufox Firefox base detected",
+			"camoufox_ff", localFF,
+			"upstream_ff", upstreamFF,
+		)
+		return
+	}
+
+	// Approximate staleness: each major Firefox release is roughly 4 weeks.
+	// One major version gap ≈ 28 days; we warn at >staleDays (≈ >1 major behind).
+	approxDays := (upstreamMajor - localMajor) * 28
+
+	if approxDays > staleDays {
+		slog.Warn("health: Camoufox Firefox base is stale — consider bumping CAMOUFOX_VERSION in Dockerfile",
+			"camoufox_ff", localFF,
+			"upstream_ff", upstreamFF,
+			"approx_days_behind", approxDays,
+			"threshold_days", staleDays,
+		)
+	} else {
+		slog.Info("health: Camoufox Firefox base is current",
+			"camoufox_ff", localFF,
+			"upstream_ff", upstreamFF,
+			"approx_days_behind", approxDays,
+		)
+	}
+}
+
+// detectCamoufoxFirefoxVersion runs `python3 -m camoufox version` and parses
+// the Firefox version from its output.
+//
+// Camoufox prints lines like:
+//
+//	Camoufox 0.4.11 (Firefox 135.0.1)
+//
+// We extract the Firefox version from that line.
+func detectCamoufoxFirefoxVersion(ctx context.Context) (string, error) {
+	cmdCtx, cancel := context.WithTimeout(ctx, 15*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(cmdCtx, "python3", "-m", "camoufox", "version").CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("camoufox version: %w (output: %s)", err, strings.TrimSpace(string(out)))
+	}
+
+	return parseCamoufoxVersionOutput(string(out))
+}
+
+// versionLineRe matches "Firefox 135.0.1" or "Firefox 135.0.1-beta.24" anywhere in a line.
+var versionLineRe = regexp.MustCompile(`(?i)firefox\s+([\d]+[\d.\-a-zA-Z]*)`)
+
+// parseCamoufoxVersionOutput extracts the Firefox version string from camoufox
+// version command output.  It is exported for unit testing.
+func parseCamoufoxVersionOutput(output string) (string, error) {
+	m := versionLineRe.FindStringSubmatch(output)
+	if len(m) < 2 {
+		return "", fmt.Errorf("could not find Firefox version in camoufox output: %q", output)
+	}
+	return strings.TrimRight(m[1], ".-"), nil
+}
+
+// currentFirefoxVersion returns the latest upstream Firefox release version.
+// Results are cached in Redis for mozVersionCacheTTL to avoid hammering Mozilla.
+func currentFirefoxVersion(ctx context.Context, rdb *redis.Client) (string, error) {
+	// Try Redis cache first.
+	if rdb != nil {
+		cached, err := rdb.Get(ctx, mozVersionCacheKey).Result()
+		if err == nil && cached != "" {
+			return cached, nil
+		}
+	}
+
+	// Fetch from Mozilla.
+	version, err := fetchMozillaFirefoxVersion(ctx)
+	if err != nil {
+		return "", err
+	}
+
+	// Cache result.
+	if rdb != nil {
+		if setErr := rdb.Set(ctx, mozVersionCacheKey, version, mozVersionCacheTTL).Err(); setErr != nil {
+			slog.Debug("health: failed to cache Firefox version in Redis", "error", setErr)
+		}
+	}
+
+	return version, nil
+}
+
+// fetchMozillaFirefoxVersion fetches the current Firefox release version from
+// Mozilla's product-details API.
+func fetchMozillaFirefoxVersion(ctx context.Context) (string, error) {
+	httpCtx, cancel := context.WithTimeout(ctx, httpTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(httpCtx, http.MethodGet, mozVersionURL, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("User-Agent", "serp-scraper/health-check")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("fetch %s: %w", mozVersionURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("fetch %s: HTTP %d", mozVersionURL, resp.StatusCode)
+	}
+
+	var payload mozVersionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&payload); err != nil {
+		return "", fmt.Errorf("decode Mozilla versions: %w", err)
+	}
+
+	if payload.LatestFirefoxVersion == "" {
+		return "", fmt.Errorf("Mozilla API returned empty LATEST_FIREFOX_VERSION")
+	}
+
+	return payload.LatestFirefoxVersion, nil
+}
+
+// parseMajor extracts the major version integer from a version string like
+// "135.0.1" or "135.0.1-beta.24".  Returns 0 on parse failure.
+func parseMajor(version string) int {
+	parts := strings.SplitN(version, ".", 2)
+	if len(parts) == 0 {
+		return 0
+	}
+	// Strip any pre-release suffix from the major component (e.g. "135-beta").
+	major := strings.Split(parts[0], "-")[0]
+	n, err := strconv.Atoi(major)
+	if err != nil {
+		return 0
+	}
+	return n
+}

--- a/internal/health/startup_test.go
+++ b/internal/health/startup_test.go
@@ -1,0 +1,85 @@
+package health
+
+import (
+	"testing"
+)
+
+func TestParseCamoufoxVersionOutput(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:   "standard output",
+			output: "Camoufox 0.4.11 (Firefox 135.0.1)",
+			want:   "135.0.1",
+		},
+		{
+			name:   "beta suffix",
+			output: "Camoufox 0.4.9 (Firefox 135.0.1-beta.24)",
+			want:   "135.0.1-beta.24",
+		},
+		{
+			name:   "multiline output",
+			output: "fetching browser...\nCamoufox 0.4.11 (Firefox 135.0.1)\ndone",
+			want:   "135.0.1",
+		},
+		{
+			name:   "uppercase Firefox",
+			output: "FIREFOX 142.0",
+			want:   "142.0",
+		},
+		{
+			name:    "no version present",
+			output:  "something went wrong",
+			wantErr: true,
+		},
+		{
+			name:    "empty output",
+			output:  "",
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseCamoufoxVersionOutput(tc.output)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error, got nil (result=%q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestParseMajor(t *testing.T) {
+	tests := []struct {
+		input string
+		want  int
+	}{
+		{"135.0.1", 135},
+		{"135.0.1-beta.24", 135},
+		{"150.0.1", 150},
+		{"0.4.11", 0},
+		{"", 0},
+		{"abc", 0},
+		{"135", 135},
+	}
+
+	for _, tc := range tests {
+		got := parseMajor(tc.input)
+		if got != tc.want {
+			t.Errorf("parseMajor(%q) = %d, want %d", tc.input, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- **Dockerfile**: Add `CAMOUFOX_VERSION=0.4.11` and `NOPECHA_TAG=0.5.6` build ARGs so Docker layer cache is deterministic and version bumps require an explicit code change. `PWGO_VER` continues to derive from `go.mod` at build time. NopeCHA now downloads from a pinned tag URL instead of `/releases/latest`.

- **internal/health/startup.go** (new): `CheckCamoufoxStaleness(ctx, rdb)` runs once at startup. It:
  1. Runs `python3 -m camoufox version` to detect the embedded Firefox version.
  2. Fetches `https://product-details.mozilla.org/1.0/firefox_versions.json` (cached in Redis 24 h) to get upstream Firefox latest.
  3. Approximates the calendar-day gap (one major version ≈ 28 days).
  4. Logs `WARN` when gap > 30 days with `camoufox_ff`, `upstream_ff`, and `approx_days_behind` fields; logs `INFO` otherwise.
  5. Best-effort: any error (camoufox not installed, Mozilla endpoint down) is logged `DEBUG` and does not block startup.

- **cmd/run.go**: call `health.CheckCamoufoxStaleness` in a goroutine after Redis is ready.

## Current state

`CAMOUFOX_VERSION=0.4.11` ships Firefox 135.0.1-beta.24. Upstream Firefox is 150.0.1. The startup check will immediately log WARN (~42 major versions × 28 days ≈ ~210 days behind). This is expected and intentional — it surfaces the existing staleness. When camoufox upstream releases a newer pip package tracking a more current Firefox, bump the ARG and the WARN disappears.

## Test plan

- [x] `go test ./internal/health/...` — 7/7 tests pass
- [x] `go build -tags playwright,tls ./...` — clean
- [x] `go test -tags playwright,tls ./...` — all passing (dedup, health, monitor, stage)
- [ ] Reviewer: confirm no secrets in ARGs (CAMOUFOX_VERSION and NOPECHA_TAG are public version strings, not credentials)
- [ ] qa-engineer: boot the container locally, check startup log shows the Camoufox staleness WARN line

## Related

Closes issue #4 (version pinning). Separate PR for issue #7 (Bing browser fallback) follows.