### PR TITLE
Consumer filters: country/city/has_phone/has_social/sort on /api/v2/results

### DIFF
--- a/docker-compose.registry.yaml
+++ b/docker-compose.registry.yaml
@@ -19,10 +19,11 @@
 # `docker-compose.yaml` (build-based) remains the default for local dev.
 #
 # Scaling:
-#   SERP_WORKER_COUNT=2     → 2 SERP containers
-#   ENRICH_WORKER_COUNT=4   → 4 Enrich containers
-#   SERP_CONCURRENCY=4      → 4 browser tabs per SERP container
-#   ENRICH_CONCURRENCY=20   → 20 concurrent fetchers per Enrich container
+#   SERP_WORKER_COUNT=2       → 2 SERP containers
+#   ENRICH_WORKER_COUNT=2     → 2 Enrich containers
+#   REENRICH_WORKER_COUNT=3   → 3 Reenrich containers × 3 goroutines = 9 reenrich workers
+#   SERP_CONCURRENCY=4        → 4 browser tabs per SERP container
+#   ENRICH_CONCURRENCY=20     → 20 concurrent fetchers per Enrich container
 
 services:
 
@@ -238,7 +239,7 @@ services:
       - scraper-network
     deploy:
       mode: replicated
-      replicas: ${ENRICH_WORKER_COUNT:-4}
+      replicas: ${ENRICH_WORKER_COUNT:-2}
       resources:
         limits:
           cpus: "1"
@@ -274,10 +275,10 @@ services:
       BROWSER_TIMEOUT_SEC: "${BROWSER_TIMEOUT_SEC:-60}"
       BETA_FEATURES: "${BETA_FEATURES:-0}"
       TZ: "${TZ:-Asia/Jakarta}"
-      REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-1}"
+      REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-3}"
       REENRICH_SCORE: "${REENRICH_SCORE:-90}"
     shm_size: "512mb"
-    command: ["run", "-stage", "reenrich", "-workers", "${REENRICH_WORKER_COUNT:-1}"]
+    command: ["run", "-stage", "reenrich", "-workers", "${REENRICH_WORKER_COUNT:-3}"]
     healthcheck:
       test: ["CMD-SHELL", "test -f /tmp/worker-healthy && test $(( $(date +%s) - $(stat -c %Y /tmp/worker-healthy) )) -lt 120"]
       interval: 30s
@@ -288,7 +289,7 @@ services:
       - scraper-network
     deploy:
       mode: replicated
-      replicas: ${REENRICH_WORKER_COUNT:-1}
+      replicas: ${REENRICH_WORKER_COUNT:-3}
       resources:
         limits:
           cpus: "1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,11 @@
 # docker-compose.yaml — Production deployment
 #
 # Scaling:
-#   SERP_WORKER_COUNT=2     → 2 SERP containers
-#   ENRICH_WORKER_COUNT=4   → 4 Enrich containers
-#   SERP_CONCURRENCY=4      → 4 browser tabs per SERP container
-#   ENRICH_CONCURRENCY=20   → 20 concurrent fetchers per Enrich container
+#   SERP_WORKER_COUNT=2       → 2 SERP containers
+#   ENRICH_WORKER_COUNT=2     → 2 Enrich containers
+#   REENRICH_WORKER_COUNT=3   → 3 Reenrich containers × 3 goroutines = 9 reenrich workers
+#   SERP_CONCURRENCY=4        → 4 browser tabs per SERP container
+#   ENRICH_CONCURRENCY=20     → 20 concurrent fetchers per Enrich container
 
 services:
 
@@ -220,7 +221,7 @@ services:
       - scraper-network
     deploy:
       mode: replicated
-      replicas: ${ENRICH_WORKER_COUNT:-4}
+      replicas: ${ENRICH_WORKER_COUNT:-2}
       resources:
         limits:
           cpus: "1"
@@ -256,10 +257,10 @@ services:
       BROWSER_TIMEOUT_SEC: "${BROWSER_TIMEOUT_SEC:-60}"
       BETA_FEATURES: "${BETA_FEATURES:-0}"
       TZ: "${TZ:-Asia/Jakarta}"
-      REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-1}"
+      REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-3}"
       REENRICH_SCORE: "${REENRICH_SCORE:-90}"
     shm_size: "512mb"
-    command: ["run", "-stage", "reenrich", "-workers", "${REENRICH_WORKER_COUNT:-1}"]
+    command: ["run", "-stage", "reenrich", "-workers", "${REENRICH_WORKER_COUNT:-3}"]
     healthcheck:
       test: ["CMD-SHELL", "test -f /tmp/worker-healthy && test $(( $(date +%s) - $(stat -c %Y /tmp/worker-healthy) )) -lt 120"]
       interval: 30s
@@ -270,7 +271,7 @@ services:
       - scraper-network
     deploy:
       mode: replicated
-      replicas: ${REENRICH_WORKER_COUNT:-1}
+      replicas: ${REENRICH_WORKER_COUNT:-3}
       resources:
         limits:
           cpus: "1"

--- a/docs/api-response.md
+++ b/docs/api-response.md
@@ -264,7 +264,42 @@ Semua V2 list/single response dibungkus:
 
 ### `GET /api/v2/results`
 
