### PR TITLE
Tail-parse country/city from address blob when JSON-LD lacks structured fields

### DIFF
--- a/internal/directory/jsonld.go
+++ b/internal/directory/jsonld.go
@@ -33,7 +33,7 @@ func extractFromJSONLD(ld map[string]any, source string) Listing {
 	// Address.
 	if addr, ok := ld["address"].(map[string]any); ok {
 		var parts []string
-		for _, key := range []string{"streetAddress", "addressLocality", "addressRegion", "postalCode"} {
+		for _, key := range []string{"streetAddress", "addressLocality", "addressRegion", "postalCode", "addressCountry"} {
 			if v, ok := addr[key].(string); ok && v != "" {
 				parts = append(parts, v)
 			}

--- a/internal/directory/jsonld_test.go
+++ b/internal/directory/jsonld_test.go
@@ -1,0 +1,22 @@
+package directory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractFromJSONLD_IncludesAddressCountry(t *testing.T) {
+	ld := map[string]any{
+		"address": map[string]any{
+			"streetAddress":   "521 Oak Grove Rd",
+			"addressLocality": "Flat Rock",
+			"addressRegion":   "NC",
+			"postalCode":      "28731",
+			"addressCountry":  "United States",
+		},
+	}
+	l := extractFromJSONLD(ld, "test")
+	if !strings.Contains(l.Address, "United States") {
+		t.Errorf("Address should include addressCountry; got %q", l.Address)
+	}
+}

--- a/internal/scraper/contact.go
+++ b/internal/scraper/contact.go
@@ -5,6 +5,8 @@ package scraper
 import (
 	"fmt"
 	"net"
+	"net/url"
+	"os"
 	"regexp"
 	"strings"
 
@@ -151,6 +153,19 @@ func ExtractContacts(body []byte) *ContactData {
 	// ── HTML address fallback (if JSON-LD didn't provide one) ──
 	if cd.Address == "" {
 		extractHTMLAddress(resp, cd)
+	}
+
+	// ── Address tail-parse fallback for City + Country ──
+	// Catches the common case where JSON-LD had no addressCountry/addressLocality
+	// and we have a raw address blob like "...Flat Rock, NC, United States" with
+	// the country (and a US-style city) embedded as trailing tokens.
+	if cd.Address != "" {
+		if cd.Country == "" {
+			cd.Country = tailParseCountry(cd.Address)
+		}
+		if cd.City == "" {
+			cd.City = tailParseCity(cd.Address)
+		}
 	}
 
 	// ── Page title fallback ──
@@ -459,6 +474,180 @@ func extractLDCityCountry(ld map[string]any) (string, string) {
 		}
 	}
 	return city, normalizeCountry(rawCountry)
+}
+
+// usStateCodes is the set of US state 2-letter codes used by tailParseCity to
+// recognize the canonical US-style "..., <city>, <ST>[ <zip>][, <country>]"
+// pattern. Mirrors the stateBlocklist in normalizeCountry — kept here as a
+// dedicated set so the city parser does not silently broaden to non-US
+// state-like tokens.
+var usStateCodes = map[string]bool{
+	"CA": true, "NY": true, "TX": true, "WA": true, "OR": true,
+	"FL": true, "IL": true, "MA": true, "PA": true, "AZ": true,
+	"CO": true, "NV": true, "NJ": true, "GA": true, "NC": true,
+	"VA": true, "MI": true, "OH": true, "IN": true, "MN": true,
+	"WI": true, "MO": true, "MD": true, "TN": true, "SC": true,
+	"AL": true, "KY": true, "LA": true, "OK": true, "CT": true,
+	"UT": true, "NM": true, "NH": true, "VT": true, "ME": true,
+	"RI": true, "DE": true, "HI": true, "AK": true, "ID": true,
+	"MT": true, "ND": true, "SD": true, "NE": true, "KS": true,
+	"WV": true, "AR": true, "MS": true, "IA": true, "DC": true,
+}
+
+// usCityRe matches a US-style trailing "<city>, <STATE>[<sep><zip>][, <country>]"
+// segment. Group 1 = city candidate, Group 2 = state code. The separator
+// between state and zip can be either a space ("TX 75244") or a comma
+// (", TX, 75244, USA") — both forms are common in scraped data. Anchored
+// to end of string so we extract the LAST city in the address (the
+// business location, not a street-level token).
+var usCityRe = regexp.MustCompile(`(?:^|,)\s*([^,]+?)\s*,\s*([A-Z]{2})\b(?:[\s,]+\d{5}(?:-\d{4})?)?(?:[\s,].*)?$`)
+
+// ccTLDToISO maps reliable ccTLDs to their ISO 3166-1 alpha-2 country code.
+// Curated allowlist — generic-looking ccTLDs (.io, .co, .me, .tv, .cc) are
+// deliberately excluded because they are dominated by global startups and
+// would mis-flag US/EU companies as British-Indian-Ocean-Territory etc.
+// Compound entries (".co.uk") must precede their single-component form.
+var ccTLDToISO = map[string]string{
+	// Compound (longest match first via lookup order below).
+	"co.uk": "GB", "org.uk": "GB", "ac.uk": "GB", "gov.uk": "GB",
+	"com.au": "AU", "net.au": "AU", "org.au": "AU",
+	"co.jp": "JP", "or.jp": "JP", "ne.jp": "JP",
+	"co.kr": "KR",
+	"co.id": "ID", "or.id": "ID", "ac.id": "ID",
+	"co.in":  "IN",
+	"co.nz":  "NZ",
+	"co.za":  "ZA",
+	"com.br": "BR", "com.mx": "MX", "com.sg": "SG", "com.my": "MY",
+	"com.tr": "TR", "com.tw": "TW", "com.hk": "HK", "com.ph": "PH",
+	// Single-component ccTLDs (high-signal: dominantly used by local entities).
+	"nl": "NL", "de": "DE", "fr": "FR", "it": "IT", "es": "ES",
+	"be": "BE", "at": "AT", "ch": "CH", "se": "SE", "no": "NO",
+	"dk": "DK", "fi": "FI", "pl": "PL", "pt": "PT", "ie": "IE",
+	"gr": "GR", "hu": "HU", "cz": "CZ", "ro": "RO", "ru": "RU",
+	"au": "AU", "nz": "NZ", "ca": "CA", "br": "BR", "mx": "MX",
+	"id": "ID", "jp": "JP", "kr": "KR", "in": "IN", "my": "MY",
+	"th": "TH", "vn": "VN", "ph": "PH", "sg": "SG", "tw": "TW",
+	"hk": "HK", "ae": "AE", "sa": "SA", "il": "IL", "tr": "TR",
+	"za": "ZA",
+}
+
+// tailParseCountry walks the comma-separated tokens of an address from the
+// tail backward and returns the first token that resolves via normalizeCountry
+// to a non-empty ISO alpha-2 code. Used as a fallback when JSON-LD did not
+// provide an addressCountry — e.g. raw HTML addresses like
+// "521 Oak Grove Rd, Flat Rock, NC, United States" where the country is
+// embedded as the trailing free-form token.
+//
+// Within each candidate segment we also try right-anchored word slices (last
+// 1..3 whitespace-separated words) so embedded forms like "239222\nSingapore"
+// or "6011\nNew Zealand" — common when a postal code and country share the
+// final comma segment — still resolve to SG / NZ.
+func tailParseCountry(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	parts := strings.Split(addr, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		candidate := strings.TrimRight(strings.TrimSpace(parts[i]), ".,;: ")
+		if candidate == "" {
+			continue
+		}
+		if iso := normalizeCountry(candidate); iso != "" {
+			return iso
+		}
+		// Collapse internal whitespace (incl. \n, \t) and try right-anchored
+		// word slices. Right-anchored only: avoids "USA Drive, ..." style
+		// false positives where the country-looking token is at the START
+		// of a street-name segment.
+		words := strings.Fields(candidate)
+		maxSlice := 3
+		if maxSlice > len(words) {
+			maxSlice = len(words)
+		}
+		for w := 1; w <= maxSlice; w++ {
+			slice := strings.Join(words[len(words)-w:], " ")
+			if iso := normalizeCountry(slice); iso != "" {
+				return iso
+			}
+		}
+	}
+	return ""
+}
+
+// tailParseCity returns the city from a US-style trailing address segment of
+// the form "..., <city>, <STATE>[ <zip>][, <country>]". Returns "" for any
+// address that does not match this canonical US shape — non-US addresses
+// have too many regional formats to parse reliably, and a wrong city is
+// worse than an empty one (per the "prefer empty over wrong" policy that
+// normalizeCountry also follows).
+func tailParseCity(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	m := usCityRe.FindStringSubmatch(addr)
+	if len(m) < 3 {
+		return ""
+	}
+	if !usStateCodes[strings.ToUpper(m[2])] {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// tldCountryHint returns the ISO 3166-1 alpha-2 code suggested by the host's
+// ccTLD, or "" if the TLD is not in the curated allowlist. Tries the
+// two-segment compound form first (.co.uk, .com.au) before falling back to
+// the single-segment ccTLD. Generic TLDs (.com, .io, .co, .me) deliberately
+// return "" to avoid false positives.
+func tldCountryHint(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimSuffix(host, ".")
+	if host == "" || !strings.Contains(host, ".") {
+		return ""
+	}
+	segs := strings.Split(host, ".")
+	if len(segs) >= 2 {
+		compound := segs[len(segs)-2] + "." + segs[len(segs)-1]
+		if iso, ok := ccTLDToISO[compound]; ok {
+			return iso
+		}
+	}
+	if iso, ok := ccTLDToISO[segs[len(segs)-1]]; ok {
+		return iso
+	}
+	return ""
+}
+
+// ApplyTLDCountryFallback fills cd.Country from the page URL's ccTLD when
+// it is still empty after all other extraction paths. Gated behind the
+// COUNTRY_TLD_FALLBACK_ENABLED env flag because ccTLD is a soft signal —
+// global companies on .com mask their origin and local sites occasionally
+// host on .io/.co. Off by default; callers opt in per-deployment.
+func ApplyTLDCountryFallback(cd *ContactData, pageURL string) {
+	if cd == nil || cd.Country != "" || pageURL == "" {
+		return
+	}
+	if !envFlagEnabled("COUNTRY_TLD_FALLBACK_ENABLED") {
+		return
+	}
+	u, err := url.Parse(pageURL)
+	if err != nil || u.Host == "" {
+		return
+	}
+	if iso := tldCountryHint(u.Host); iso != "" {
+		cd.Country = iso
+	}
+}
+
+// envFlagEnabled returns true when the named env var is set to a truthy
+// value ("1", "true", "yes", "on" — case-insensitive). All other values
+// (including unset / empty) return false.
+func envFlagEnabled(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 // whichYouTubePath reconstructs a canonical YouTube URL from the matched

--- a/internal/scraper/contact_test.go
+++ b/internal/scraper/contact_test.go
@@ -1,0 +1,227 @@
+//go:build playwright
+
+package scraper
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTailParseCountry(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+		want string
+	}{
+		// Verified production rows from the audit.
+		{"marineandboat US", "521 Oak Grove Rd, Flat Rock, NC, United States", "US"},
+		{"officialalphaland US", "Missouri City, TX 77489, United States", "US"},
+
+		// Country at tail in various forms.
+		{"GB at tail", "10 Downing St, London, United Kingdom", "GB"},
+		{"GB England", "1 High St, London, England", "GB"},
+		{"ID full name", "Jl. Sudirman 1, Jakarta, Indonesia", "ID"},
+		{"NL full name", "Compagnonsplein 1, 1234 AB Amsterdam, Netherlands", "NL"},
+		{"AU at tail", "1 George St, Sydney, NSW 2000, Australia", "AU"},
+		{"alpha-3 USA", "1 Main St, USA", "US"},
+		{"alpha-3 GBR", "1 Main St, GBR", "GB"},
+		{"trailing punct", "1 Main St, Indonesia.", "ID"},
+		{"trailing space", "1 Main St, Indonesia ", "ID"},
+
+		// Must NOT match — state codes & junk.
+		{"US state CA alone", "1 Infinite Loop, Cupertino, CA 95014", ""},
+		{"US state NC alone", "Foo, Flat Rock, NC", ""},
+		{"no comma cvsf.nl style", "Compagnonsplein 1", ""},
+		{"empty", "", ""},
+		{"single token", "FooBar", ""},
+		{"only zip", "12345", ""},
+		{"state with zip combined token", "TX 77489", ""},
+
+		// Tail-walk: country deeper than last token.
+		{"country before postal token", "1 Main St, Jakarta, Indonesia, 12345", "ID"},
+
+		// REAL PRODUCTION rows (DB verified, 2026-05-11) — verifies tail-walk
+		// across the actual address shapes seen in business_listings.
+		{"canada postal at tail", "1137, Derry Road East, Mississauga, ON, Canada, L5T 1P3", "CA"},
+		{"sg with newline", "20 Leonie Hill, #06-22, Singapore, 239222\nSingapore", "SG"},
+		{"montreal canada postal", "1250 Boulevard René Lévesque Ouest, Montréal, Canada, H3B 4W8", "CA"},
+		{"uk postal tail", "32 Lake Rd, Bowness-on-Windermere, Windermere LA23 3AP, United Kingdom", "GB"},
+		{"frankfurt germany", "Frankfurt, Germany", "DE"},
+		{"paris france", "75 bis Avenue Marceau, 75116 Paris, France", "FR"},
+		{"france postal", "ZI du bois de Leuze 12 rue Denis Papin, St Martin de Crau, France, 13310", "FR"},
+		{"jakarta indo", "AD Premier 9th floor, Jl. TB Simatupang No.5 Ragunan, Pasar Minggu, Jakarta Selatan 12550, DKI Jakarta, Indonesia", "ID"},
+		{"germany de-ni", "Hildesheim, DE-NI, Germany", "DE"},
+		{"india tail", "303, Camps Corner-II, Nr. Prahladnagar Garden, Satellite, Ahmedabad – 380 015. Gujarat, India", "IN"},
+		{"comma sep zip then country", "8344 Foothill Blvd, Sunland, CA, 91040, United States", "US"},
+
+		// Right-anchored word-slice fallback (DB-verified embedded-newline shapes).
+		{"singapore postal newline", "20 Leonie Hill, #06-22, Singapore, 239222\nSingapore", "SG"},
+		{"nz postal newline", "5/23 Waring Taylor Street\nWellington, Wellington, 6011\nNew Zealand", "NZ"},
+		{"ph postal trailing word", "522 J.A. Clarin St, Tagbilaran City, 6300 Bohol, Philippines", "PH"},
+		{"mexico with period", "TV AZTECA Periférico Sur 4121, Ciudad De México, México.", "MX"},
+
+		// Word-slice must NOT create false positives mid-segment.
+		{"usa drive false positive guard", "1 USA Drive, Some City", ""},
+		{"africa street guard", "South Africa Street, Boston, MA, 02134", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tailParseCountry(tc.addr)
+			if got != tc.want {
+				t.Errorf("tailParseCountry(%q) = %q; want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTailParseCity_USStyle(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+		want string
+	}{
+		// US-style address: ..., <city>, <STATE_CODE> [zip][, country]
+		{"marineandboat city", "521 Oak Grove Rd, Flat Rock, NC, United States", "Flat Rock"},
+		{"officialalphaland city", "Missouri City, TX 77489, United States", "Missouri City"},
+		{"cupertino", "1 Infinite Loop, Cupertino, CA 95014", "Cupertino"},
+		{"san antonio no zip", "1 Main St, San Antonio, TX", "San Antonio"},
+		{"city is first token", "Missouri City, TX 77489", "Missouri City"},
+		{"city with extended zip", "1 Main, Foo Town, CA 90210-1234", "Foo Town"},
+
+		// REAL PRODUCTION rows (DB verified, 2026-05-11) — comma-separated
+		// zip form: <city>, <STATE>, <ZIP>, <country>. This form was the
+		// original regex's blind spot.
+		{"sunland prod", "8344 Foothill Blvd, Sunland, CA, 91040, United States", "Sunland"},
+		{"swannanoa prod", "701 Warren Wilson Rd, Swannanoa, NC, 28778, USA", "Swannanoa"},
+		{"englewood prod", "61 West Palisade 2B, Englewood, NJ, 07631, USA", "Englewood"},
+		{"schaumburg prod", "1375   E Schaumburg Rd #100, Schaumburg, IL, 60194, USA", "Schaumburg"},
+		{"new york prod", "40 West 25th Street, 4th Fl, New York, NY, 10010, United States", "New York"},
+		{"dallas prod", "4100 Alpha Rd, Dallas, TX 75244, USA", "Dallas"},
+		{"streamwood prod", "1092 Frances Dr, Streamwood, IL 60107, USA", "Streamwood"},
+
+		// Must NOT match — non-US format or insufficient signal.
+		{"non-US Dutch", "Compagnonsplein 1, 1234 AB Amsterdam, Netherlands", ""},
+		{"no state pattern", "Just City, Indonesia", ""},
+		{"single token", "FooBar", ""},
+		{"empty", "", ""},
+		{"state-like but not US state", "Foo, GB, Bar", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tailParseCity(tc.addr)
+			if got != tc.want {
+				t.Errorf("tailParseCity(%q) = %q; want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTLDCountryHint(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		// Allowlisted ccTLDs.
+		{"NL", "cvsf.nl", "NL"},
+		{"NL with www", "www.cvsf.nl", "NL"},
+		{"DE", "example.de", "DE"},
+		{"FR", "example.fr", "FR"},
+		{"AU", "example.au", "AU"},
+		{"ID", "example.id", "ID"},
+		{"CH", "example.ch", "CH"},
+		{"JP", "example.jp", "JP"},
+
+		// Compound ccTLDs.
+		{"co.uk", "example.co.uk", "GB"},
+		{"com.au", "example.com.au", "AU"},
+		{"co.id", "example.co.id", "ID"},
+		{"co.jp", "example.co.jp", "JP"},
+		{"com.br", "example.com.br", "BR"},
+
+		// Subdomain handling.
+		{"deep subdomain", "shop.eu.example.de", "DE"},
+
+		// Excluded generic / ambiguous TLDs.
+		{"com", "example.com", ""},
+		{"net", "example.net", ""},
+		{"org", "example.org", ""},
+		{"io is ccTLD but generic in practice", "example.io", ""},
+		{"co generic", "example.co", ""},
+		{"me generic", "example.me", ""},
+		{"tv generic", "example.tv", ""},
+		{"app generic", "example.app", ""},
+		{"empty", "", ""},
+		{"no dot", "localhost", ""},
+
+		// With URL scheme stripping (function should handle host-only).
+		{"trailing dot", "example.de.", "DE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tldCountryHint(tc.host)
+			if got != tc.want {
+				t.Errorf("tldCountryHint(%q) = %q; want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyTLDCountryFallback_EnvGated(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		os.Unsetenv("COUNTRY_TLD_FALLBACK_ENABLED")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "https://cvsf.nl/about")
+		if cd.Country != "" {
+			t.Errorf("flag unset: want Country='', got %q", cd.Country)
+		}
+	})
+	t.Run("explicit false is no-op", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "false")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "https://cvsf.nl/about")
+		if cd.Country != "" {
+			t.Errorf("flag=false: want Country='', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true fills empty Country", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "https://cvsf.nl/about")
+		if cd.Country != "NL" {
+			t.Errorf("flag=true cvsf.nl: want Country='NL', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true does not overwrite existing Country", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{Country: "US"}
+		ApplyTLDCountryFallback(cd, "https://example.nl/")
+		if cd.Country != "US" {
+			t.Errorf("existing Country must not be overwritten: want 'US', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true, empty URL is no-op", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "")
+		if cd.Country != "" {
+			t.Errorf("empty URL: want Country='', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true, generic TLD is no-op", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "https://example.com/")
+		if cd.Country != "" {
+			t.Errorf("generic TLD: want Country='', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true, malformed URL is no-op", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "::not-a-url")
+		if cd.Country != "" {
+			t.Errorf("malformed URL: want Country='', got %q", cd.Country)
+		}
+	})
+}

--- a/internal/stage/enrich.go
+++ b/internal/stage/enrich.go
@@ -651,6 +651,7 @@ func (c *EnrichStage) worker(ctx context.Context, workerID int) {
 
 		// Extract contacts.
 		cd := internalScraper.ExtractContacts([]byte(body))
+		internalScraper.ApplyTLDCountryFallback(cd, pageURL)
 		emails := internalScraper.FilterEmails(cd.Emails)
 		phones := internalScraper.FilterPhones(cd.Phones)
 

--- a/internal/stage/reenrich.go
+++ b/internal/stage/reenrich.go
@@ -270,6 +270,7 @@ func (r *ReenrichStage) processRow(ctx context.Context, stealth *fetch.StealthFe
 
 	// Extract contacts from fetched body.
 	cd := internalScraper.ExtractContacts([]byte(body))
+	internalScraper.ApplyTLDCountryFallback(cd, row.URL)
 	emails := internalScraper.FilterEmails(cd.Emails)
 	phones := internalScraper.FilterPhones(cd.Phones)
 	socialLinks := buildSocialLinks(cd) // reuse enrich.go helper — same package

--- a/internal/standalone/runner.go
+++ b/internal/standalone/runner.go
@@ -317,6 +317,7 @@ func (r *Runner) runEnrichment(ctx context.Context, workerID int) {
 
 		// Regular page — extract contacts.
 		cd := scraper.ExtractContacts([]byte(body))
+		scraper.ApplyTLDCountryFallback(cd, pageURL)
 
 		// Store results.
 		for _, email := range cd.Emails {


### PR DESCRIPTION
## Summary

Audit 2026-05-11 menemukan ~27% baris `business_listings` punya `country=NULL` padahal trailing country tokens (`"Flat Rock, NC, United States"`, `"Compagnonsplein 1"`) ada di kolom `address`. Root cause: extractor cuma baca JSON-LD `addressCountry`; HTML fallback set `cd.Address` saja tanpa post-parse.

PR ini tambah 3 capability always-on + 1 opt-in env-gated, plus 1 bonus fix:

- **`tailParseCountry`** — walk comma-separated tokens dari tail, normalize via existing `normalizeCountry`. Right-anchored word slices handle embedded-newline shapes (`"239222\nSingapore"` → SG).
- **`tailParseCity`** — regex US-style `<city>, <ST>[<sep><zip>][, country]`. Handle dua-duanya: space-zip (`"Dallas, TX 75244"`) DAN comma-zip (`"Sunland, CA, 91040, United States"`). Form kedua sebelumnya luput, ketemu lewat validasi DB.
- **`ApplyTLDCountryFallback`** — curated ccTLD allowlist (`.nl, .de, .au, .id, .co.uk, .com.au`, dst). **Off by default**, gated lewat env `COUNTRY_TLD_FALLBACK_ENABLED=true`. Generic TLDs (`.com, .io, .co, .me`) sengaja excluded.
- **Bonus**: `internal/directory/jsonld.go` sebelumnya iterate `[streetAddress, addressLocality, addressRegion, postalCode]` — kelewatan `addressCountry`. One-key add.

## Behavior on verified-bad rows

| Domain | Old | New |
|--------|-----|-----|
| `marineandboat.directory` | country=NULL | **country=US, city=Flat Rock** (tail-parse) |
| `officialalphaland.com` | country=NULL | **country=US, city=Missouri City** (tail-parse) |
| `cvsf.nl` | country=NULL | **country=NL** (TLD fallback, only when env=true) |
| `crossfitmettle.com` | country=US | unchanged (gate prevents overwrite) |

## Risk gating

- Tail-parse selalu jalan — pakai existing `normalizeCountry` whitelist + state-code blocklist. Low risk: rejects ambiguous tokens, prefers empty over wrong.
- TLD fallback opt-in via env flag. ccTLD adalah soft signal — global companies pakai `.com` masks origin.
- Semua path di-gate `if cd.Country == ""` (tidak override existing value).

## Verification

- `go build -tags playwright ./...` clean
- `go vet -tags playwright ./...` clean
- `go test -tags playwright ./...` — 86 subtests passing, 0 fail. Termasuk 25 real-data case dari production DB (audit table `business_listings`).
- Paranoid check 60 row dengan `country IS NOT NULL` plausible → 0 regression. Gate `if cd.Country == ""` mencegah overwrite.

## Test plan

- [x] Unit tests: 86 subtests covering normalize, tail-parse country, tail-parse city, TLD hint, env-gated fallback, false-positive guards
- [x] Real-data validation: 25 production rows from DB
- [x] Paranoid regression check: 60 rows with country already filled
- [x] Build + vet clean
- [ ] Post-deploy: monitor `country IS NULL` count trend di production
- [ ] Post-deploy (opsional): set `COUNTRY_TLD_FALLBACK_ENABLED=true` di Dokploy worker env untuk uji ccTLD path

## Out-of-scope issues yang ketemu (separate PRs nanti)

1. Reenrich stale lock leak (708 row stuck, paling tua 3 hari)
2. `re_enrich_attempts` column dead — tidak pernah di-increment
3. DB migration regex (`migrate.go:447`) sumber 10K+ baris garbage di country column (UK postcode tails ditafsirkan sebagai country)
4. 2-letter ISO collision dengan US state (ID=Indonesia vs Idaho)
5. **Reenrich should offline-parse existing `address` column SEBELUM network refetch** — currently selalu refetch padahal data ada di DB