### PR TITLE
Reenrich offline pre-pass: derive country/city before refetching

### DIFF
--- a/internal/scraper/contact.go
+++ b/internal/scraper/contact.go
@@ -594,6 +594,19 @@ func tailParseCity(addr string) string {
 	return strings.TrimSpace(m[1])
 }
 
+// ParseAddressFallback runs tail-based country and city derivation on a raw
+// address string. Returns ISO alpha-2 country (or "") and US-style city
+// (or "") — the same logic that ExtractContacts applies internally after
+// HTML address fallback. Pure offline transform — no network. Exposed so
+// the reenrich worker can pre-pass existing DB rows before paying for a
+// network refetch, and the backfill CLI can sweep historical NULL rows.
+func ParseAddressFallback(address string) (country, city string) {
+	if address == "" {
+		return "", ""
+	}
+	return tailParseCountry(address), tailParseCity(address)
+}
+
 // tldCountryHint returns the ISO 3166-1 alpha-2 code suggested by the host's
 // ccTLD, or "" if the TLD is not in the curated allowlist. Tries the
 // two-segment compound form first (.co.uk, .com.au) before falling back to

--- a/internal/scraper/contact_test.go
+++ b/internal/scraper/contact_test.go
@@ -116,6 +116,35 @@ func TestTailParseCity_USStyle(t *testing.T) {
 	}
 }
 
+func TestParseAddressFallback(t *testing.T) {
+	cases := []struct {
+		name        string
+		addr        string
+		wantCountry string
+		wantCity    string
+	}{
+		{"empty", "", "", ""},
+		{"both filled US-style", "521 Oak Grove Rd, Flat Rock, NC, United States", "US", "Flat Rock"},
+		{"country only no US city", "Compagnonsplein 1, 1234 AB Amsterdam, Netherlands", "NL", ""},
+		{"country only newline embedded", "20 Leonie Hill, Singapore, 239222\nSingapore", "SG", ""},
+		{"neither resolves", "Compagnonsplein 1", "", ""},
+		{"both empty inputs", "   ", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCountry, gotCity := ParseAddressFallback(tc.addr)
+			if gotCountry != tc.wantCountry {
+				t.Errorf("ParseAddressFallback(%q) country = %q; want %q",
+					tc.addr, gotCountry, tc.wantCountry)
+			}
+			if gotCity != tc.wantCity {
+				t.Errorf("ParseAddressFallback(%q) city = %q; want %q",
+					tc.addr, gotCity, tc.wantCity)
+			}
+		})
+	}
+}
+
 func TestTLDCountryHint(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/stage/reenrich.go
+++ b/internal/stage/reenrich.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,11 +46,21 @@ func NewReenrichStage(cfg *config.Config, database *sql.DB, dd *dedup.Store) *Re
 	return &ReenrichStage{cfg: cfg, db: database, dedup: dd}
 }
 
-// reenrichRow is a candidate row from the eligibility query.
+// reenrichRow is a candidate row from the eligibility query. Address /
+// Country / City are surfaced for the offline pre-pass (applyOfflineParse)
+// so we can fill missing geo fields from the existing address blob without
+// paying a network refetch. EmailCount / PhoneCount drive the skip-fetch
+// decision — a row that already has contact data and just needs geo can
+// graduate via offline parse alone.
 type reenrichRow struct {
-	ID     int64
-	Domain string
-	URL    string
+	ID         int64
+	Domain     string
+	URL        string
+	Address    sql.NullString
+	Country    sql.NullString
+	City       sql.NullString
+	EmailCount int64
+	PhoneCount int64
 }
 
 // Run starts numWorkers goroutines each running the continuous re-enrich loop.
@@ -212,7 +223,16 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 		SET re_enrich_locked_at = NOW()
 		FROM eligible
 		WHERE bl.id = eligible.id