-Query: `page`, `per_page≤200`, `domain`, `has_email`, `email`, `email_provider`, `email_status`, `search`
+Query (semua optional, kecuali pagination):
+
+| Param | Tipe | Catatan |
+|---|---|---|
+| `page` | int | OFFSET mode. Default 1. Tidak dipakai jika `cursor` di-set. |
+| `per_page` | int | Default 50, max 200. |
+| `cursor` | base64 | **Cursor mode** — keyset pagination O(log N). Opaque value dari response sebelumnya. Lihat bawah. |
+| `cursor_dir` | `next`\|`prev` | Default `next`. Hanya berlaku bila `cursor` di-set. |
+| `sort` | string | OFFSET mode only. Whitelist: `id_desc` (default), `id_asc`, `updated_desc`, `updated_asc`, `created_desc`, `created_asc`. Cursor mode dipaksa `id_desc` agar keyset boundary konsisten. |
+| `domain` | string | Match exact `bl.domain`. |
+| `country` | string | ISO alpha-2, case-insensitive (`id` ≡ `ID`). |
+| `city` | string | Prefix ILIKE — `?city=Berlin` cocok dengan "Berlin", "Berlin-Mitte". |
+| `has_email` | `true` | Hanya yang punya minimal 1 email. |
+| `has_phone` | `true` | Hanya yang `phone` non-empty. |
+| `has_social` | `true` | Hanya yang `social_links` non-empty (`{}` dianggap kosong). |
+| `email` | string | Match exact email address. |
+| `email_provider` | string | Match suffix — `?email_provider=gmail.com` cocok dengan `*@gmail.com`. |
+| `email_status` | string | Filter `validation_status` (`valid`, `pending`, `invalid`, dst). |
+| `search` | string | ILIKE `%x%` pada `business_name`. |
+
+**Cursor mode response** (saat `cursor` di-set) — tanpa `meta`, ganti dengan `next_cursor` + `has_more`:
+
+```json
+{
+  "data": [ /* V2BusinessListing[], lihat schema di bawah */ ],
+  "next_cursor": "eyJpZCI6MTIyOTV9",
+  "has_more": true
+}
+```
+
+- `next_cursor` opaque — perlakukan sebagai black box. Pakai persis di request berikutnya: `?cursor=<next_cursor>&per_page=...`.
+- Kalau `has_more=false`, `next_cursor` kosong → akhir hasil.
+- Cursor mode TIDAK mengembalikan `meta.total`. Kalau butuh total, panggil `GET /api/v2/results/count?<filter>` terpisah (cached 60s).
+- Cursor malformed → HTTP 400 `{"error":{"code":"invalid_cursor",...}}`.
+
+**OFFSET mode response** (default, saat `cursor` tidak di-set):
 
 ```json
 {

--- a/docs/superpowers/plans/2026-05-14-api-endpoint-caching-plan.md
+++ b/docs/superpowers/plans/2026-05-14-api-endpoint-caching-plan.md
@@ -1,0 +1,1161 @@
+# API Endpoint Caching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate timeouts on `/api/v2/{stats,queries,results}` under high-traffic + large-data scenarios by adding Redis-backed caching, statement_timeout protection, and cursor pagination.
+
+**Architecture:** Three layers. (1) Shared `cache.go` helper providing `cachedCount`, `trySingleFlight`, `waitForCache`. (2) Endpoint-specific cache usage — `/api/v2/stats` wraps full response, `/api/v2/queries` caches count + adds statement_timeout, `/api/v2/results` adds cursor pagination as additive query param. (3) Observability via `X-Cache` response header (`HIT|MISS|WAITED|BYPASS`).
+
+**Tech Stack:** Go 1.25, `database/sql`, `github.com/redis/go-redis/v9` (already used), `github.com/alicebob/miniredis/v2` (new test-only dep). No production-binary deps added.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-api-endpoint-caching-design.md`
+
+---
+
+## Test Strategy (read before starting)
+
+**TDD discipline applies to pure-logic code. Redis-coordination tests use `miniredis`. DB-touching code is verified manually via `X-Cache` header + staging traffic.**
+
+| Code type | Test approach |
+|---|---|
+| `buildCountCacheKey`, `encodeCursor`, `decodeCursor` | Standard unit tests, no deps |
+| `trySingleFlight`, `waitForCache` | `miniredis` (test-only dep) |
+| `cachedCount` (touches DB) | Manual verification + staging — no `sqlmock` to keep test surface small |
+| Handler glue | Manual verification via dashboard polling + `X-Cache` header in browser DevTools |
+
+This trade-off is deliberate: the cache logic that's hard to test (single-flight race, lock TTL boundary) gets `miniredis` coverage. The glue that's easy to verify manually doesn't get a 200-line mock setup. Reference: @superpowers:test-driven-development for the discipline; this plan exercises judgment about test ROI inside that discipline.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `internal/api/cache.go` | **Create** | Shared cache helpers: `cachedCount`, `trySingleFlight`, `waitForCache`, `cachedJSON`. Also re-homes `buildCountCacheKey` from `v2_handlers_results.go`. |
+| `internal/api/cache_test.go` | **Create** | Tests for pure functions + miniredis-backed Redis coordination tests. |
+| `internal/api/cursor.go` | **Create** | `encodeCursor`/`decodeCursor` for opaque base64 cursor format. |
+| `internal/api/cursor_test.go` | **Create** | Round-trip + malformed input tests for cursor codec. |
+| `internal/api/v2_handlers_results.go` | **Modify** | (a) Remove `buildCountCacheKey` (moved). (b) Refactor `cachedFilteredCount` to call new `cachedCount`. (c) Add cursor branch to `handleV2ListResults`. |
+| `internal/api/v2_handlers_queries.go` | **Modify** | Refactor `handleV2ListQueries` to use `cachedCount` + wrap in tx with `statement_timeout=10s`. |
+| `internal/api/v2_handlers_stats.go` | **Modify** | Refactor `handleV2DashboardStats` — extract `computeDashboardStats` from cache-aware wrapper. |
+| `docs/api-response.md` | **Modify** | Document cursor query param + response shape for `/api/v2/results`. |
+| `go.mod`, `go.sum` | **Modify** | Add `github.com/alicebob/miniredis/v2` as test-only dependency. |
+
+---
+
+## Task 1: Shared cache helpers + miniredis dep
+
+**Files:**
+- Create: `internal/api/cache.go`
+- Create: `internal/api/cache_test.go`
+- Modify: `go.mod`, `go.sum`
+- Modify: `internal/api/v2_handlers_results.go:22,30-79` (remove `buildCountCacheKey` + refactor `cachedFilteredCount`)
+
+- [ ] **Step 1: Add miniredis test dependency**
+
+Run:
+```bash
+cd /Users/sadewadee/Downloads/Plugin\ Pro/serp-scraper
+go get -t github.com/alicebob/miniredis/v2@latest
+```
+Expected: `go: added github.com/alicebob/miniredis/v2 vX.Y.Z`. `go.mod` should now contain the dep.
+
+- [ ] **Step 2: Write failing test for `buildCountCacheKey`**
+
+Create `internal/api/cache_test.go`:
+
+```go
+package api
+
+import (
+	"testing"
+)
+
+func TestBuildCountCacheKey_StableAcrossCalls(t *testing.T) {
+	where := "WHERE bl.domain = $1"
+	args := []any{"example.com"}
+	a := buildCountCacheKey(where, args)
+	b := buildCountCacheKey(where, args)
+	if a != b {
+		t.Fatalf("expected stable key, got %q vs %q", a, b)
+	}
+	if a == "" {
+		t.Fatal("expected non-empty key")
+	}
+}
+
+func TestBuildCountCacheKey_DifferentArgs(t *testing.T) {
+	where := "WHERE bl.domain = $1"
+	a := buildCountCacheKey(where, []any{"a.com"})
+	b := buildCountCacheKey(where, []any{"b.com"})
+	if a == b {
+		t.Fatalf("expected different keys for different args")
+	}
+}
+
+// Regression: %v formatting would collide ["a","bc"] with ["ab","c"].
+func TestBuildCountCacheKey_NoTransposeCollision(t *testing.T) {
+	a := buildCountCacheKey("WHERE x = $1 AND y = $2", []any{"a", "bc"})
+	b := buildCountCacheKey("WHERE x = $1 AND y = $2", []any{"ab", "c"})
+	if a == b {
+		t.Fatal("transpose collision — %q must separate args")
+	}
+}
+```
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestBuildCountCacheKey -v
+```
+Expected: FAIL with `undefined: buildCountCacheKey` (function lives in `v2_handlers_results.go` still, but package compiles — wait, it's same package). Actually expect: PASS (function exists in same `package api`). Goal of this step is to capture current behavior before move.
+
+If PASS: tests now codify current behavior. If FAIL: investigate before moving.
+
+- [ ] **Step 3: Create `internal/api/cache.go` with `buildCountCacheKey` moved from results handler**
+
+Create `internal/api/cache.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// buildCountCacheKey hashes WHERE + args into a stable Redis key.
+// %q separates adjacent string args so ["a","bc"] and ["ab","c"] don't collide.
+func buildCountCacheKey(where string, args []any) string {
+	h := sha1.New()
+	h.Write([]byte(where))
+	for _, a := range args {
+		fmt.Fprintf(h, "|%q|", a)
+	}
+	return "v2:count:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// cachedCount returns COUNT(*) for `SELECT COUNT(*) FROM <fromClause> <where>`.
+// Caches result in Redis with TTL. On query timeout or DB error returns (-1, err)
+// so callers can serve `count_known=false` instead of HTTP 500.
+//
+// fromClause includes any join alias, e.g. "business_listings bl".
+// where includes the leading "WHERE", e.g. "WHERE bl.domain = $1" or "WHERE 1=1".
+func (s *Server) cachedCount(ctx context.Context, fromClause, where string, args []any, ttl, timeout time.Duration) (int, error) {
+	key := buildCountCacheKey(fromClause+"|"+where, args)
+
+	if s.redis != nil {
+		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+			if n, perr := strconv.Atoi(v); perr == nil {
+				return n, nil
+			}
+		}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return -1, err
+	}
+	defer tx.Rollback()
+
+	timeoutMs := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = '%d'", timeoutMs)); err != nil {
+		return -1, err
+	}
+
+	var total int
+	q := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", fromClause, where)
+	if err := tx.QueryRowContext(ctx, q, args...).Scan(&total); err != nil {
+		return -1, err
+	}
+	if err := tx.Commit(); err != nil {
+		return -1, err
+	}
+
+	if s.redis != nil {
+		_ = s.redis.Set(ctx, key, strconv.Itoa(total), ttl).Err()
+	}
+	return total, nil
+}
+
+// trySingleFlight acquires a Redis NX EX lock for the given key.
+// Returns true if caller should compute the value, false if another caller
+// is already computing. lockTTL bounds the maximum work duration.
+func (s *Server) trySingleFlight(ctx context.Context, key string, lockTTL time.Duration) bool {
+	if s.redis == nil {
+		return true // no Redis = no coordination = every caller computes
+	}
+	ok, err := s.redis.SetNX(ctx, key+":lock", "1", lockTTL).Result()
+	if err != nil {
+		slog.Debug("single-flight lock error", "key", key, "error", err)
+		return true // Redis errored — degrade to compute-anyway
+	}
+	return ok
+}
+
+// releaseSingleFlight removes the lock. Best-effort; lock TTL is the safety net.
+func (s *Server) releaseSingleFlight(ctx context.Context, key string) {
+	if s.redis == nil {
+		return
+	}
+	_ = s.redis.Del(ctx, key+":lock").Err()
+}
+
+// waitForCache polls a cache key up to maxWait. Returns value+true if populated,
+// "" + false on timeout.
+func (s *Server) waitForCache(ctx context.Context, key string, maxWait time.Duration) (string, bool) {
+	if s.redis == nil {
+		return "", false
+	}
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+			return v, true
+		}
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return "", false
+}
+
+// cachedJSON serves a JSON response from Redis cache or computes and caches it.
+// Adds X-Cache: HIT|WAITED|MISS|BYPASS header for observability.
+//
+// On cache miss the caller acquires a single-flight lock. Other callers wait
+// up to waitMs for the cache to populate. If they time out, they compute
+// anyway (degraded mode — better than failing).
+func (s *Server) cachedJSON(
+	ctx context.Context,
+	w http.ResponseWriter,
+	key string,
+	ttl time.Duration,
+	waitOnMiss time.Duration,
+	compute func() (any, error),
+) {
+	// Try cache.
+	if s.redis != nil {
+		if cached, err := s.redis.Get(ctx, key).Result(); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			io.WriteString(w, cached)
+			return
+		}
+	}
+
+	// Single-flight.
+	gotLock := s.trySingleFlight(ctx, key, 20*time.Second)
+	if !gotLock {
+		if cached, ok := s.waitForCache(ctx, key, waitOnMiss); ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "WAITED")
+			io.WriteString(w, cached)
+			return
+		}
+		// Timed out waiting — fall through to compute (degraded).
+	}
+	defer s.releaseSingleFlight(context.Background(), key)
+
+	value, err := compute()
+	if err != nil {
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to compute response")
+		return
+	}
+
+	body, err := json.Marshal(value)
+	if err != nil {
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to marshal response")
+		return
+	}
+
+	if s.redis != nil {
+		_ = s.redis.Set(ctx, key, body, ttl).Err()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if gotLock {
+		w.Header().Set("X-Cache", "MISS")
+	} else {
+		w.Header().Set("X-Cache", "BYPASS")
+	}
+	w.Write(body)
+}
+
+// _ keeps sql import used even if a future refactor removes the only call site.
+var _ = sql.ErrNoRows
+```
+
+- [ ] **Step 4: Remove `buildCountCacheKey` + `resultsCountTTL` + `cachedFilteredCount` body from `v2_handlers_results.go`**
+
+In `/Users/sadewadee/Downloads/Plugin Pro/serp-scraper/internal/api/v2_handlers_results.go`:
+
+Delete lines 20-79 (the `resultsCountTTL` const, `cachedFilteredCount` method, and `buildCountCacheKey` function). Replace with:
+
+```go
+// resultsCountTTL is the cache TTL for filtered COUNT(*) on business_listings.
+const resultsCountTTL = 60 * time.Second
+
+// cachedFilteredCount is the existing call signature, now thin wrapper over cachedCount.
+func (s *Server) cachedFilteredCount(ctx context.Context, where string, args []any) (int, error) {
+	return s.cachedCount(ctx, "business_listings bl", where, args, resultsCountTTL, 12*time.Second)
+}
+```
+
+Note: `buildCountCacheKey` is now in `cache.go` and accessible within the same package.
+
+- [ ] **Step 5: Run cache tests + build**
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestBuildCountCacheKey -v
+go build -tags playwright,tls ./...
+```
+Expected: tests PASS, build clean (no output).
+
+- [ ] **Step 6: Write failing tests for `trySingleFlight` and `waitForCache` using miniredis**
+
+Append to `internal/api/cache_test.go`:
+
+```go
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestServer(t *testing.T) (*Server, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	s := &Server{redis: rdb}
+	return s, mr
+}
+
+func TestTrySingleFlight_FirstCallerWins(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	if !s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("first caller must win the lock")
+	}
+	if s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("second caller must NOT get the lock while held")
+	}
+}
+
+func TestTrySingleFlight_AfterRelease(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	s.trySingleFlight(ctx, "test:key", 5*time.Second)
+	s.releaseSingleFlight(ctx, "test:key")
+	if !s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("lock must be acquirable after release")
+	}
+}
+
+func TestTrySingleFlight_NoRedis(t *testing.T) {
+	s := &Server{redis: nil}
+	if !s.trySingleFlight(context.Background(), "test:key", 5*time.Second) {
+		t.Fatal("nil redis must degrade to compute-anyway (true)")
+	}
+}
+
+func TestWaitForCache_Populated(t *testing.T) {
+	s, mr := newTestServer(t)
+	ctx := context.Background()
+
+	mr.Set("test:key", `{"hello":"world"}`)
+	v, ok := s.waitForCache(ctx, "test:key", 1*time.Second)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if v != `{"hello":"world"}` {
+		t.Fatalf("unexpected value: %q", v)
+	}
+}
+
+func TestWaitForCache_TimesOut(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	start := time.Now()
+	_, ok := s.waitForCache(ctx, "test:nonexistent", 200*time.Millisecond)
+	elapsed := time.Since(start)
+	if ok {
+		t.Fatal("expected timeout")
+	}
+	if elapsed < 200*time.Millisecond || elapsed > 400*time.Millisecond {
+		t.Fatalf("waitForCache elapsed %v outside expected 200-400ms window", elapsed)
+	}
+}
+```
+
+Note: imports merge into the existing import block — Go formatter handles ordering.
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestTrySingleFlight -v
+go test -tags playwright,tls ./internal/api/ -run TestWaitForCache -v
+```
+Expected: tests PASS (implementation already in `cache.go` from Step 3).
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add internal/api/cache.go internal/api/cache_test.go \
+        internal/api/v2_handlers_results.go go.mod go.sum
+git commit -m "Add shared cache helpers (cachedCount, single-flight, cachedJSON)
+
+- Move buildCountCacheKey + cachedFilteredCount logic into cache.go
+- Add trySingleFlight/releaseSingleFlight/waitForCache for thundering-herd
+- Add cachedJSON for full-response cache (X-Cache observability header)
+- Tests via miniredis (test-only dep)
+
+Existing cachedFilteredCount preserved as thin wrapper for back-compat.
+No production binary deps added."
+```
+
+---
+
+## Task 2: `/api/v2/queries` — statement_timeout + count cache
+
+**Why P0:** Currently the only one of the 3 endpoints with NO `statement_timeout`. An ILIKE-search on unindexed `text` column on a growing `queries` table will hang the manager's connection pool indefinitely.
+
+**Files:**
+- Modify: `internal/api/v2_handlers_queries.go:15-75` (`handleV2ListQueries`)
+
+- [ ] **Step 1: Read current handler shape**
+
+Re-read `internal/api/v2_handlers_queries.go:15-75` to understand the count + data query flow before editing. The bug to preserve: `total int` is captured but `Scan` error is silently dropped — keep that behavior to avoid scope creep (separate ticket for error logging).
+
+- [ ] **Step 2: Refactor `handleV2ListQueries`**
+
+Replace `internal/api/v2_handlers_queries.go` lines 15-75 with:
+
+```go
+// handleV2ListQueries returns paginated queries wrapped in V2 format.
+// COUNT is cached in Redis (60s TTL) and protected by a 10s statement_timeout.
+func (s *Server) handleV2ListQueries(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := v2RequestContext(r)
+	defer cancel()
+
+	q := r.URL.Query()
+	page := queryInt(q, "page", 1)
+	perPage := queryInt(q, "per_page", 50)
+	if perPage > 200 {
+		perPage = 200
+	}
+	offset := (page - 1) * perPage
+
+	where := "WHERE 1=1"
+	args := []any{}
+	argIdx := 1
+
+	if status := q.Get("status"); status != "" {
+		where += fmt.Sprintf(" AND status = $%d", argIdx)
+		args = append(args, status)
+		argIdx++
+	}
+	if search := q.Get("search"); search != "" {
+		where += fmt.Sprintf(" AND text ILIKE $%d", argIdx)
+		args = append(args, "%"+search+"%")
+		argIdx++
+	}
+
+	// Cached count with 10s statement_timeout. -1 sentinel on timeout.
+	total, err := s.cachedCount(ctx, "queries", where, args, 60*time.Second, 10*time.Second)
+	if err != nil {
+		slog.Warn("v2: queries count failed (serving with -1 sentinel)", "error", err)
+	}
+
+	dataQuery := fmt.Sprintf(`
+		SELECT id, text, status, result_count, COALESCE(error_msg,''), created_at
+		FROM queries %s
+		ORDER BY id DESC
+		LIMIT $%d OFFSET $%d
+	`, where, argIdx, argIdx+1)
+	args = append(args, perPage, offset)
+
+	rows, err := s.db.QueryContext(ctx, dataQuery, args...)
+	if err != nil {
+		slog.Error("v2: list queries error", "error", err)
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch queries")
+		return
+	}
+	defer rows.Close()
+
+	type queryRow struct {
+		ID          int64     `json:"id"`
+		Text        string    `json:"text"`
+		Status      string    `json:"status"`
+		ResultCount int       `json:"result_count"`
+		Error       string    `json:"error"`
+		CreatedAt   time.Time `json:"created_at"`
+	}
+
+	queries := []queryRow{}
+	for rows.Next() {
+		var qr queryRow
+		rows.Scan(&qr.ID, &qr.Text, &qr.Status, &qr.ResultCount, &qr.Error, &qr.CreatedAt)
+		queries = append(queries, qr)
+	}
+
+	writeV2Paginated(w, queries, total, page, perPage)
+}
+```
+
+Key changes from current code:
+- Replace direct `s.db.QueryRow("SELECT COUNT(*) ...")` with `s.cachedCount(...)`.
+- `cachedCount` internally wraps in tx + `SET LOCAL statement_timeout`.
+- `ctx, cancel := v2RequestContext(r)` added (was missing — other v2 handlers have it).
+- Use `QueryContext` instead of `Query` for the data query (uses request context).
+
+- [ ] **Step 3: Build + verify**
+
+Run:
+```bash
+go build -tags playwright,tls ./...
+go test -tags playwright,tls ./internal/api/ -v
+```
+Expected: build clean, tests PASS (Task 1 tests still pass — no regression).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/v2_handlers_queries.go
+git commit -m "Protect /api/v2/queries with statement_timeout + count cache
+
+Currently the only v2 list endpoint without statement_timeout — an
+ILIKE-search on unindexed queries.text can hang the manager's
+connection pool indefinitely as the table grows.
+
+- Wrap COUNT in cachedCount helper (10s timeout, 60s Redis TTL)
+- Use QueryContext for data query (request context cancellation)
+- On count timeout, serve page with total=-1 sentinel via writeV2Paginated
+  (consumers already handle count_known=false in PaginationMeta)"
+```
+
+---
+
+## Task 3: `/api/v2/stats` — full-response cache + single-flight
+
+**Files:**
+- Modify: `internal/api/v2_handlers_stats.go:9-146`
+
+- [ ] **Step 1: Extract `computeDashboardStats` from current handler**
+
+Replace `internal/api/v2_handlers_stats.go` content with:
+
+```go
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// dashboardStatsCacheTTL is the Redis cache window for /api/v2/stats.
+// Dashboard polling clients re-hit within this window for ~free.
+const dashboardStatsCacheTTL = 30 * time.Second
+
+// handleV2DashboardStats returns the full dashboard stats wrapped in V2 format.
+// Backed by a 30s Redis cache with single-flight to prevent thundering herd
+// when the cache TTL expires under polling load.
+func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := v2RequestContext(r)
+	defer cancel()
+
+	s.cachedJSON(ctx, w,
+		"v2:stats:dashboard", dashboardStatsCacheTTL, 5*time.Second,
+		func() (any, error) {
+			return s.computeDashboardStats(ctx)
+		},
+	)
+}
+
+// computeDashboardStats runs the 5 COUNT(*) queries against the live DB.
+// Wrapped in cachedJSON above. Statement timeout 15s.
+func (s *Server) computeDashboardStats(ctx context.Context) (map[string]any, error) {
+	// -- Queries (small table, no timeout needed) --
+	queries := map[string]int{}
+	qRows, _ := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM queries GROUP BY status`)
+	if qRows != nil {
+		for qRows.Next() {
+			var status string
+			var cnt int
+			qRows.Scan(&status, &cnt)
+			queries[status] = cnt
+		}
+		qRows.Close()
+	}
+	qTotal := 0
+	for _, c := range queries {
+		qTotal += c
+	}
+	queries["total"] = qTotal
+
+	// -- Big-table aggregates: serp_jobs + enrichment_jobs + emails --
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("v2: dashboard tx error", "error", err)
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// 15s — serp_jobs (5.7M rows) and emails (828K+) need headroom.
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '15000'"); err != nil {
+		slog.Error("v2: set timeout error", "error", err)
+		return nil, err
+	}
+
+	serp := map[string]any{}
+	var serpTotal, serpNew, serpProcessing, serpCompleted, serpFailed int
+	var serpURLsFound, serpPerHour, serpToday int
+	tx.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE status = 'new'),
+			COUNT(*) FILTER (WHERE status = 'processing'),
+			COUNT(*) FILTER (WHERE status = 'completed'),
+			COUNT(*) FILTER (WHERE status = 'failed'),
+			COALESCE(SUM(result_count) FILTER (WHERE status = 'completed'), 0),
+			COUNT(*) FILTER (WHERE status = 'completed' AND updated_at > NOW() - INTERVAL '1 hour'),
+			COUNT(*) FILTER (WHERE status = 'completed' AND updated_at > NOW() - INTERVAL '24 hours')
+		FROM serp_jobs
+	`).Scan(&serpTotal, &serpNew, &serpProcessing, &serpCompleted, &serpFailed, &serpURLsFound, &serpPerHour, &serpToday)
+	serp["total"] = serpTotal
+	serp["pending"] = serpNew
+	serp["processing"] = serpProcessing
+	serp["completed"] = serpCompleted
+	serp["failed"] = serpFailed
+	serp["urls_found"] = serpURLsFound
+	serp["rate_per_hour"] = serpPerHour
+	serp["today"] = serpToday
+
+	enrich := map[string]any{}
+	var enrichTotal, enrichPending, enrichProcessing, enrichCompleted, enrichFailed, enrichDead int
+	var enrichPerHour, enrichToday int
+	tx.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE status = 'pending'),
+			COUNT(*) FILTER (WHERE status = 'processing'),
+			COUNT(*) FILTER (WHERE status = 'completed'),
+			COUNT(*) FILTER (WHERE status = 'failed'),
+			COUNT(*) FILTER (WHERE status = 'dead'),
+			COUNT(*) FILTER (WHERE status = 'completed' AND completed_at > NOW() - INTERVAL '1 hour'),
+			COUNT(*) FILTER (WHERE status = 'completed' AND completed_at > NOW() - INTERVAL '24 hours')
+		FROM enrichment_jobs
+	`).Scan(&enrichTotal, &enrichPending, &enrichProcessing, &enrichCompleted, &enrichFailed, &enrichDead, &enrichPerHour, &enrichToday)
+	enrich["total"] = enrichTotal
+	enrich["pending"] = enrichPending
+	enrich["processing"] = enrichProcessing
+	enrich["completed"] = enrichCompleted
+	enrich["failed"] = enrichFailed
+	enrich["dead"] = enrichDead
+	enrich["rate_per_hour"] = enrichPerHour
+	enrich["today"] = enrichToday
+
+	results := map[string]any{}
+	var totalEmails, emailsToday, emailsLastHour, uniqueDomains int
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails`).Scan(&totalEmails)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'`).Scan(&emailsToday)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'`).Scan(&emailsLastHour)
+	tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT domain) FROM business_listings`).Scan(&uniqueDomains)
+	results["total_emails"] = totalEmails
+	results["emails_today"] = emailsToday
+	results["emails_per_hour"] = emailsLastHour
+	results["unique_domains"] = uniqueDomains
+
+	providerRows, _ := tx.QueryContext(ctx, `
+		SELECT domain, COUNT(*) AS cnt
+		FROM emails
+		GROUP BY domain ORDER BY cnt DESC LIMIT 10
+	`)
+	providers := map[string]int{}
+	if providerRows != nil {
+		for providerRows.Next() {
+			var p string
+			var c int
+			providerRows.Scan(&p, &c)
+			providers[p] = c
+		}
+		providerRows.Close()
+	}
+	results["providers"] = providers
+
+	tx.Commit()
+
+	queueMap := map[string]int64{}
+	qd, _ := s.redis.ZCard(ctx, "serp:queue:queries").Result()
+	queueMap["serp:queue:queries"] = qd
+	sb, _ := s.redis.LLen(ctx, "serp:buffer").Result()
+	queueMap["serp:buffer"] = sb
+	eb, _ := s.redis.LLen(ctx, "enrich:buffer").Result()
+	queueMap["enrich:buffer"] = eb
+
+	// Wrap in V2 envelope manually since we're not going through writeV2Single.
+	// cachedJSON caches the entire envelope so subsequent hits return identical
+	// shape without re-wrapping.
+	return map[string]any{
+		"data": map[string]any{
+			"queries": queries,
+			"serp":    serp,
+			"enrich":  enrich,
+			"results": results,
+			"queues":  queueMap,
+		},
+	}, nil
+}
+```
+
+Notable changes from original:
+- Body of original `handleV2DashboardStats` becomes `computeDashboardStats`.
+- New `handleV2DashboardStats` is a thin wrapper that delegates to `cachedJSON`.
+- The V2 envelope `{"data": ...}` is constructed inline because `cachedJSON` caches raw JSON bytes (not the Go map). Going through `writeV2Single` inside the cached path would re-wrap on every cache miss.
+
+- [ ] **Step 2: Build + run all api tests**
+
+Run:
+```bash
+go build -tags playwright,tls ./...
+go test -tags playwright,tls ./internal/api/ -v
+```
+Expected: build clean, Task 1 tests still PASS.
+
+- [ ] **Step 3: Manual smoke (skip if no local PG/Redis)**
+
+If you have local PG+Redis (e.g. via `docker compose up db redis`), spin manager:
+```bash
+go run -tags playwright,tls . run -stage none
+```
+Then in another terminal:
+```bash
+curl -i -H "x-api-key: $API_KEY" http://localhost:8080/api/v2/stats | head -10
+curl -i -H "x-api-key: $API_KEY" http://localhost:8080/api/v2/stats | head -10
+```
+Expected: first response `X-Cache: MISS`, second response `X-Cache: HIT` within 30s.
+
+If no local env: skip — verified post-deploy.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/v2_handlers_stats.go
+git commit -m "Cache /api/v2/stats response with 30s TTL + single-flight
+
+Dashboard polls every 5-10s with 3-5 concurrent users. Without cache,
+each request runs 5 sequential COUNT(*) on serp_jobs (5.7M) +
+enrichment_jobs + emails (828K) + business_listings + emails group-by.
+At scale that's 30-60 stat req/min × ~15s each = pool exhaustion.
+
+- Wrap response in cachedJSON helper (30s TTL)
+- Single-flight via Redis NX EX prevents thundering herd at TTL expiry
+- Extract compute path as computeDashboardStats for testability
+- Response shape unchanged (cached body is the full V2 envelope)
+- X-Cache: HIT|WAITED|MISS|BYPASS for observability"
+```
+
+---
+
+## Task 4: `/api/v2/results` — cursor pagination
+
+**Files:**
+- Create: `internal/api/cursor.go`
+- Create: `internal/api/cursor_test.go`
+- Modify: `internal/api/v2_handlers_results.go` (add cursor branch to `handleV2ListResults`)
+- Modify: `docs/api-response.md`
+
+- [ ] **Step 1: Write failing tests for cursor codec**
+
+Create `internal/api/cursor_test.go`:
+
+```go
+package api
+
+import (
+	"testing"
+)
+
+func TestCursor_RoundTrip(t *testing.T) {
+	encoded := encodeCursor(12345)
+	if encoded == "" {
+		t.Fatal("expected non-empty cursor")
+	}
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != 12345 {
+		t.Fatalf("expected id=12345, got %d", id)
+	}
+}
+
+func TestCursor_EmptyDecode(t *testing.T) {
+	_, err := decodeCursor("")
+	if err == nil {
+		t.Fatal("empty cursor must error")
+	}
+}
+
+func TestCursor_MalformedDecode(t *testing.T) {
+	_, err := decodeCursor("not-base64!!!")
+	if err == nil {
+		t.Fatal("malformed cursor must error")
+	}
+}
+
+func TestCursor_MalformedJSON(t *testing.T) {
+	// Valid base64 but not JSON
+	_, err := decodeCursor("aGVsbG8=") // "hello"
+	if err == nil {
+		t.Fatal("non-JSON cursor body must error")
+	}
+}
+
+func TestCursor_NegativeID(t *testing.T) {
+	encoded := encodeCursor(-1)
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != -1 {
+		t.Fatalf("expected -1, got %d", id)
+	}
+}
+```
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestCursor -v
+```
+Expected: FAIL with `undefined: encodeCursor` / `undefined: decodeCursor`.
+
+- [ ] **Step 2: Implement cursor codec**
+
+Create `internal/api/cursor.go`:
+
+```go
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+)
+
+// cursorPayload is the wire format inside an opaque cursor.
+// Versioned via the struct shape so future fields stay backward-compatible.
+type cursorPayload struct {
+	ID int64 `json:"id"`
+}
+
+// encodeCursor builds an opaque base64url cursor from a row ID.
+// Used for pagination "next page" pointer.
+func encodeCursor(id int64) string {
+	payload, _ := json.Marshal(cursorPayload{ID: id})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+// decodeCursor unwraps a cursor back to its row ID.
+// Returns error for empty, non-base64, or non-JSON inputs.
+func decodeCursor(cursor string) (int64, error) {
+	if cursor == "" {
+		return 0, errors.New("cursor is empty")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, err
+	}
+	var p cursorPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return 0, err
+	}
+	return p.ID, nil
+}
+```
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestCursor -v
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Add cursor branch to `handleV2ListResults`**
+
+Modify `internal/api/v2_handlers_results.go` `handleV2ListResults` (lines 122-261 in original). The change is in the WHERE-clause assembly + pagination logic; the email-fetch section (lines 203-254) is unchanged.
+
+Locate this block (around line 134):
+
+```go
+	where, args, argIdx := buildResultsFilter(q)
+
+	// Count total via Redis-cached helper. On timeout/error the helper returns -1
+	// so we serve the page with a sentinel instead of 500.
+	total, err := s.cachedFilteredCount(ctx, where, args)
+	if err != nil {
+		slog.Warn("v2: count failed (returning -1 sentinel)", "error", err)
+	}
+```
+
+Replace with:
+
+```go
+	where, args, argIdx := buildResultsFilter(q)
+
+	// Cursor mode: ?cursor=<base64> uses keyset pagination — O(log N) at deep pages.
+	// OFFSET mode (existing): ?page=N + ?per_page=M — capped at perPage=200.
+	cursorParam := q.Get("cursor")
+	useCursor := cursorParam != ""
+
+	var cursorID int64
+	if useCursor {
+		var err error
+		cursorID, err = decodeCursor(cursorParam)
+		if err != nil {
+			writeV2Error(w, http.StatusBadRequest, "invalid_cursor", "cursor is malformed")
+			return
+		}
+		dir := q.Get("cursor_dir")
+		if dir == "prev" {
+			where += fmt.Sprintf(" AND bl.id > $%d", argIdx)
+		} else {
+			where += fmt.Sprintf(" AND bl.id < $%d", argIdx)
+		}
+		args = append(args, cursorID)
+		argIdx++
+	}
+
+	// Count is only computed for offset mode. Cursor mode returns has_more flag.
+	var total int
+	if !useCursor {
+		var err error
+		total, err = s.cachedFilteredCount(ctx, where, args)
+		if err != nil {
+			slog.Warn("v2: count failed (returning -1 sentinel)", "error", err)
+		}
+	}
+```
+
+Then locate the existing query construction (around line 144):
+
+```go
+	// Query 1: Fetch paginated listings (all columns).
+	dataQuery := fmt.Sprintf(`
+		SELECT bl.id, COALESCE(bl.business_name,''), ...
+		FROM business_listings bl %s
+		ORDER BY bl.id DESC
+		LIMIT $%d OFFSET $%d
+	`, where, argIdx, argIdx+1)
+	args = append(args, perPage, offset)
+```
+
+Replace the `dataQuery` block + `args = append(args, perPage, offset)` with:
+
+```go
+	// Cursor mode: fetch perPage+1 to detect has_more without separate query.
+	// OFFSET mode: existing pagination.
+	limit := perPage
+	if useCursor {
+		limit = perPage + 1 // +1 sentinel for has_more detection
+	}
+
+	dataQuery := fmt.Sprintf(`
+		SELECT bl.id, COALESCE(bl.business_name,''), COALESCE(bl.category,''),
+		       COALESCE(bl.description,''), COALESCE(bl.website,''),
+		       bl.domain, bl.url, COALESCE(bl.social_links,'{}'),
+		       COALESCE(bl.address,''), COALESCE(bl.location,''),
+		       COALESCE(bl.city,''), COALESCE(bl.country,''), COALESCE(bl.contact_name,''),
+		       COALESCE(bl.opening_hours,''), COALESCE(bl.rating,''),
+		       COALESCE(bl.page_title,''), COALESCE(bl.phone,''), COALESCE(bl.phones,'{}'),
+		       COALESCE(bl.tiktok,''), COALESCE(bl.youtube,''), COALESCE(bl.telegram,''),
+		       bl.source_query_id, bl.created_at, bl.updated_at
+		FROM business_listings bl %s
+		ORDER BY bl.id DESC
+		LIMIT $%d`, where, argIdx)
+	args = append(args, limit)
+	argIdx++
+
+	if !useCursor {
+		dataQuery += fmt.Sprintf(" OFFSET $%d", argIdx)
+		args = append(args, offset)
+	}
+```
+
+Then at the END of the handler (currently `writeV2Paginated(w, listings, total, page, perPage)` around line 260), replace with:
+
+```go
+	if useCursor {
+		hasMore := len(listings) > perPage
+		if hasMore {
+			listings = listings[:perPage] // drop sentinel row
+		}
+		var nextCursor string
+		if hasMore && len(listings) > 0 {
+			nextCursor = encodeCursor(listings[len(listings)-1].ID)
+		}
+		writeV2Single(w, map[string]any{
+			"data":        listings,
+			"next_cursor": nextCursor,
+			"has_more":    hasMore,
+		})
+		return
+	}
+
+	writeV2Paginated(w, listings, total, page, perPage)
+```
+
+- [ ] **Step 4: Build + run all api tests**
+
+Run:
+```bash
+go build -tags playwright,tls ./...
+go test -tags playwright,tls ./internal/api/ -v
+```
+Expected: build clean, all tests PASS.
+
+- [ ] **Step 5: Update docs/api-response.md**
+
+Append to `docs/api-response.md` (after the existing `/api/v2/results` section):
+
+```markdown
+### Cursor pagination for `/api/v2/results` (v0.8.0+)
+
+Two pagination modes are supported on the same endpoint. Choose based on UX:
+
+| Mode | Use when | Trigger param |
+|---|---|---|
+| OFFSET (default) | Need total count, jumping to arbitrary page (page 5, 10, etc.) | `?page=N&per_page=M` |
+| Cursor | "Load more" UX, deep pagination, no total count needed | `?cursor=<base64>&per_page=M` |
+
+Cursor request:
+```
+GET /api/v2/results?cursor=eyJpZCI6MTIzNDV9&per_page=50
+```
+
+Cursor response (200):
+```json
+{
+  "data": [ /* business listings */ ],
+  "next_cursor": "eyJpZCI6MTIyOTV9",
+  "has_more": true
+}
+```
+
+Notes:
+- `next_cursor` is an opaque base64-encoded value — treat as a black box.
+- When `has_more=false`, `next_cursor` is empty — pagination is done.
+- Optional `?cursor_dir=prev` reverses the direction (rare; for back-navigation).
+- Cursor mode does NOT return `meta.total` — use `/api/v2/results/count` separately if needed.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/cursor.go internal/api/cursor_test.go \
+        internal/api/v2_handlers_results.go docs/api-response.md
+git commit -m "Add cursor pagination to /api/v2/results (additive)
+
+OFFSET pagination degrades at deep pages — OFFSET 50,000 scans 50K rows
+just to skip them. For 'load more' UX at 700K+ business_listings scale,
+keyset (cursor) pagination is O(log N) via the existing PK index.
+
+- Add encodeCursor/decodeCursor (base64url + JSON payload, versioned shape)
+- handleV2ListResults branches on ?cursor=...:
+    OFFSET mode (existing): unchanged, ?page + ?per_page
+    cursor mode (new):      ?cursor + ?per_page, returns next_cursor + has_more
+- Fetch perPage+1 to detect has_more in single query
+- Optional ?cursor_dir=prev for back-navigation
+- Documented in docs/api-response.md
+
+No breaking change. Frontend opts in by passing cursor instead of page."
+```
+
+---
+
+## Task 5: Integration verification
+
+**Files:** none modified — pure verification.
+
+- [ ] **Step 1: Full build (production target)**
+
+Run:
+```bash
+CGO_ENABLED=0 go build -tags playwright,tls -ldflags="-w -s" -o /tmp/serp-scraper-build .
+ls -lh /tmp/serp-scraper-build
+rm /tmp/serp-scraper-build
+```
+Expected: binary ~30-35MB, no compile error.
+
+- [ ] **Step 2: Full test suite**
+
+Run:
+```bash
+go test -tags playwright,tls ./... 2>&1 | tail -30
+```
+Expected: all packages PASS, no failures. Verify especially:
+- `ok  github.com/sadewadee/serp-scraper/internal/api` with N+ tests.
+- No regression in `internal/stage/...`, `internal/scraper/...`.
+
+- [ ] **Step 3: Race detector on api package**
+
+Run:
+```bash
+go test -tags playwright,tls -race -count=1 ./internal/api/...
+```
+Expected: ok, no race conditions. Single-flight + waitForCache use goroutine coordination — race detector validates we got it right.
+
+- [ ] **Step 4: Vet**
+
+Run:
+```bash
+go vet -tags playwright,tls ./...
+```
+Expected: no output (clean).
+
+- [ ] **Step 5: Final summary (no commit)**
+
+Run:
+```bash
+git log --oneline -5
+git diff --stat origin/canary/v0.8.0-country-extraction..HEAD
+```
+Expected: 4 commits ahead of remote (one per Task 1-4), `~400-500` lines net delta.
+
+---
+
+## Rollout
+
+After all tasks land:
+
+1. Push branch: `git push origin canary/v0.8.0-country-extraction`
+2. Build canary image on kurama via `docker-compose.build.yaml` (existing infra).
+3. Push to GHCR `ghcr.io/sadewadee/foxhound-serp-scraper:canary-latest`.
+4. Redeploy via Dokploy.
+5. Verify post-deploy:
+   - `curl -i -H "x-api-key: $API_KEY" https://manager.../api/v2/stats` — confirm `X-Cache` header present.
+   - Repeat curl within 30s — `X-Cache: HIT`.
+   - Watch dashboard p95 latency for 1h via Prometheus on `:9090`.
+6. Rollback path: revert the 4 commits, redeploy previous tag.
+
+## Success criteria (post-deploy)
+
+- `/api/v2/stats` p95 latency: <100ms (was 5-15s).
+- `/api/v2/queries`: zero HTTP 500 from statement timeout under ILIKE search.
+- `/api/v2/results?cursor=...`: <500ms at any logical page depth.
+- Worker email throughput unchanged (sanity check: no write-path regression).

