### PR TITLE
fix(reenrich): drop ORDER BY RANDOM() that stalled the eligibility query (#28)

### DIFF
--- a/internal/stage/reenrich.go
+++ b/internal/stage/reenrich.go
@@ -66,9 +66,10 @@ type reenrichRow struct {
 // Run starts numWorkers goroutines each running the continuous re-enrich loop
 // plus one lock-reaper goroutine that deterministically releases stale claims.
 // The reaper exists because the worker's eligibility-query stale-claim recovery
-// is probabilistic (ORDER BY RANDOM over a 261K-row pool) — a row's specific
-// stale lock has 0.04% chance of being re-picked per batch, so rows stuck for
-// hours/days accumulate. The reaper closes that gap with a deterministic sweep.
+// is best-effort: the query scans re_enriched_at IS NULL rows in index order
+// and stops at the first LIMIT eligible rows, so a stale lock deep in the pool
+// may not resurface for a long time. Rows stuck for hours/days would otherwise
+// accumulate; the reaper closes that gap with a deterministic sweep.
 func (r *ReenrichStage) Run(ctx context.Context) error {
 	numWorkers := r.cfg.ReenrichWorkerCount
 	if numWorkers < 1 {
@@ -179,6 +180,69 @@ func (r *ReenrichStage) worker(ctx context.Context, workerID int) {
 // anti-pattern (zero-reset retry) caused the 2026-04-06 pipeline deadlock.
 const reenrichMaxAttempts = 10
 
+// eligibilityQuery is the exact SQL fetchEligibleBatch runs, lifted to package
+// scope so TestEligibilityQuery_NoOrderByRandom can guard against the ORDER BY
+// RANDOM() regression that stalled the reenrich worker (issue #28).
+const eligibilityQuery = `
+		WITH eligible AS (
+			SELECT bl.id
+			FROM business_listings bl
+			WHERE re_enriched_at IS NULL
+			  AND (re_enrich_locked_at IS NULL
+			       OR re_enrich_locked_at < NOW() - INTERVAL '15 minutes')
+			  AND COALESCE(bl.re_enrich_attempts, 0) < $3
+			  AND (
+				CASE WHEN EXISTS(
+					SELECT 1 FROM business_emails be
+					JOIN emails e ON e.id = be.email_id
+					WHERE be.business_id = bl.id
+					  AND (e.is_acceptable = true OR e.score >= 0.7)
+				) THEN 40 ELSE 0 END
+				+
+				CASE WHEN (bl.phone IS NOT NULL AND bl.phone != '')
+					OR (bl.phones IS NOT NULL AND array_length(bl.phones, 1) > 0)
+				THEN 20 ELSE 0 END
+				+
+				CASE WHEN (bl.business_name IS NOT NULL AND bl.business_name != '')
+					AND (bl.category IS NOT NULL AND bl.category != '')
+				THEN 15 ELSE 0 END
+				+
+				CASE WHEN (bl.address IS NOT NULL AND bl.address != '')
+					OR ((bl.city IS NOT NULL AND bl.city != '') AND (bl.country IS NOT NULL AND bl.country != ''))
+				THEN 15 ELSE 0 END
+				+
+				CASE WHEN bl.social_links IS NOT NULL AND bl.social_links != '{}'::jsonb
+				THEN 10 ELSE 0 END
+			  ) < $1
+			-- Deliberately NOT randomly ordered: a random sort over the whole
+			-- eligible pool forced a full index scan + sort of every
+			-- re_enriched_at IS NULL row (~340K), so the SELECT blew the 5s
+			-- statement_timeout on every loop and the worker claimed ~0 rows
+			-- (issue #28 — reenrich stalled at ~88 rows/hr). Index-order scan +
+			-- LIMIT short-circuits after the first $2 eligible rows (~4ms on
+			-- prod). Work is still spread across workers/iterations by FOR UPDATE
+			-- OF bl SKIP LOCKED plus the 15-min re_enrich_locked_at window, which
+			-- advances the scan as claimed rows drop out of the candidate set.
+			LIMIT $2
+			FOR UPDATE OF bl SKIP LOCKED
+		)
+		UPDATE business_listings bl
+		SET re_enrich_locked_at = NOW(),
+		    re_enrich_attempts  = COALESCE(bl.re_enrich_attempts, 0) + 1
+		FROM eligible
+		WHERE bl.id = eligible.id
+		RETURNING
+			bl.id,
+			bl.domain,
+			COALESCE(bl.website, 'https://' || bl.domain),
+			bl.address,
+			bl.country,
+			bl.city,
+			(SELECT COUNT(*) FROM business_emails be WHERE be.business_id = bl.id),
+			(CASE WHEN bl.phone IS NOT NULL AND bl.phone != '' THEN 1 ELSE 0 END
+			 + COALESCE(array_length(bl.phones, 1), 0))
+	`
+
 // fetchEligibleBatch atomically claims up to limit business_listings rows.
 //
 // Multi-worker correctness: uses CTE with FOR UPDATE OF bl SKIP LOCKED to
@@ -210,57 +274,7 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	const q = `
-		WITH eligible AS (
-			SELECT bl.id
-			FROM business_listings bl
-			WHERE re_enriched_at IS NULL
-			  AND (re_enrich_locked_at IS NULL
-			       OR re_enrich_locked_at < NOW() - INTERVAL '15 minutes')
-			  AND COALESCE(bl.re_enrich_attempts, 0) < $3
-			  AND (
-				CASE WHEN EXISTS(
-					SELECT 1 FROM business_emails be
-					JOIN emails e ON e.id = be.email_id
-					WHERE be.business_id = bl.id
-					  AND (e.is_acceptable = true OR e.score >= 0.7)
-				) THEN 40 ELSE 0 END
-				+
-				CASE WHEN (bl.phone IS NOT NULL AND bl.phone != '')
-					OR (bl.phones IS NOT NULL AND array_length(bl.phones, 1) > 0)
-				THEN 20 ELSE 0 END
-				+
-				CASE WHEN (bl.business_name IS NOT NULL AND bl.business_name != '')
-					AND (bl.category IS NOT NULL AND bl.category != '')
-				THEN 15 ELSE 0 END
-				+
-				CASE WHEN (bl.address IS NOT NULL AND bl.address != '')
-					OR ((bl.city IS NOT NULL AND bl.city != '') AND (bl.country IS NOT NULL AND bl.country != ''))
-				THEN 15 ELSE 0 END
-				+
-				CASE WHEN bl.social_links IS NOT NULL AND bl.social_links != '{}'::jsonb
-				THEN 10 ELSE 0 END
-			  ) < $1
-			ORDER BY RANDOM()
-			LIMIT $2
-			FOR UPDATE OF bl SKIP LOCKED
-		)
-		UPDATE business_listings bl
-		SET re_enrich_locked_at = NOW(),
-		    re_enrich_attempts  = COALESCE(bl.re_enrich_attempts, 0) + 1
-		FROM eligible
-		WHERE bl.id = eligible.id
-		RETURNING
-			bl.id,
-			bl.domain,
-			COALESCE(bl.website, 'https://' || bl.domain),
-			bl.address,
-			bl.country,
-			bl.city,
-			(SELECT COUNT(*) FROM business_emails be WHERE be.business_id = bl.id),
-			(CASE WHEN bl.phone IS NOT NULL AND bl.phone != '' THEN 1 ELSE 0 END
-			 + COALESCE(array_length(bl.phones, 1), 0))
-	`
+	const q = eligibilityQuery
 
 	tx, err := r.db.BeginTx(queryCtx, nil)
 	if err != nil {
@@ -510,9 +524,10 @@ func (r *ReenrichStage) releaseLock(ctx context.Context, id int64) {
 }
 
 // lockReaper releases stale re_enrich_locked_at claims deterministically on
-// a 5-minute tick. Without this, the probabilistic ORDER BY RANDOM eligibility
-// query rarely re-rolls specific stuck rows — production audit (2026-05-12)
-// found 708 rows stale-locked, oldest 3 days. The reaper closes that gap.
+// a 5-minute tick. Without this, the eligibility query (which scans in index
+// order and stops at the LIMIT) may not revisit specific stuck rows for a long
+// time — production audit (2026-05-12) found 708 rows stale-locked, oldest 3
+// days. The reaper closes that gap.
 //
 // Idempotent — clearing a non-stale lock is a no-op. Safe to run alongside
 // workers; the 15-min threshold is much longer than max processRow timeout

--- a/internal/stage/reenrich_test.go
+++ b/internal/stage/reenrich_test.go
@@ -211,3 +211,32 @@ func TestReaperSweepSQL_Shape(t *testing.T) {
 		}
 	}
 }
+
+// TestEligibilityQuery_NoOrderByRandom guards the issue-#28 regression: the
+// reenrich eligibility query MUST NOT use ORDER BY RANDOM(). Sorting the whole
+// re_enriched_at IS NULL pool (~340K rows) by random() forced a full index
+// scan + sort and blew the 5s statement_timeout on every loop, stalling the
+// worker at ~88 rows/hr. Without the sort, LIMIT short-circuits the scan after
+// the first batch of eligible rows (~4ms measured on prod). This test inspects
+// the actual SQL the worker runs (package-level eligibilityQuery), not a copy.
+func TestEligibilityQuery_NoOrderByRandom(t *testing.T) {
+	if strings.Contains(strings.ToUpper(eligibilityQuery), "ORDER BY RANDOM") {
+		t.Error("eligibilityQuery contains ORDER BY RANDOM() — reintroduces the issue-#28 stall (full scan+sort blows the 5s statement_timeout). Rely on LIMIT + FOR UPDATE SKIP LOCKED instead.")
+	}
+
+	// The clauses that keep the query both correct and able to short-circuit.
+	required := []struct {
+		clause string
+		why    string
+	}{
+		{"re_enriched_at IS NULL", "candidate set must be unprocessed rows only"},
+		{"COALESCE(bl.re_enrich_attempts, 0) < $3", "retry cap stops genuinely-broken sites from cycling"},
+		{"LIMIT $2", "bounds the batch and lets the index scan short-circuit"},
+		{"FOR UPDATE OF bl SKIP LOCKED", "multi-worker safety + distributes work without random ordering"},
+	}
+	for _, c := range required {
+		if !strings.Contains(eligibilityQuery, c.clause) {
+			t.Errorf("eligibilityQuery missing clause %q — %s", c.clause, c.why)
+		}
+	}
+}


### PR DESCRIPTION
Fixes #28.

## Problem

The `reenrich` worker (kurama, `serpscraper-serp-9mg1q5-rxyd9w-reenrich-1`, `v0.8.3-niche`) was running and reporting **healthy**, but producing almost nothing. Every eligibility loop hit its 5s `statement_timeout` and claimed ~0 rows.

- Throughput collapsed to **88 rows/hr** (vs enrich ~30,700/hr), and falling.
- Backlog ~360K `re_enriched_at IS NULL` rows (~340K never attempted) — never draining.
- The container's healthcheck only touches `/tmp/worker-healthy`, so the stall was invisible (green "healthy" the whole time).

Confirmed via logs — identical line every ~20s for the full window sampled:
```
WARN reenrich: eligibility query failed worker=0
  error="pq: canceling statement due to statement timeout (57014)"
```

## Root cause

`EXPLAIN` on prod showed the eligibility CTE costing **~3.7M**:
- `ORDER BY RANDOM()` forced a full index scan + sort of every `re_enriched_at IS NULL` row (~340K)…
- …and the per-row correlated `EXISTS(business_emails JOIN emails)` completeness subscore ran for the entire pool **before** `LIMIT` could apply.

No way it finishes under `SET LOCAL statement_timeout='5000'`.

## Fix

Remove `ORDER BY RANDOM()`. The index scan returns rows in index order and `LIMIT` short-circuits after the first batch of eligible rows.

**Measured on prod (`EXPLAIN ANALYZE`, read-only):**

| | Before | After |
|---|---|---|
| Execution time | >5000 ms (timeout) | **4.3 ms** |
| Rows scanned | ~340K (then sort) | **101** |
| SubPlan (EXISTS) loops | ~340K | **101** |

Work is still distributed across workers and loop iterations by `FOR UPDATE OF bl SKIP LOCKED` + the 15-min `re_enrich_locked_at` window (which advances the scan as claimed rows drop out). The deterministic `lockReaper` still handles stale claims, so dropping the random re-roll does **not** regress stale-claim recovery.

## Changes

- `internal/stage/reenrich.go`: drop `ORDER BY RANDOM()`; lift the eligibility SQL to a package-level `eligibilityQuery` const so it can be asserted against; update comments that described the old probabilistic behavior.
- `internal/stage/reenrich_test.go`: add `TestEligibilityQuery_NoOrderByRandom` — inspects the **real** query the worker runs and fails if `ORDER BY RANDOM()` returns (also asserts the guard clauses + `LIMIT`/`SKIP LOCKED` that enable short-circuiting).

**No schema change.**

## Base branch

Targets `feat/api-niche-classifier` because that is the deployed line (`v0.8.3-niche`, 35 commits ahead of `main`). `main` carries an older, simpler reenrich query that *also* has `ORDER BY RANDOM()`; it should get the same fix when the lines reconcile.

## Follow-up (not in this PR)

`re_enriched_at IS NULL` rows whose completeness is already ≥ threshold are never eligible and never stamped, so they accumulate as residue the index scan must skip. Negligible today (eligibility is dense), but as the backlog drains, consider stamping complete rows so they exit the candidate pool — otherwise the index-order scan slowly pays more to reach eligible rows.

## Verification

- `go vet -tags playwright ./internal/stage/` — clean
- `CGO_ENABLED=0 go build -tags playwright,tls -ldflags="-w -s"` — OK
- `go test -tags playwright ./...` — all pass