-		RETURNING bl.id, bl.domain, COALESCE(bl.website, 'https://' || bl.domain)
+		RETURNING
+			bl.id,
+			bl.domain,
+			COALESCE(bl.website, 'https://' || bl.domain),
+			bl.address,
+			bl.country,
+			bl.city,
+			(SELECT COUNT(*) FROM business_emails be WHERE be.business_id = bl.id),
+			(CASE WHEN bl.phone IS NOT NULL AND bl.phone != '' THEN 1 ELSE 0 END
+			 + COALESCE(array_length(bl.phones, 1), 0))
 	`
 
 	tx, err := r.db.BeginTx(queryCtx, nil)
@@ -234,7 +254,11 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 	var result []reenrichRow
 	for dbRows.Next() {
 		var row reenrichRow
-		if err := dbRows.Scan(&row.ID, &row.Domain, &row.URL); err != nil {
+		if err := dbRows.Scan(
+			&row.ID, &row.Domain, &row.URL,
+			&row.Address, &row.Country, &row.City,
+			&row.EmailCount, &row.PhoneCount,
+		); err != nil {
 			slog.Warn("reenrich: scan row failed", "error", err)
 			continue
 		}
@@ -251,6 +275,14 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 }
 
 func (r *ReenrichStage) processRow(ctx context.Context, stealth *fetch.StealthFetcher, row reenrichRow, workerID int) {
+	// Offline pre-pass: derive country/city from the existing address blob
+	// before paying for a network refetch. If the row already had contact
+	// data (emails/phones) and the offline parse fills in country+city, we
+	// can mark it done and skip the fetch entirely.
+	if r.applyOfflineParse(ctx, row, workerID) {
+		return
+	}
+
 	timeout := time.Duration(r.cfg.Enrich.TimeoutMs) * time.Millisecond
 	if timeout <= 0 {
 		timeout = 30 * time.Second
@@ -356,6 +388,86 @@ func (r *ReenrichStage) processRow(ctx context.Context, stealth *fetch.StealthFe
 			"phones", len(phones),
 			"worker", workerID)
 	}
+}
+
+// applyOfflineParse derives country/city from row.Address via the tail-parse
+// logic used by ExtractContacts, then writes any newly-derived values back to
+// business_listings. If the row already had at least one email/phone AND the
+// offline parse produced (or row already had) both country and city, the row
+// is marked re_enriched_at = NOW() and the function returns true — caller
+// skips the network fetch.
+//
+// Returns true when the network fetch can be skipped, false when the worker
+// should proceed with the normal fetch path. Errors fall through to the
+// network path (defensive — better to refetch than lose a row).
+func (r *ReenrichStage) applyOfflineParse(ctx context.Context, row reenrichRow, workerID int) bool {
+	if !row.Address.Valid || strings.TrimSpace(row.Address.String) == "" {
+		return false
+	}
+
+	parsedCountry, parsedCity := internalScraper.ParseAddressFallback(row.Address.String)
+	newCountry, newCity, skipFetch := offlineParseDecision(row, parsedCountry, parsedCity)
+
+	if newCountry.Valid || newCity.Valid {
+		// COALESCE on the SQL side mirrors the trigger's merge semantics: only
+		// overwrite when the existing column is NULL. Defensive against races
+		// where another worker filled the column between our SELECT and UPDATE.
+		_, err := r.db.ExecContext(ctx, `
+			UPDATE business_listings
+			SET country    = COALESCE(country, $2),
+			    city       = COALESCE(city,    $3),
+			    updated_at = NOW()
+			WHERE id = $1
+		`, row.ID, newCountry, newCity)
+		if err != nil {
+			slog.Warn("reenrich: offline parse update failed, will fall through to fetch",
+				"id", row.ID, "domain", row.Domain, "error", err, "worker", workerID)
+			return false
+		}
+		slog.Debug("reenrich: offline parse filled",
+			"id", row.ID, "domain", row.Domain,
+			"new_country", newCountry.String, "new_city", newCity.String,
+			"worker", workerID)
+	}
+
+	if !skipFetch {
+		return false
+	}
+
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE business_listings
+		SET re_enriched_at = NOW(), re_enrich_locked_at = NULL
+		WHERE id = $1
+	`, row.ID)
+	if err != nil {
+		slog.Warn("reenrich: mark done after offline parse failed, falling through to fetch",
+			"id", row.ID, "domain", row.Domain, "error", err, "worker", workerID)
+		return false
+	}
+	r.processed.Add(1)
+	slog.Info("reenrich: completed via offline parse (no network)",
+		"id", row.ID, "domain", row.Domain,
+		"filled_country", newCountry.Valid, "filled_city", newCity.Valid,
+		"worker", workerID)
+	return true
+}
+
+// offlineParseDecision is the pure-logic core of applyOfflineParse — given
+// the row's current state and the parsed (country, city) values from
+// scraper.ParseAddressFallback, it decides what to write back and whether
+// the network fetch can be skipped. No I/O; trivially unit-testable.
+func offlineParseDecision(row reenrichRow, parsedCountry, parsedCity string) (newCountry, newCity sql.NullString, skipFetch bool) {
+	if (!row.Country.Valid || row.Country.String == "") && parsedCountry != "" {
+		newCountry = sql.NullString{String: parsedCountry, Valid: true}
+	}
+	if (!row.City.Valid || row.City.String == "") && parsedCity != "" {
+		newCity = sql.NullString{String: parsedCity, Valid: true}
+	}
+	hasContact := row.EmailCount > 0 || row.PhoneCount > 0
+	countryFinal := (row.Country.Valid && row.Country.String != "") || newCountry.Valid
+	cityFinal := (row.City.Valid && row.City.String != "") || newCity.Valid
+	skipFetch = hasContact && countryFinal && cityFinal
+	return
 }
 
 // releaseLock clears re_enrich_locked_at so another worker can immediately