--- a/docs/superpowers/specs/2026-05-14-api-endpoint-caching-design.md
+++ b/docs/superpowers/specs/2026-05-14-api-endpoint-caching-design.md
@@ -1,0 +1,155 @@
+# API Endpoint Caching — Design
+
+**Date**: 2026-05-14
+**Branch**: `canary/v0.8.0-country-extraction`
+**Problem**: User-facing v2 endpoints time out at scale. `/api/v2/stats` runs 5 sequential COUNT(*) on multi-million-row tables per request, dashboard polls every 5-10s with 3-5 concurrent users. `/api/v2/queries` has no `statement_timeout` and can hang the connection pool indefinitely. `/api/v2/results` is partially cached but OFFSET pagination degrades at deep pages.
+
+**Non-goals**: counter table + trigger (write amplification), materialized view (staleness), read replica (ops overhead), trigram index for ILIKE (separate concern).
+
+## Scope
+
+Four targeted changes inside `internal/api/v2_handlers_*.go`. No schema migration. No worker changes. No API breaking change.
+
+| # | Endpoint | Change |
+|---|---|---|
+| 1 | `/api/v2/stats` | Redis cache the full response body, TTL 30s, single key |
+| 2 | `/api/v2/queries` (list) | Add `SET LOCAL statement_timeout = '10000'` + Redis-cache the COUNT (TTL 60s, key by filter hash) |
+| 3 | `/api/v2/results` (list) | Add cursor pagination as additive query param; existing OFFSET path unchanged |
+| 4 | (shared) | Single-flight lock around cache misses to prevent thundering herd at TTL expiry |
+
+## Design — Component 1: `/api/v2/stats` full-response cache
+
+**Cache key**: `v2:stats:dashboard` (single key — endpoint has no filters)
+
+**TTL**: 30s
+
+**Flow**:
+```
+handleV2DashboardStats:
+  if GET v2:stats:dashboard hits → return raw JSON
+  else:
+    acquire single-flight lock (key: v2:stats:dashboard:lock, NX EX 20s)
+    if lock acquired:
+      run the 5 COUNT queries inside existing tx (statement_timeout=15s)
+      build response JSON
+      SET v2:stats:dashboard {json} EX 30
+      DEL v2:stats:dashboard:lock
+      return JSON
+    else:
+      wait up to 5s polling cache (50ms intervals)
+      if cache populated → return it
+      else → return cached-stale-or-503
+```
+
+**Failure mode**: Redis down → fall through to current code path (no cache, direct DB query). Single-flight lock degrades to "every request hits DB" — same as today, no regression.
+
+**Stale-while-revalidate**: NOT in v1. Add later if cache-miss latency proves painful.
+
+## Design — Component 2: `/api/v2/queries` count cache + timeout
+
+**Cache key**: `v2:queries:count:<sha1(where|args)>` — same pattern as existing `buildCountCacheKey` in `v2_handlers_results.go:72`.
+
+**TTL**: 60s
+
+**Statement timeout**: 10s (wrapped in `tx` like results.go does for COUNT).
+
+**Flow**: identical to `cachedFilteredCount` in `v2_handlers_results.go:30` — extract into a shared helper `cachedCount(ctx, table, where, args, ttl)` that both endpoints use. Sentinel `-1` on timeout, caller serves page with `count_known=false`.
+
+**Why 60s vs 30s for stats**: queries list count changes less frequently (user manually creates queries, not auto-incrementing); stats counters tick with every job completion (~hundreds/sec at peak).
+
+## Design — Component 3: `/api/v2/results` cursor pagination
+
+**New query params** (additive, optional):
+- `cursor` — opaque base64-encoded `last_id` from previous page
+- `cursor_dir` — `next` (default) or `prev`
+
+**Cursor format**: `base64url(json{"id": 12345, "ts": "2026-05-14T..."})` — version stays inside JSON for forward-compat.
+
+**Flow**:
+```
+if ?cursor is present:
+  decode → last_id
+  WHERE bl.id < $last_id (next)  or  bl.id > $last_id (prev)
+  ORDER BY bl.id DESC LIMIT $perPage
+  → response includes next_cursor = base64(last_row.id), no total count
+elif ?page is present:
+  (existing OFFSET path unchanged)
+```
+
+**Response shape** (cursor mode): `{data: [...], next_cursor: "...", has_more: true}` — no `total` field. Documented in `docs/api-response.md` update.
+
+**Backward compat**: `?page` continues to work. Frontend can opt-in to cursor for "load more" UX. No client breaking change.
+
+## Design — Component 4: single-flight lock helper
+
+**Pattern**:
+```go
+// trySingleFlight attempts to acquire a Redis NX EX lock. Returns true if
+// caller should compute the value, false if another caller is already computing.
+func (s *Server) trySingleFlight(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+    ok, err := s.redis.SetNX(ctx, key+":lock", "1", ttl).Result()
+    return ok, err
+}
+
+// waitForCache polls a cache key up to maxWait, returning value when present.
+func (s *Server) waitForCache(ctx context.Context, key string, maxWait time.Duration) (string, bool) {
+    deadline := time.Now().Add(maxWait)
+    for time.Now().Before(deadline) {
+        if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+            return v, true
+        }
+        time.Sleep(50 * time.Millisecond)
+    }
+    return "", false
+}
+```
+
+**Where used**: Component 1 only (stats endpoint). Component 2 reuses existing `cachedFilteredCount` semantics (cache miss = each caller computes; cheap enough since query is already `LIMIT`-bounded). Avoiding single-flight on Component 2 keeps surface small.
+
+## Failure modes & fallbacks
+
+| Failure | Behavior |
+|---|---|
+| Redis down (GET fails) | Fall through to DB path. Same as current. |
+| Redis down (SET fails) | Best-effort, log + serve response. |
+| Single-flight lock held but holder dies | Lock TTL (20s) frees it. Next caller retries. |
+| DB statement_timeout fires | Return `count_known=false` (count endpoint) or 500 (stats/queries) — current behavior. |
+| Stale cache served during DB outage | Acceptable for dashboard. Document. |
+
+## Testing
+
+| Test | What | Where |
+|---|---|---|
+| `TestV2StatsCache_HitMiss` | First call DB, second call cache, after TTL expire DB again | `internal/api/v2_handlers_stats_test.go` (new) |
+| `TestV2StatsCache_SingleFlight` | 10 concurrent requests at cache miss → exactly 1 DB call | same |
+| `TestV2QueriesCount_CacheKey` | Different filter combos produce different cache keys | `internal/api/v2_handlers_queries_test.go` (new) |
+| `TestV2QueriesCount_StatementTimeout` | Slow mock DB → returns sentinel within 10s + 500 buffer | same |
+| `TestV2ResultsCursor_Encode` | Cursor round-trip (encode → decode → query) | `internal/api/v2_handlers_results_test.go` (existing file or new) |
+| `TestV2ResultsCursor_NextPrev` | next/prev directions return non-overlapping result sets | same |
+
+Redis mock: use `miniredis` or `redis-mock` if already in `go.sum`; otherwise small interface around `redis.Cmdable` mocked manually.
+
+## Out of scope (deferred to separate work items)
+
+- Trigram/full-text index for ILIKE search (affects both `queries.text` and `business_listings.business_name`) — separate ticket
+- Read-replica routing for analytics queries — too much ops surface change
+- Counter-table + trigger for real-time stats — write amplification risk
+- Stale-while-revalidate cache pattern — add only if cache-miss latency complaints arise
+
+## Rollout
+
+- Behind no feature flag — straightforward additive change, low risk.
+- Deploy via canary stack (`docker-compose.build.yaml` → GHCR → Dokploy).
+- Validate via `docker logs manager 2>&1 | grep "v2:.*cache"` for hit/miss counter — add `slog.Debug` lines.
+- Rollback path: revert one commit, redeploy previous tag.
+
+## Success criteria
+
+- `/api/v2/stats` p95 latency drops from current ~5-15s to <100ms under 5 concurrent users.
+- `/api/v2/queries` no longer returns 500 when ILIKE search hits unindexed scan.
+- `/api/v2/results` page=500 (deep) returns in <500ms via cursor path; existing OFFSET path unchanged for back-compat.
+- Zero impact on worker write throughput (no schema changes, no triggers).
+
+## Effort
+
+~150-200 lines net across 3 handler files + 1 new shared cache helper + 6 tests. No migration. Single commit feasible.

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Noooste/uquic-go v1.0.5 // indirect
 	github.com/Noooste/utls v1.3.20 // indirect
 	github.com/Noooste/websocket v1.0.3 // indirect
+	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/bdandy/go-errors v1.2.2 // indirect
@@ -47,6 +48,7 @@ require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/Noooste/websocket v1.0.3 h1:drW7tvZ3YqzqI9wApnaH1Q0syFMXO7gbLlsBWjZvM
 github.com/Noooste/websocket v1.0.3/go.mod h1:Qhw0Rtuju/fPPbcb3R5XGq7poa51qPDL462jTltl9nQ=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
@@ -121,6 +123,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=

--- a/internal/api/cache.go
+++ b/internal/api/cache.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// buildCountCacheKey hashes WHERE + args into a stable Redis key.
+// %q separates adjacent string args so ["a","bc"] and ["ab","c"] don't collide.
+func buildCountCacheKey(where string, args []any) string {
+	h := sha1.New()
+	h.Write([]byte(where))
+	for _, a := range args {
+		fmt.Fprintf(h, "|%q|", a)
+	}
+	return "v2:count:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// cachedCount returns COUNT(*) for `SELECT COUNT(*) FROM <fromClause> <where>`.
+// Caches result in Redis with TTL. On query timeout or DB error returns (-1, err)
+// so callers can serve `count_known=false` instead of HTTP 500.
+//
+// fromClause includes any join alias, e.g. "business_listings bl".
+// where includes the leading "WHERE", e.g. "WHERE bl.domain = $1" or "WHERE 1=1".
+func (s *Server) cachedCount(ctx context.Context, fromClause, where string, args []any, ttl, timeout time.Duration) (int, error) {
+	key := buildCountCacheKey(fromClause+"|"+where, args)
+
+	if s.redis != nil {
+		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+			if n, perr := strconv.Atoi(v); perr == nil {
+				return n, nil
+			}
+		}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return -1, err
+	}
+	defer tx.Rollback()
+
+	timeoutMs := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = '%d'", timeoutMs)); err != nil {
+		return -1, err
+	}
+
+	var total int
+	q := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", fromClause, where)
+	if err := tx.QueryRowContext(ctx, q, args...).Scan(&total); err != nil {
+		return -1, err
+	}
+	if err := tx.Commit(); err != nil {
+		return -1, err
+	}
+
+	if s.redis != nil {
+		_ = s.redis.Set(ctx, key, strconv.Itoa(total), ttl).Err()
+	}
+	return total, nil
+}
+
+// trySingleFlight acquires a Redis NX EX lock for the given key.
+// Returns true if caller should compute the value, false if another caller
+// is already computing. lockTTL bounds the maximum work duration.
+func (s *Server) trySingleFlight(ctx context.Context, key string, lockTTL time.Duration) bool {
+	if s.redis == nil {
+		return true // no Redis = no coordination = every caller computes
+	}
+	ok, err := s.redis.SetNX(ctx, key+":lock", "1", lockTTL).Result()
+	if err != nil {
+		slog.Debug("single-flight lock error", "key", key, "error", err)
+		return true // Redis errored — degrade to compute-anyway
+	}
+	return ok
+}
+
+// releaseSingleFlight removes the lock. Best-effort; lock TTL is the safety net.
+func (s *Server) releaseSingleFlight(ctx context.Context, key string) {
+	if s.redis == nil {
+		return
+	}
+	_ = s.redis.Del(ctx, key+":lock").Err()
+}
+
+// waitForCache polls a cache key up to maxWait. Returns value+true if populated,
+// "" + false on timeout.
+func (s *Server) waitForCache(ctx context.Context, key string, maxWait time.Duration) (string, bool) {
+	if s.redis == nil {
+		return "", false
+	}
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+			return v, true
+		}
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return "", false
+}
+
+// cachedJSON serves a JSON response from Redis cache or computes and caches it.
+// Adds X-Cache: HIT|WAITED|MISS|BYPASS header for observability.
+//
+// On cache miss the caller acquires a single-flight lock. Other callers wait
+// up to waitOnMiss for the cache to populate. If they time out, they compute
+// anyway (degraded mode — better than failing).
+func (s *Server) cachedJSON(
+	ctx context.Context,
+	w http.ResponseWriter,
+	key string,
+	ttl time.Duration,
+	waitOnMiss time.Duration,
+	compute func() (any, error),
+) {
+	// Try cache.
+	if s.redis != nil {
+		if cached, err := s.redis.Get(ctx, key).Result(); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			io.WriteString(w, cached)
+			return
+		}
+	}
+
+	// Single-flight.
+	gotLock := s.trySingleFlight(ctx, key, 20*time.Second)
+	if !gotLock {
+		if cached, ok := s.waitForCache(ctx, key, waitOnMiss); ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "WAITED")
+			io.WriteString(w, cached)
+			return
+		}
+		// Timed out waiting — fall through to compute (degraded).
+	}
+	defer s.releaseSingleFlight(context.Background(), key)
+
+	value, err := compute()
+	if err != nil {
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to compute response")
+		return
+	}
+
+	body, err := json.Marshal(value)
+	if err != nil {
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to marshal response")
+		return
+	}
+
+	if s.redis != nil {
+		_ = s.redis.Set(ctx, key, body, ttl).Err()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if gotLock {
+		w.Header().Set("X-Cache", "MISS")
+	} else {
+		w.Header().Set("X-Cache", "BYPASS")
+	}
+	w.Write(body)
+}