--- a/internal/stage/reenrich_test.go
+++ b/internal/stage/reenrich_test.go
@@ -1,0 +1,155 @@
+//go:build playwright
+
+package stage
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestOfflineParseDecision covers the pure decision logic of applyOfflineParse:
+// what country/city values to write, and whether the network fetch can be
+// skipped. SQL ops + slog are covered by integration tests in staging.
+func TestOfflineParseDecision(t *testing.T) {
+	cases := []struct {
+		name           string
+		row            reenrichRow
+		parsedCountry  string
+		parsedCity     string
+		wantNewCountry sql.NullString
+		wantNewCity    sql.NullString
+		wantSkipFetch  bool
+	}{
+		{
+			name: "country and city both NULL, parser found both, row has email — skip fetch",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "521 Oak Grove Rd, Flat Rock, NC, United States", Valid: true},
+				Country:    sql.NullString{Valid: false},
+				City:       sql.NullString{Valid: false},
+				EmailCount: 1,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "US",
+			parsedCity:     "Flat Rock",
+			wantNewCountry: sql.NullString{String: "US", Valid: true},
+			wantNewCity:    sql.NullString{String: "Flat Rock", Valid: true},
+			wantSkipFetch:  true,
+		},
+		{
+			name: "country NULL, city NULL, no contact data — fill but DON'T skip",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "1 Main St, San Antonio, TX", Valid: true},
+				EmailCount: 0,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "",
+			parsedCity:     "San Antonio",
+			wantNewCountry: sql.NullString{Valid: false},
+			wantNewCity:    sql.NullString{String: "San Antonio", Valid: true},
+			wantSkipFetch:  false,
+		},
+		{
+			name: "row has phone, country already set, city NULL, parser fills city — skip fetch",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "521 Oak Grove Rd, Flat Rock, NC, US", Valid: true},
+				Country:    sql.NullString{String: "US", Valid: true},
+				City:       sql.NullString{Valid: false},
+				EmailCount: 0,
+				PhoneCount: 2,
+			},
+			parsedCountry:  "US",
+			parsedCity:     "Flat Rock",
+			wantNewCountry: sql.NullString{Valid: false}, // already set, don't overwrite
+			wantNewCity:    sql.NullString{String: "Flat Rock", Valid: true},
+			wantSkipFetch:  true,
+		},
+		{
+			name: "everything already filled, parser also found same — write nothing, skip fetch",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "521 Oak Grove Rd, Flat Rock, NC, US", Valid: true},
+				Country:    sql.NullString{String: "US", Valid: true},
+				City:       sql.NullString{String: "Flat Rock", Valid: true},
+				EmailCount: 5,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "US",
+			parsedCity:     "Flat Rock",
+			wantNewCountry: sql.NullString{Valid: false},
+			wantNewCity:    sql.NullString{Valid: false},
+			wantSkipFetch:  true,
+		},
+		{
+			name: "parser found nothing, row already complete — skip fetch (still valid)",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "Compagnonsplein 1", Valid: true},
+				Country:    sql.NullString{String: "NL", Valid: true},
+				City:       sql.NullString{String: "Amsterdam", Valid: true},
+				EmailCount: 1,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "",
+			parsedCity:     "",
+			wantNewCountry: sql.NullString{Valid: false},
+			wantNewCity:    sql.NullString{Valid: false},
+			wantSkipFetch:  true,
+		},
+		{
+			name: "country present, city NULL, parser nothing, has contact — DON'T skip (city missing)",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "Compagnonsplein 1", Valid: true},
+				Country:    sql.NullString{String: "NL", Valid: true},
+				City:       sql.NullString{Valid: false},
+				EmailCount: 1,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "",
+			parsedCity:     "",
+			wantNewCountry: sql.NullString{Valid: false},
+			wantNewCity:    sql.NullString{Valid: false},
+			wantSkipFetch:  false,
+		},
+		{
+			name: "row totally empty, parser fills country only — fill country, no skip",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "Frankfurt, Germany", Valid: true},
+				EmailCount: 0,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "DE",
+			parsedCity:     "",
+			wantNewCountry: sql.NullString{String: "DE", Valid: true},
+			wantNewCity:    sql.NullString{Valid: false},
+			wantSkipFetch:  false,
+		},
+		{
+			name: "Country empty-string sql.Valid=true treated as missing",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "1 Main St, Boston, MA, USA", Valid: true},
+				Country:    sql.NullString{String: "", Valid: true}, // edge: stored empty
+				City:       sql.NullString{String: "", Valid: true},
+				EmailCount: 1,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "US",
+			parsedCity:     "Boston",
+			wantNewCountry: sql.NullString{String: "US", Valid: true},
+			wantNewCity:    sql.NullString{String: "Boston", Valid: true},
+			wantSkipFetch:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCountry, gotCity, gotSkip := offlineParseDecision(tc.row, tc.parsedCountry, tc.parsedCity)
+			if gotCountry != tc.wantNewCountry {
+				t.Errorf("newCountry = %+v; want %+v", gotCountry, tc.wantNewCountry)
+			}
+			if gotCity != tc.wantNewCity {
+				t.Errorf("newCity = %+v; want %+v", gotCity, tc.wantNewCity)
+			}
+			if gotSkip != tc.wantSkipFetch {
+				t.Errorf("skipFetch = %v; want %v", gotSkip, tc.wantSkipFetch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Stacked on top of #16.** Merge that one first or use the GitHub stack tooling.

## Summary

DB audit menemukan **17,490 baris** dengan `country=NULL AND address IS NOT NULL` di production. Dari sampel — sekitar 15% bisa di-parse offline (country sudah ada embedded di address blob), tapi reenrich worker tetap network-refetch karena tidak memeriksa kolom address dulu.

PR ini tambah offline pre-pass di awal `processRow`:

```
processRow(row):
  ┌─ STEP A: offline parse dari row.address (ZERO network) ── NEW
  │    ParseAddressFallback(row.address) → (country, city)
  │    UPDATE business_listings (COALESCE — won't overwrite non-NULL)
  │    decision: kalau row sudah punya email/phone DAN geo lengkap → skip fetch
  │    return true (DONE, no network)
  │
  └─ STEP B: NETWORK FETCH (existing path, unchanged)
```

## Yang berubah

| File | Perubahan |
|------|-----------|
| `internal/scraper/contact.go` | Export `ParseAddressFallback(address) (country, city string)` — public wrapper untuk reusability (reenrich, future backfill CLI) |
| `internal/scraper/contact_test.go` | 6 subtests untuk `ParseAddressFallback` |
| `internal/stage/reenrich.go` | `reenrichRow` tambah `Address, Country, City, EmailCount, PhoneCount`. Eligibility query RETURNS extra columns. `applyOfflineParse` + pure helper `offlineParseDecision`. Wiring di `processRow`. |
| `internal/stage/reenrich_test.go` | 8 subtests untuk `offlineParseDecision` (semua kombinasi geo×contact×parser hit/miss) |

## Estimated impact

- 17,490 rows eligible for offline parse
- ~2,686 (~15%) langsung fillable via tail-parse
- Subset yang punya emails/phones → skip fetch entirely (save proxy + bandwidth)
- Sisa rows → country/city tetap di-fill sebagai bonus, network fetch tetap jalan untuk emails/phones

## Verification

- `go build -tags playwright ./...` clean
- `go vet -tags playwright ./...` clean
- `go test -tags playwright ./...` — **217 subtests pass, 0 fail**
- New SQL query divalidasi terhadap production DB (sample 10 row, semua kolom expected ada, types match)
- Decision logic 8-test coverage matrix: { country missing/present } × { city missing/present } × { has contact / no contact } × { parser hit / miss }

## Test plan

- [x] Unit: 8 decision-logic subtests cover branching
- [x] Unit: 6 ParseAddressFallback subtests cover empty/parseable/edge inputs
- [x] SQL syntax: dry-run RETURNING query against production
- [ ] Post-deploy: monitor `slog "reenrich: completed via offline parse (no network)"` count rate
- [ ] Post-deploy: monitor reenrich rate (rows/min) — should increase as offline parse takes work off fetch path
- [ ] Post-deploy: spot-check sample of 20 newly-filled rows for accuracy

## Risk

- **Low** — `COALESCE(country, $2)` di SQL prevents overwriting non-NULL existing values
- Pure offline logic — no new network calls, no new external dependencies
- Skip-fetch only fires when row is "mostly complete" (has contact + both geo) → safe even if offline parse output is wrong (which it shouldn't be — 86 subtests + 60-row DB validation from sprint 1)
- Rollback = revert branch; reenrich worker reverts to current refetch-everything behavior

## Next sprint

Sprint 3 — one-shot backfill CLI (`cmd/backfill-address-fields`) untuk rows yang sudah di atas score threshold (tidak akan di-claim worker) tapi tetap punya country/city NULL. Akan pakai `ParseAddressFallback` yang sama.