--- a/internal/api/cache.go
+++ b/internal/api/cache.go
@@ -30,8 +30,14 @@ func buildCountCacheKey(where string, args []any) string {
 //
 // fromClause includes any join alias, e.g. "business_listings bl".
 // where includes the leading "WHERE", e.g. "WHERE bl.domain = $1" or "WHERE 1=1".
+//
+// SECURITY: fromClause and where are interpolated directly into the SQL string.
+// Both MUST be compile-time constants. NEVER pass user input as either; pass
+// user values through args and reference them via $N placeholders in where.
 func (s *Server) cachedCount(ctx context.Context, fromClause, where string, args []any, ttl, timeout time.Duration) (int, error) {
-	key := buildCountCacheKey(fromClause+"|"+where, args)
+	// %q quotes both parts so concatenation is unambiguous: an unquoted "|"
+	// inside either string cannot collide with the separator.
+	key := buildCountCacheKey(fmt.Sprintf("%q|%q", fromClause, where), args)
 
 	if s.redis != nil {
 		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
@@ -145,7 +151,14 @@ func (s *Server) cachedJSON(
 		}
 		// Timed out waiting — fall through to compute (degraded).
 	}
-	defer s.releaseSingleFlight(context.Background(), key)
+	// Only release if WE acquired the lock. BYPASS callers (timed out waiting)
+	// must NOT delete a key they don't own — that would let other concurrent
+	// callers re-acquire and partially defeat thundering-herd protection.
+	// context.Background() (not ctx) so release fires even if request ctx is
+	// already cancelled by the time compute() returns.
+	if gotLock {
+		defer s.releaseSingleFlight(context.Background(), key)
+	}
 
 	value, err := compute()
 	if err != nil {

--- a/internal/api/cache_test.go
+++ b/internal/api/cache_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestBuildCountCacheKey_StableAcrossCalls(t *testing.T) {
+	where := "WHERE bl.domain = $1"
+	args := []any{"example.com"}
+	a := buildCountCacheKey(where, args)
+	b := buildCountCacheKey(where, args)
+	if a != b {
+		t.Fatalf("expected stable key, got %q vs %q", a, b)
+	}
+	if a == "" {
+		t.Fatal("expected non-empty key")
+	}
+}
+
+func TestBuildCountCacheKey_DifferentArgs(t *testing.T) {
+	where := "WHERE bl.domain = $1"
+	a := buildCountCacheKey(where, []any{"a.com"})
+	b := buildCountCacheKey(where, []any{"b.com"})
+	if a == b {
+		t.Fatalf("expected different keys for different args")
+	}
+}
+
+// Regression: %v formatting would collide ["a","bc"] with ["ab","c"].
+func TestBuildCountCacheKey_NoTransposeCollision(t *testing.T) {
+	a := buildCountCacheKey("WHERE x = $1 AND y = $2", []any{"a", "bc"})
+	b := buildCountCacheKey("WHERE x = $1 AND y = $2", []any{"ab", "c"})
+	if a == b {
+		t.Fatal("transpose collision: adjacent string args produced the same key")
+	}
+}
+
+func newTestServer(t *testing.T) (*Server, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	s := &Server{redis: rdb}
+	return s, mr
+}
+
+func TestTrySingleFlight_FirstCallerWins(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	if !s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("first caller must win the lock")
+	}
+	if s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("second caller must NOT get the lock while held")
+	}
+}
+
+func TestTrySingleFlight_AfterRelease(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	s.trySingleFlight(ctx, "test:key", 5*time.Second)
+	s.releaseSingleFlight(ctx, "test:key")
+	if !s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("lock must be acquirable after release")
+	}
+}
+
+func TestTrySingleFlight_NoRedis(t *testing.T) {
+	s := &Server{redis: nil}
+	if !s.trySingleFlight(context.Background(), "test:key", 5*time.Second) {
+		t.Fatal("nil redis must degrade to compute-anyway (true)")
+	}
+}
+
+func TestWaitForCache_Populated(t *testing.T) {
+	s, mr := newTestServer(t)
+	ctx := context.Background()
+
+	mr.Set("test:key", `{"hello":"world"}`)
+	v, ok := s.waitForCache(ctx, "test:key", 1*time.Second)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if v != `{"hello":"world"}` {
+		t.Fatalf("unexpected value: %q", v)
+	}
+}
+
+func TestWaitForCache_TimesOut(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	start := time.Now()
+	_, ok := s.waitForCache(ctx, "test:nonexistent", 200*time.Millisecond)
+	elapsed := time.Since(start)
+	if ok {
+		t.Fatal("expected timeout")
+	}
+	if elapsed < 200*time.Millisecond || elapsed > 400*time.Millisecond {
+		t.Fatalf("waitForCache elapsed %v outside expected 200-400ms window", elapsed)
+	}
+}

--- a/internal/api/cursor.go
+++ b/internal/api/cursor.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+)
+
+// cursorPayload is the wire format inside an opaque cursor.
+// Versioned via the struct shape so future fields stay backward-compatible.
+type cursorPayload struct {
+	ID int64 `json:"id"`
+}
+
+// encodeCursor builds an opaque base64url cursor from a row ID.
+// Used for pagination "next page" pointer.
+func encodeCursor(id int64) string {
+	payload, _ := json.Marshal(cursorPayload{ID: id})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+// decodeCursor unwraps a cursor back to its row ID.
+// Returns error for empty, non-base64, or non-JSON inputs.
+func decodeCursor(cursor string) (int64, error) {
+	if cursor == "" {
+		return 0, errors.New("cursor is empty")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, err
+	}
+	var p cursorPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return 0, err
+	}
+	return p.ID, nil
+}

--- a/internal/api/cursor_test.go
+++ b/internal/api/cursor_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestCursor_RoundTrip(t *testing.T) {
+	encoded := encodeCursor(12345)
+	if encoded == "" {
+		t.Fatal("expected non-empty cursor")
+	}
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != 12345 {
+		t.Fatalf("expected id=12345, got %d", id)
+	}
+}
+
+func TestCursor_EmptyDecode(t *testing.T) {
+	_, err := decodeCursor("")
+	if err == nil {
+		t.Fatal("empty cursor must error")
+	}
+}
+
+func TestCursor_MalformedDecode(t *testing.T) {
+	_, err := decodeCursor("not-base64!!!")
+	if err == nil {
+		t.Fatal("malformed cursor must error")
+	}
+}
+
+func TestCursor_MalformedJSON(t *testing.T) {
+	// Valid base64 ("hello") but not JSON.
+	_, err := decodeCursor("aGVsbG8")
+	if err == nil {
+		t.Fatal("non-JSON cursor body must error")
+	}
+}
+
+func TestCursor_NegativeID(t *testing.T) {
+	encoded := encodeCursor(-1)
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != -1 {
+		t.Fatalf("expected -1, got %d", id)
+	}
+}
+
+func TestCursor_LargeID(t *testing.T) {
+	const big int64 = 9_223_372_036_854_775_000 // near max int64
+	encoded := encodeCursor(big)
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != big {
+		t.Fatalf("expected %d, got %d", big, id)
+	}
+}

--- a/internal/api/handlers_contacts.go
+++ b/internal/api/handlers_contacts.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -98,7 +99,7 @@ func (s *Server) handleListContacts(w http.ResponseWriter, r *http.Request) {
 		}
 
 		contacts = append(contacts, map[string]any{
-			"id": id,
+			"id":            id,
 			"business_name": businessName, "business_category": category,
 			"description": description, "website": website,
 			"emails": emails, "phones": phones, "domain": domain,
@@ -198,29 +199,62 @@ func (s *Server) handleExportContacts(w http.ResponseWriter, r *http.Request) {
 			"business_name": businessName, "business_category": category,
 			"website": website, "emails": emails, "domain": domain,
 			"social_links": json.RawMessage(socialLinksJSON),
-			"address": address, "location": location, "phone": phone,
+			"address":      address, "location": location, "phone": phone,
 		})
 	}
 	w.Write([]byte("]"))
 }
 
 func (s *Server) handleContactStats(w http.ResponseWriter, r *http.Request) {
+	// 10s budget — must exceed the 8s statement_timeout below.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
 	var totalBiz, withEmail, uniqueDomains, totalEmails, lastHour, last24h int
 	var validEmails, pendingEmails, invalidEmails int
 
-	s.db.QueryRow("SELECT COUNT(*) FROM business_listings").Scan(&totalBiz)
-	s.db.QueryRow("SELECT COUNT(DISTINCT bl.id) FROM business_listings bl JOIN business_emails be ON be.business_id = bl.id").Scan(&withEmail)
-	s.db.QueryRow("SELECT COUNT(DISTINCT domain) FROM business_listings").Scan(&uniqueDomains)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails").Scan(&totalEmails)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'").Scan(&lastHour)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'").Scan(&last24h)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE validation_status = 'valid'").Scan(&validEmails)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE validation_status = 'pending'").Scan(&pendingEmails)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE validation_status = 'invalid'").Scan(&invalidEmails)
+	// 9 serial QueryRow on a 2-conn pool was the cascade root: 1 slow query
+	// held both pool conns ~40s and v2 endpoints saw 500 with context deadline.
+	// Fold into 3 queries (business, email, providers) inside one tx with
+	// statement_timeout to bound the damage on the pool.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("v1: contact-stats tx error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '8000'"); err != nil {
+		slog.Error("v1: contact-stats set timeout error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+
+	// Business listings: 2 aggregates in 1 pass.
+	tx.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COUNT(DISTINCT domain)
+		FROM business_listings
+	`).Scan(&totalBiz, &uniqueDomains)
+
+	// with_email needs a join; separate query (still inside tx).
+	tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT business_id) FROM business_emails`).Scan(&withEmail)
+
+	// Emails: 6 aggregates in 1 pass.
+	tx.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COUNT(*) FILTER (WHERE validation_status = 'valid'),
+		       COUNT(*) FILTER (WHERE validation_status = 'pending'),
+		       COUNT(*) FILTER (WHERE validation_status = 'invalid'),
+		       COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '1 hour'),
+		       COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours')
+		FROM emails
+	`).Scan(&totalEmails, &validEmails, &pendingEmails, &invalidEmails, &lastHour, &last24h)
 
 	// Top email providers.
 	providers := map[string]int{}
-	providerRows, _ := s.db.Query(`
+	providerRows, _ := tx.QueryContext(ctx, `
 		SELECT domain, COUNT(*) AS cnt
 		FROM emails
 		GROUP BY domain
@@ -228,14 +262,16 @@ func (s *Server) handleContactStats(w http.ResponseWriter, r *http.Request) {
 		LIMIT 10
 	`)
 	if providerRows != nil {
-		defer providerRows.Close()
 		for providerRows.Next() {
 			var provider string
 			var cnt int
 			providerRows.Scan(&provider, &cnt)
 			providers[provider] = cnt
 		}
+		providerRows.Close()
 	}
+
+	tx.Commit()
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"total":          totalBiz,

--- a/internal/api/handlers_pipeline.go
+++ b/internal/api/handlers_pipeline.go
@@ -12,10 +12,32 @@ import (
 )
 
 func (s *Server) handlePipelineStats(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	// 10s budget — must exceed the 8s statement_timeout below so PG cancels
+	// the query first and we observe a clean error rather than a context-cancel.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
 	stats := map[string]any{}
 
-	// Table counts.
+	// Wrap big-table COUNT(*) in a single tx with statement_timeout so a slow
+	// query can't hold the manager's 2-conn pool open indefinitely (the cascade
+	// that was causing v2 endpoints to balas 500 with context deadline exceeded).
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("v1: pipeline-stats tx error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '8000'"); err != nil {
+		slog.Error("v1: pipeline-stats set timeout error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+
+	// Table counts. tables is compile-time only — no user input flows into the
+	// SQL string here, so fmt.Sprintf is safe.
 	tables := map[string]string{
 		"queries": "queries", "serp_jobs": "serp_jobs",
 		"enrichment_jobs": "enrichment_jobs", "emails": "emails",
@@ -23,9 +45,12 @@ func (s *Server) handlePipelineStats(w http.ResponseWriter, r *http.Request) {
 	}
 	for key, table := range tables {
 		var total int
-		s.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&total)
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&total); err != nil {
+			slog.Warn("v1: pipeline-stats count failed", "table", table, "error", err)
+		}
 		stats[key+"_total"] = total
 	}
+	tx.Commit()
 
 	// Queue depths from Redis (buffers are LISTs, queries queue is sorted set).
 	queueStats := map[string]int64{}
@@ -41,11 +66,15 @@ func (s *Server) handlePipelineStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	// 18s — same budget as v2_response.v2RequestContext so the V1 dashboard
+	// won't outlive V2 requests. Statement timeout below is 15s; PG cancels first.
+	ctx, cancel := context.WithTimeout(r.Context(), 18*time.Second)
+	defer cancel()
 
-	// -- Queries --
+	// -- Queries (small table — runs outside the big tx since CSV-style status
+	// rollup is cheap and we want it to complete even if the tx hits timeout.) --
 	queries := map[string]int{}
-	qRows, _ := s.db.Query(`SELECT status, COUNT(*) FROM queries GROUP BY status`)
+	qRows, _ := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM queries GROUP BY status`)
 	if qRows != nil {
 		for qRows.Next() {
 			var status string
@@ -61,11 +90,28 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	queries["total"] = qTotal
 
+	// Big-table aggregates wrapped in a tx + statement_timeout to bound the
+	// time these can hold the manager's 2-conn pool. Without this V2 endpoints
+	// see 500 with context deadline exceeded when this handler runs slow.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("v1: dashboard tx error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '15000'"); err != nil {
+		slog.Error("v1: dashboard set timeout error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+
 	// -- SERP Jobs --
 	serp := map[string]any{}
 	var serpTotal, serpNew, serpProcessing, serpCompleted, serpFailed int
 	var serpURLsFound, serpPerHour, serpToday int
-	s.db.QueryRow(`
+	tx.QueryRowContext(ctx, `
 		SELECT
 			COUNT(*),
 			COUNT(*) FILTER (WHERE status = 'new'),
@@ -90,7 +136,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	enrich := map[string]any{}
 	var enrichTotal, enrichPending, enrichProcessing, enrichCompleted, enrichFailed, enrichDead int
 	var enrichPerHour, enrichToday int
-	s.db.QueryRow(`
+	tx.QueryRowContext(ctx, `
 		SELECT
 			COUNT(*),
 			COUNT(*) FILTER (WHERE status = 'pending'),
@@ -114,11 +160,11 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	// -- Contacts (from normalized tables) --
 	contacts := map[string]any{}
 	var totalEmails, uniqueEmails, emailsToday, emailsLastHour, uniqueDomains int
-	s.db.QueryRow(`SELECT COUNT(*) FROM emails`).Scan(&totalEmails)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails`).Scan(&totalEmails)
 	uniqueEmails = totalEmails // emails table has UNIQUE constraint, so total == unique
-	s.db.QueryRow(`SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'`).Scan(&emailsToday)
-	s.db.QueryRow(`SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'`).Scan(&emailsLastHour)
-	s.db.QueryRow(`SELECT COUNT(DISTINCT domain) FROM business_listings`).Scan(&uniqueDomains)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'`).Scan(&emailsToday)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'`).Scan(&emailsLastHour)
+	tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT domain) FROM business_listings`).Scan(&uniqueDomains)
 
 	contacts["total_emails"] = totalEmails
 	contacts["unique_emails"] = uniqueEmails
@@ -126,7 +172,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	contacts["emails_per_hour"] = emailsLastHour
 
 	// Top email providers.
-	providerRows, _ := s.db.Query(`
+	providerRows, _ := tx.QueryContext(ctx, `
 		SELECT domain, COUNT(*) AS cnt
 		FROM emails
 		GROUP BY domain ORDER BY cnt DESC LIMIT 10
@@ -143,6 +189,8 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	contacts["providers"] = providers
 	contacts["unique_domains"] = uniqueDomains
+
+	tx.Commit()
 
 	// -- Queues (Redis) --
 	queueMap := map[string]int64{}

--- a/internal/api/v2_filters_test.go
+++ b/internal/api/v2_filters_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestBuildResultsFilter_NoParams(t *testing.T) {
+	q := url.Values{}
+	where, args, idx := buildResultsFilter(q)
+	if where != "WHERE 1=1" {
+		t.Fatalf("expected baseline WHERE 1=1, got %q", where)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %d", len(args))
+	}
+	if idx != 1 {
+		t.Fatalf("expected argIdx=1, got %d", idx)
+	}
+}
+
+func TestBuildResultsFilter_Country(t *testing.T) {
+	q := url.Values{"country": {"id"}}
+	where, args, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "UPPER(bl.country) = UPPER($1)") {
+		t.Fatalf("country clause missing or wrong, got %q", where)
+	}
+	if len(args) != 1 || args[0] != "id" {
+		t.Fatalf("unexpected args: %v", args)
+	}
+}
+
+func TestBuildResultsFilter_City(t *testing.T) {
+	q := url.Values{"city": {"Berlin"}}
+	where, args, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "bl.city ILIKE $1") {
+		t.Fatalf("city clause missing, got %q", where)
+	}
+	if args[0] != "Berlin%" {
+		t.Fatalf("city must be prefix-wildcarded, got %v", args[0])
+	}
+}
+
+func TestBuildResultsFilter_HasPhone(t *testing.T) {
+	q := url.Values{"has_phone": {"true"}}
+	where, args, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "bl.phone IS NOT NULL AND bl.phone <> ''") {
+		t.Fatalf("has_phone clause missing, got %q", where)
+	}
+	if len(args) != 0 {
+		t.Fatalf("has_phone should not bind args, got %d", len(args))
+	}
+}
+
+func TestBuildResultsFilter_HasPhoneFalseIgnored(t *testing.T) {
+	q := url.Values{"has_phone": {"false"}}
+	where, _, _ := buildResultsFilter(q)
+	if strings.Contains(where, "phone") {
+		t.Fatalf("has_phone=false must not add a clause, got %q", where)
+	}
+}
+
+func TestBuildResultsFilter_HasSocial(t *testing.T) {
+	q := url.Values{"has_social": {"true"}}
+	where, _, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "bl.social_links IS NOT NULL") {
+		t.Fatalf("has_social clause missing, got %q", where)
+	}
+	if !strings.Contains(where, "NOT IN ('{}', '')") {
+		t.Fatalf("has_social must exclude empty jsonb objects, got %q", where)
+	}
+}
+
+func TestBuildResultsFilter_Combined(t *testing.T) {
+	q := url.Values{
+		"country":    {"DE"},
+		"city":       {"Berlin"},
+		"has_phone":  {"true"},
+		"has_social": {"true"},
+	}
+	where, args, idx := buildResultsFilter(q)
+	// 2 bound args (country + city); has_phone + has_social bind no args.
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args (country + city), got %d: %v", len(args), args)
+	}
+	if idx != 3 {
+		t.Fatalf("expected argIdx=3 after 2 binds, got %d", idx)
+	}
+	for _, frag := range []string{"UPPER(bl.country)", "bl.city ILIKE", "bl.phone IS NOT NULL", "bl.social_links"} {
+		if !strings.Contains(where, frag) {
+			t.Fatalf("combined clause missing %q in %q", frag, where)
+		}
+	}
+}
+
+func TestResultsOrderBy_Whitelist(t *testing.T) {
+	cases := map[string]string{
+		"":              "ORDER BY bl.id DESC",
+		"id_desc":       "ORDER BY bl.id DESC",
+		"id_asc":        "ORDER BY bl.id ASC",
+		"updated_desc":  "ORDER BY bl.updated_at DESC, bl.id DESC",
+		"updated_asc":   "ORDER BY bl.updated_at ASC, bl.id ASC",
+		"created_desc":  "ORDER BY bl.created_at DESC, bl.id DESC",
+		"created_asc":   "ORDER BY bl.created_at ASC, bl.id ASC",
+		"DROP TABLE bl": "ORDER BY bl.id DESC", // unknown -> default
+		"random()":      "ORDER BY bl.id DESC",
+	}
+	for sort, want := range cases {
+		got := resultsOrderBy(sort)
+		if got != want {
+			t.Errorf("resultsOrderBy(%q) = %q, want %q", sort, got, want)
+		}
+	}
+}

--- a/internal/api/v2_handlers_queries.go
+++ b/internal/api/v2_handlers_queries.go
@@ -11,8 +11,19 @@ import (
 	"github.com/sadewadee/serp-scraper/internal/query"
 )
 
+// queriesCountTTL is the cache TTL for filtered COUNT(*) on queries.
+// 60s — list mutates only on manual create/retry, not in the hot path.
+const queriesCountTTL = 60 * time.Second
+
 // handleV2ListQueries returns paginated queries wrapped in V2 format.
+// COUNT is Redis-cached (60s TTL) and protected by a 10s statement_timeout.
+// On count timeout the handler still serves data with total=-1 sentinel — the
+// envelope's TotalKnown=false signals to consumers that pagination math is
+// unreliable, avoiding a cascade 500 on an ILIKE search hitting an unindexed scan.
 func (s *Server) handleV2ListQueries(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := v2RequestContext(r)
+	defer cancel()
+
 	q := r.URL.Query()
 	page := queryInt(q, "page", 1)
 	perPage := queryInt(q, "per_page", 50)
@@ -36,8 +47,10 @@ func (s *Server) handleV2ListQueries(w http.ResponseWriter, r *http.Request) {
 		argIdx++
 	}
 
-	var total int
-	s.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM queries %s", where), args...).Scan(&total)
+	total, err := s.cachedCount(ctx, "queries", where, args, queriesCountTTL, 10*time.Second)
+	if err != nil {
+		slog.Warn("v2: queries count failed (serving with -1 sentinel)", "error", err)
+	}
 
 	dataQuery := fmt.Sprintf(`
 		SELECT id, text, status, result_count, COALESCE(error_msg,''), created_at
@@ -47,7 +60,7 @@ func (s *Server) handleV2ListQueries(w http.ResponseWriter, r *http.Request) {
 	`, where, argIdx, argIdx+1)
 	args = append(args, perPage, offset)
 
-	rows, err := s.db.Query(dataQuery, args...)
+	rows, err := s.db.QueryContext(ctx, dataQuery, args...)
 	if err != nil {
 		slog.Error("v2: list queries error", "error", err)
 		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch queries")

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -2,80 +2,24 @@ package api
 
 import (
 	"context"
-	"crypto/sha1"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
 	pq "github.com/lib/pq"
 )
 
-// resultsCountTTL is the Redis cache window for filtered COUNT(*) results.
-// Polling clients re-hit the same filter combo within this window for free.
+// resultsCountTTL is the cache TTL for filtered COUNT(*) on business_listings.
 const resultsCountTTL = 60 * time.Second
 
-// cachedFilteredCount returns COUNT(*) for the given WHERE+args, served from
-// Redis when fresh. On query timeout/error, returns (-1, err) so the caller can
-// still serve the page with a "many" sentinel instead of HTTP 500.
-//
-// Cache key shape: "v2:count:<sha1(where|args)>" — args serialized via fmt to
-// keep numbers/strings/timestamps stable across calls.
+// cachedFilteredCount is the existing call signature, now thin wrapper over cachedCount.
 func (s *Server) cachedFilteredCount(ctx context.Context, where string, args []any) (int, error) {
-	key := buildCountCacheKey(where, args)
-
-	if s.redis != nil {
-		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
-			if n, perr := strconv.Atoi(v); perr == nil {
-				return n, nil
-			}
-		}
-	}
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return -1, err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '12000'"); err != nil {
-		return -1, err
-	}
-
-	var total int
-	q := fmt.Sprintf("SELECT COUNT(*) FROM business_listings bl %s", where)
-	if err := tx.QueryRowContext(ctx, q, args...).Scan(&total); err != nil {
-		return -1, err
-	}
-	if err := tx.Commit(); err != nil {
-		// Commit failure means the COUNT result may be from a tx that did not
-		// fully reconcile — never cache it and signal the caller to skip.
-		return -1, err
-	}
-
-	if s.redis != nil {
-		// Best-effort SETEX; cache miss isn't worth failing the request over.
-		_ = s.redis.Set(ctx, key, strconv.Itoa(total), resultsCountTTL).Err()
-	}
-	return total, nil
-}
-
-// buildCountCacheKey hashes WHERE + args into a stable Redis key. Args are
-// formatted with %q so adjacent string values cannot transpose into the same
-// byte stream (e.g. ["a","bc"] and ["ab","c"] used to collide under %v).
-func buildCountCacheKey(where string, args []any) string {
-	h := sha1.New()
-	h.Write([]byte(where))
-	for _, a := range args {
-		fmt.Fprintf(h, "|%q|", a)
-	}
-	return "v2:count:" + hex.EncodeToString(h.Sum(nil))
+	return s.cachedCount(ctx, "business_listings bl", where, args, resultsCountTTL, 12*time.Second)
 }
 
 // buildResultsFilter builds a WHERE clause + args from query parameters.

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -57,8 +57,48 @@ func buildResultsFilter(q url.Values) (string, []any, int) {
 		args = append(args, "%"+search+"%")
 		argIdx++
 	}
+	if country := q.Get("country"); country != "" {
+		// Stored values are ISO alpha-2 ("ID", "DE", ...) — accept any case
+		// from the caller and normalize via UPPER on both sides.
+		where += fmt.Sprintf(" AND UPPER(bl.country) = UPPER($%d)", argIdx)
+		args = append(args, country)
+		argIdx++
+	}
+	if city := q.Get("city"); city != "" {
+		// Prefix ILIKE so "?city=Berlin" matches "Berlin", "Berlin-Mitte", etc.
+		// Cheaper than substring %x% and friendlier to a btree(city) index.
+		where += fmt.Sprintf(" AND bl.city ILIKE $%d", argIdx)
+		args = append(args, city+"%")
+		argIdx++
+	}
+	if hasPhone := q.Get("has_phone"); hasPhone == "true" {
+		where += " AND bl.phone IS NOT NULL AND bl.phone <> ''"
+	}
+	if hasSocial := q.Get("has_social"); hasSocial == "true" {
+		where += " AND bl.social_links IS NOT NULL AND bl.social_links::text NOT IN ('{}', '')"
+	}
 
 	return where, args, argIdx
+}
+
+// resultsOrderBy returns a safe ORDER BY clause for the results endpoint.
+// Whitelist-only to prevent SQL injection — q.Get("sort") is user input.
+// Defaults to id_desc for compat with the original hardcoded ordering.
+func resultsOrderBy(sort string) string {
+	switch sort {
+	case "id_asc":
+		return "ORDER BY bl.id ASC"
+	case "updated_desc":
+		return "ORDER BY bl.updated_at DESC, bl.id DESC"
+	case "updated_asc":
+		return "ORDER BY bl.updated_at ASC, bl.id ASC"
+	case "created_desc":
+		return "ORDER BY bl.created_at DESC, bl.id DESC"
+	case "created_asc":
+		return "ORDER BY bl.created_at ASC, bl.id ASC"
+	default:
+		return "ORDER BY bl.id DESC"
+	}
 }
 
 // handleV2ListResults returns paginated business listings with full email info.
@@ -118,6 +158,14 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		limit = perPage + 1
 	}
 
+	// Cursor mode is keyed on bl.id, so ?sort= only takes effect in OFFSET mode.
+	// Forcing id-order in cursor mode keeps the keyset boundary consistent —
+	// mixing sort keys with a cursor would skip or duplicate rows.
+	orderBy := "ORDER BY bl.id DESC"
+	if !useCursor {
+		orderBy = resultsOrderBy(q.Get("sort"))
+	}
+
 	// Query 1: Fetch paginated listings (all columns).
 	dataQuery := fmt.Sprintf(`
 		SELECT bl.id, COALESCE(bl.business_name,''), COALESCE(bl.category,''),
@@ -130,8 +178,8 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		       COALESCE(bl.tiktok,''), COALESCE(bl.youtube,''), COALESCE(bl.telegram,''),
 		       bl.source_query_id, bl.created_at, bl.updated_at
 		FROM business_listings bl %s
-		ORDER BY bl.id DESC
-		LIMIT $%d`, where, argIdx)
+		%s
+		LIMIT $%d`, where, orderBy, argIdx)
 	args = append(args, limit)
 	argIdx++
 

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -77,11 +77,45 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 
 	where, args, argIdx := buildResultsFilter(q)
 
-	// Count total via Redis-cached helper. On timeout/error the helper returns -1
+	// Cursor mode (?cursor=base64): keyset pagination — O(log N) at any depth
+	// via the existing bl.id PK index. Skips COUNT entirely and returns
+	// {next_cursor, has_more} instead of a total. Detected by presence of the
+	// cursor param; if absent we fall through to the existing OFFSET path so
+	// existing consumers keep working unchanged.
+	cursorParam := q.Get("cursor")
+	useCursor := cursorParam != ""
+
+	if useCursor {
+		cursorID, derr := decodeCursor(cursorParam)
+		if derr != nil {
+			writeV2Error(w, http.StatusBadRequest, "invalid_cursor", "cursor is malformed")
+			return
+		}
+		dir := q.Get("cursor_dir")
+		if dir == "prev" {
+			where += fmt.Sprintf(" AND bl.id > $%d", argIdx)
+		} else {
+			where += fmt.Sprintf(" AND bl.id < $%d", argIdx)
+		}
+		args = append(args, cursorID)
+		argIdx++
+	}
+
+	// Count only applies in OFFSET mode. On timeout/error the helper returns -1
 	// so we serve the page with a sentinel instead of 500.
-	total, err := s.cachedFilteredCount(ctx, where, args)
-	if err != nil {
-		slog.Warn("v2: count failed (returning -1 sentinel)", "error", err)
+	var total int
+	if !useCursor {
+		var err error
+		total, err = s.cachedFilteredCount(ctx, where, args)
+		if err != nil {
+			slog.Warn("v2: count failed (returning -1 sentinel)", "error", err)
+		}
+	}
+
+	// Cursor mode fetches perPage+1 to detect has_more without a second query.
+	limit := perPage
+	if useCursor {
+		limit = perPage + 1
 	}
 
 	// Query 1: Fetch paginated listings (all columns).
@@ -97,9 +131,14 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		       bl.source_query_id, bl.created_at, bl.updated_at
 		FROM business_listings bl %s
 		ORDER BY bl.id DESC
-		LIMIT $%d OFFSET $%d
-	`, where, argIdx, argIdx+1)
-	args = append(args, perPage, offset)
+		LIMIT $%d`, where, argIdx)
+	args = append(args, limit)
+	argIdx++
+
+	if !useCursor {
+		dataQuery += fmt.Sprintf(" OFFSET $%d", argIdx)
+		args = append(args, offset)
+	}
 
 	rows, err := s.db.QueryContext(ctx, dataQuery, args...)
 	if err != nil {
@@ -142,6 +181,15 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		l.Phone = phone
 		listings = append(listings, l)
 		listingIDs = append(listingIDs, l.ID)
+	}
+
+	// Cursor mode: detect has_more via the sentinel row, then trim it BEFORE
+	// the email batch fetch so we don't waste a query on a row we're dropping.
+	hasMore := false
+	if useCursor && len(listings) > perPage {
+		hasMore = true
+		listings = listings[:perPage]
+		listingIDs = listingIDs[:perPage]
 	}
 
 	// Query 2: Batch-fetch ALL email columns for those listing IDs.
@@ -199,6 +247,23 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 
 	if listings == nil {
 		listings = []V2BusinessListing{}
+	}
+
+	if useCursor {
+		// Cursor envelope: explicit fields instead of pagination meta. Skip
+		// writeV2Single because that wraps in "data" and we also need
+		// next_cursor + has_more at the same level as the JSON-RPC-ish v2 style.
+		var nextCursor string
+		if hasMore && len(listings) > 0 {
+			nextCursor = encodeCursor(listings[len(listings)-1].ID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data":        listings,
+			"next_cursor": nextCursor,
+			"has_more":    hasMore,
+		})
+		return
 	}
 
 	writeV2Paginated(w, listings, total, page, perPage)

--- a/internal/api/v2_handlers_stats.go
+++ b/internal/api/v2_handlers_stats.go
@@ -1,16 +1,37 @@
 package api
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
+	"time"
 )
 
+// dashboardStatsCacheTTL is the Redis cache window for /api/v2/stats.
+// Dashboard polling clients re-hit within this window for ~free.
+const dashboardStatsCacheTTL = 30 * time.Second
+
 // handleV2DashboardStats returns the full dashboard stats wrapped in V2 format.
+// Backed by a 30s Redis cache with single-flight to prevent thundering herd
+// when the cache TTL expires under polling load.
 func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := v2RequestContext(r)
 	defer cancel()
 
-	// -- Queries --
+	s.cachedJSON(ctx, w,
+		"v2:stats:dashboard", dashboardStatsCacheTTL, 5*time.Second,
+		func() (any, error) {
+			return s.computeDashboardStats(ctx)
+		},
+	)
+}
+
+// computeDashboardStats runs the dashboard COUNT(*) queries against the live DB.
+// Wrapped by cachedJSON above. The V2 envelope {"data": ...} is constructed
+// inline because cachedJSON caches raw JSON bytes; going through writeV2Single
+// inside the cached path would re-wrap on every cache miss.
+func (s *Server) computeDashboardStats(ctx context.Context) (map[string]any, error) {
+	// -- Queries (small table, no timeout needed) --
 	queries := map[string]int{}
 	qRows, _ := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM queries GROUP BY status`)
 	if qRows != nil {
@@ -28,26 +49,23 @@ func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) 
 	}
 	queries["total"] = qTotal
 
-	// -- SERP Jobs (with statement timeout) --
-	serp := map[string]any{}
-	var serpTotal, serpNew, serpProcessing, serpCompleted, serpFailed int
-	var serpURLsFound, serpPerHour, serpToday int
-
+	// -- Big-table aggregates: serp_jobs + enrichment_jobs + emails --
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		slog.Error("v2: dashboard tx error", "error", err)
-		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch dashboard stats")
-		return
+		return nil, err
 	}
 	defer tx.Rollback()
 
-	// 15s — serp_jobs (5.7M rows) and emails (828K+) need more headroom.
+	// 15s — serp_jobs (5.7M rows) and emails (828K+) need headroom.
 	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '15000'"); err != nil {
 		slog.Error("v2: set timeout error", "error", err)
-		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to set timeout")
-		return
+		return nil, err
 	}
 
+	serp := map[string]any{}
+	var serpTotal, serpNew, serpProcessing, serpCompleted, serpFailed int
+	var serpURLsFound, serpPerHour, serpToday int
 	tx.QueryRowContext(ctx, `
 		SELECT
 			COUNT(*),
@@ -69,7 +87,6 @@ func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) 
 	serp["rate_per_hour"] = serpPerHour
 	serp["today"] = serpToday
 
-	// -- Enrich Jobs --
 	enrich := map[string]any{}
 	var enrichTotal, enrichPending, enrichProcessing, enrichCompleted, enrichFailed, enrichDead int
 	var enrichPerHour, enrichToday int
@@ -94,20 +111,17 @@ func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) 
 	enrich["rate_per_hour"] = enrichPerHour
 	enrich["today"] = enrichToday
 
-	// -- Results --
 	results := map[string]any{}
 	var totalEmails, emailsToday, emailsLastHour, uniqueDomains int
 	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails`).Scan(&totalEmails)
 	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'`).Scan(&emailsToday)
 	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'`).Scan(&emailsLastHour)
 	tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT domain) FROM business_listings`).Scan(&uniqueDomains)
-
 	results["total_emails"] = totalEmails
 	results["emails_today"] = emailsToday
 	results["emails_per_hour"] = emailsLastHour
 	results["unique_domains"] = uniqueDomains
 
-	// Top email providers.
 	providerRows, _ := tx.QueryContext(ctx, `
 		SELECT domain, COUNT(*) AS cnt
 		FROM emails
@@ -127,20 +141,25 @@ func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) 
 
 	tx.Commit()
 
-	// -- Queues (Redis) --
 	queueMap := map[string]int64{}
-	qd, _ := s.redis.ZCard(ctx, "serp:queue:queries").Result()
-	queueMap["serp:queue:queries"] = qd
-	sb, _ := s.redis.LLen(ctx, "serp:buffer").Result()
-	queueMap["serp:buffer"] = sb
-	eb, _ := s.redis.LLen(ctx, "enrich:buffer").Result()
-	queueMap["enrich:buffer"] = eb
+	if s.redis != nil {
+		qd, _ := s.redis.ZCard(ctx, "serp:queue:queries").Result()
+		queueMap["serp:queue:queries"] = qd
+		sb, _ := s.redis.LLen(ctx, "serp:buffer").Result()
+		queueMap["serp:buffer"] = sb
+		eb, _ := s.redis.LLen(ctx, "enrich:buffer").Result()
+		queueMap["enrich:buffer"] = eb
+	}
 
-	writeV2Single(w, map[string]any{
-		"queries": queries,
-		"serp":    serp,
-		"enrich":  enrich,
-		"results": results,
-		"queues":  queueMap,
-	})
+	// Wrap in V2 envelope manually since cachedJSON caches the raw bytes —
+	// returning the inner object alone would force callers to re-wrap on hit.
+	return map[string]any{
+		"data": map[string]any{
+			"queries": queries,
+			"serp":    serp,
+			"enrich":  enrich,
+			"results": results,
+			"queues":  queueMap,
+		},
+	}, nil
 }


### PR DESCRIPTION
## Summary

Add the location + contactability filters consumers actually need. The data was already there (82K country, 74K city, 302K phone, 481K social) — the endpoint just refused to filter on it. Additive only, no breaking change.

**Stacked on top of #23** (Fase A — stop bleeding). Merge that first; this PR diff is conflict-free against canary once #23 lands.

## Changes

| Param | Behavior |
|---|---|
| country | ISO alpha-2, case-insensitive (?country=id == ?country=ID) |
| city | Prefix ILIKE (?city=Berlin matches Berlin, Berlin-Mitte) |
| has_phone=true | bl.phone non-empty |
| has_social=true | bl.social_links non-empty ({} excluded) |
| sort | Whitelist: id_desc (default), id_asc, updated_desc, updated_asc, created_desc, created_asc. Unknown -> default. Sort only applies in OFFSET mode (cursor mode forced to id_desc). |

## Files

- internal/api/v2_handlers_results.go — buildResultsFilter() + new resultsOrderBy(). Sort wired into handleV2ListResults.
- internal/api/v2_filters_test.go — 8 new unit tests (each filter branch + whitelist behavior incl. fallback for injection-ish inputs).
- docs/api-response.md — full parameter table + cursor-vs-offset response shape.

## Verification

- go build -tags playwright,tls ./... clean
- go test -tags playwright,tls ./internal/api/... PASS
- go test -tags playwright,tls -race -count=1 ./internal/api/ PASS
- go vet -tags playwright,tls ./... clean

## Test plan

- [ ] ?country=ID returns only ID rows
- [ ] ?country=DE&city=Berlin filters by location
- [ ] ?has_phone=true&has_social=true narrows to contactable rows
- [ ] ?sort=updated_desc orders by updated_at descending
- [ ] ?sort=random() falls back to id_desc silently (whitelist)
- [ ] No conflict against canary once #23 merges

## Out of scope

- Niche filter (?niche=yoga) and off_niche infra -> PR 3
