### PR TITLE
feat(yogaalliance): directory crawler + DB insert (in-niche yoga leads)

### DIFF
--- a/Dockerfile.yogaalliance
+++ b/Dockerfile.yogaalliance
@@ -1,0 +1,24 @@
+# Dedicated image for the Yoga Alliance directory crawler (cmd/yogaalliance).
+# Pure-Go HTTP crawler — NO Camoufox/playwright, so it builds in seconds and
+# the image is tiny (~20MB). Runs on the server where it has Postgres access
+# and inserts in-niche yoga teacher/school records straight into the existing
+# tables (business_listings + emails + business_emails, source='yogaalliance').
+#
+# Build:  docker build -f Dockerfile.yogaalliance -t ghcr.mcpke.dev/yogaalliance-crawler:v1 .
+# Run:    docker run --rm -e POSTGRES_DSN=... ghcr.mcpke.dev/yogaalliance-crawler:v1 \
+#           -mode teacher -insert -concurrency 8
+
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-w -s" -o /yoga ./cmd/yogaalliance
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates tzdata && adduser -D -u 10001 yoga
+USER yoga
+COPY --from=build /yoga /usr/local/bin/yoga
+ENTRYPOINT ["yoga"]
+# Default: crawl all teachers and insert into the DB. Override args at runtime.
+CMD ["-mode", "teacher", "-insert", "-concurrency", "8"]

--- a/cmd/yogaalliance/main.go
+++ b/cmd/yogaalliance/main.go
@@ -1,36 +1,44 @@
-// Command yogaalliance crawls the public Yoga Alliance directory (schools +
-// teachers) via its guest Salesforce LWR Apex API and writes structured,
-// 100%-in-niche records to CSV.
+// Command yogaalliance crawls the public Yoga Alliance directory (teachers +
+// schools) via its guest Salesforce LWR Apex API and writes structured,
+// 100%-in-niche records to CSV and/or directly into the existing database.
 //
-// Why this exists: the SERP email-dork pipeline yields data-poor rows (only
-// ~10% have an address, niche match ~0%). Yoga Alliance is a curated directory
-// of Registered Yoga Schools (RYS) and Teachers (RYT) — every record is real,
-// in-niche (yoga/wellness/fitness), and TEACHER records expose a published
-// email + city + country directly. No spa/massage contamination.
+// Why: the SERP email-dork pipeline yields data-poor rows (~10% address, ~0%
+// niche match). Yoga Alliance is a curated directory of Registered Yoga
+// Teachers (RYT) and Schools (RYS) — every record is real and in-niche
+// (yoga/wellness/fitness; no spa/massage). TEACHER records expose a published
+// email + city + country + their school directly.
 //
-// API (reverse-engineered, guest-accessible, no auth/CSRF — just cookies):
+// API (guest, no auth/CSRF — just cookies):
 //
 //	POST https://app.yogaalliance.org/webruntime/api/apex/execute?language=en-US&asGuest=true&htmlEncode=false
-//	  body: {"namespace":"","classname":"<HASH>","method":"<M>","isContinuation":false,"params":{...},"cacheable":false}
-//	  school : classname @udd/01pTR000001kCED  method getSchoolDetails  params {"schoolId": "<id>"}
 //	  teacher: classname @udd/01pTR000001kCE1  method getTeacherDetails params {"teacherId":"<id>"}
+//	  school : classname @udd/01pTR000001kCED  method getSchoolDetails  params {"schoolId":"<id>"}
 //
-// The classname hashes are Salesforce build artifacts and CAN change on a
-// redeploy; if every call starts returning 400, re-capture them from a profile
-// page's network tab and update the constants below.
+// Teacher IDs come from app.yogaalliance.org/sitemap.xml (contact-*.xml). The
+// account-*.xml "schools" are mostly individual household accounts that
+// getSchoolDetails rejects, so the default crawl is teachers — each teacher
+// record carries its school via teachingHistoryList ("assign to school").
 //
-// IDs come from the sitemap index at https://app.yogaalliance.org/sitemap.xml
-// (account-*.xml = schools, contact-*.xml = teachers).
+// DB mapping (uses EXISTING tables — no migration):
+//   - emails              ← teacher email (UNIQUE email)
+//   - business_listings   ← one row per teacher; business_name = school (if the
+//     teacher has one) else teacher name; contact_name =
+//     teacher; niche_category='yoga'; off_niche=false;
+//     category='yogaalliance'; synthetic unique domain
+//     "<id>.ryt.yogaalliance.org"
+//   - business_emails     ← link, source='yogaalliance'  ← the source tag
 //
-// Build & run (standalone — NOT covered by the playwright tag):
+// Build & run:
 //
 //	go build -o yoga ./cmd/yogaalliance
-//	./yoga -mode teacher -out teachers.csv -concurrency 12
-//	./yoga -mode school  -out schools.csv  -concurrency 12 -limit 500   # test slice
+//	./yoga -mode teacher -out teachers.csv -concurrency 12               # CSV only
+//	./yoga -mode teacher -insert -concurrency 8                          # → DB (POSTGRES_DSN)
+//	./yoga -mode teacher -insert -dsn "postgres://..." -limit 200        # test slice
 package main
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"flag"
@@ -46,6 +54,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	_ "github.com/lib/pq"
 )
 
 const (
@@ -57,6 +67,7 @@ const (
 	classTeacher  = "@udd/01pTR000001kCE1"
 	methodSchool  = "getSchoolDetails"
 	methodTeacher = "getTeacherDetails"
+	srcTag        = "yogaalliance"
 )
 
 var (
@@ -64,6 +75,12 @@ var (
 	idRe     = regexp.MustCompile(`/(?:school|teacher)publicprofile/([A-Za-z0-9]{15,18})/`)
 	tagsRe   = regexp.MustCompile(`<[^>]+>`)
 	spacesRe = regexp.MustCompile(`\s+`)
+	freeMail = map[string]bool{
+		"gmail.com": true, "yahoo.com": true, "hotmail.com": true, "outlook.com": true,
+		"aol.com": true, "icloud.com": true, "me.com": true, "mac.com": true,
+		"live.com": true, "msn.com": true, "comcast.net": true, "gmx.com": true,
+		"protonmail.com": true, "ymail.com": true, "yahoo.co.uk": true,
+	}
 )
 
 type apexReq struct {
@@ -75,60 +92,81 @@ type apexReq struct {
 	Cacheable      bool           `json:"cacheable"`
 }
 
-// schoolResp / teacherResp capture only the fields we persist.
-type schoolResp struct {
-	ReturnValue struct {
-		Id             string `json:"Id"`
-		DirectoryName  string `json:"directoryName"`
-		Address        string `json:"address"`
-		Designation    string `json:"schoolDesignation"`
-		Facebook       string `json:"schoolFacebook"`
-		Instagram      string `json:"schoolInstagram"`
-		Languages      string `json:"languages"`
-		TypesOfYoga    string `json:"typesOfYogaTaught"`
-		Published      bool   `json:"isSchoolProfilePublished"`
-		TrainerDetails []struct {
-			TrainerId            string `json:"trainerId"`
-			TrainerDirectoryName string `json:"trainerDirectoryName"`
-		} `json:"trainerDetailsList"`
-	} `json:"returnValue"`
+type teachingLocation struct {
+	LocationName  string `json:"locationName"`
+	GoogleAddress string `json:"googleAddress"`
+	StatusLabel   string `json:"statusLabel"`
 }
 
 type teacherResp struct {
 	ReturnValue struct {
-		Id             string  `json:"Id"`
-		DirectoryName  string  `json:"directoryName"`
-		FirstName      string  `json:"firstName"`
-		LastName       string  `json:"lastName"`
-		Email          string  `json:"teacherEmail"`
-		EmailPublished bool    `json:"isEmailPublished"`
-		Address        string  `json:"address"`
-		MailingCity    string  `json:"mailingCity"`
-		MailingState   string  `json:"mailingState"`
-		MailingCountry string  `json:"mailingCountry"`
-		Instagram      string  `json:"teacherInstagram"`
-		Designation    string  `json:"teacherDesignation"`
-		Languages      string  `json:"languages"`
-		TypesOfYoga    string  `json:"typesOfYogaTaught"`
-		TeachingHours  float64 `json:"teachingHours"`
-		Published      bool    `json:"isProfilePublished"`
+		Id              string             `json:"Id"`
+		DirectoryName   string             `json:"directoryName"`
+		FirstName       string             `json:"firstName"`
+		LastName        string             `json:"lastName"`
+		Email           string             `json:"teacherEmail"`
+		EmailPublished  bool               `json:"isEmailPublished"`
+		Address         string             `json:"address"`
+		MailingCity     string             `json:"mailingCity"`
+		MailingState    string             `json:"mailingState"`
+		MailingCountry  string             `json:"mailingCountry"`
+		Instagram       string             `json:"teacherInstagram"`
+		Designation     string             `json:"teacherDesignation"`
+		Languages       string             `json:"languages"`
+		TypesOfYoga     string             `json:"typesOfYogaTaught"`
+		Biography       string             `json:"biography"`
+		TeachingHours   float64            `json:"teachingHours"`
+		OfferOnline     bool               `json:"offerOnlineClasses"`
+		IsYACEP         bool               `json:"isYACEP"`
+		MembershipBegin string             `json:"originalMembershipBeginDate"`
+		Published       bool               `json:"isProfilePublished"`
+		TeachingHistory []teachingLocation `json:"teachingHistoryList"`
 	} `json:"returnValue"`
+}
+
+type teacher struct {
+	id, name, email, city, state, country, address string
+	instagram, designation, languages, yogaTypes   string
+	biography, schoolName, schoolAddr              string
+	emailPublished, yacep, online                  bool
+	teachingHours                                  float64
 }
 
 func main() {
 	mode := flag.String("mode", "teacher", "teacher | school")
-	out := flag.String("out", "", "output CSV path (default: <mode>s.csv)")
+	out := flag.String("out", "", "output CSV path ('' = none when -insert, else <mode>s.csv)")
 	conc := flag.Int("concurrency", 10, "concurrent requests")
 	limit := flag.Int("limit", 0, "max records (0 = all)")
 	idsFile := flag.String("ids", "", "optional file of IDs (one per line); default = crawl sitemap")
+	doInsert := flag.Bool("insert", false, "upsert into business_listings/emails/business_emails")
+	dsn := flag.String("dsn", os.Getenv("POSTGRES_DSN"), "Postgres DSN (default $POSTGRES_DSN)")
 	flag.Parse()
 
-	if *mode != "teacher" && *mode != "school" {
-		log.Fatalf("mode must be teacher or school")
+	if *mode != "teacher" {
+		log.Fatalf("only -mode teacher is supported (account sitemap is mostly non-school households; schools come via teacher teachingHistory)")
 	}
+
+	var db *sql.DB
+	if *doInsert {
+		if *dsn == "" {
+			log.Fatal("-insert requires -dsn or $POSTGRES_DSN")
+		}
+		var err error
+		db, err = sql.Open("postgres", *dsn)
+		if err != nil {
+			log.Fatalf("db open: %v", err)
+		}
+		db.SetMaxOpenConns(*conc + 2)
+		if err := db.Ping(); err != nil {
+			log.Fatalf("db ping: %v", err)
+		}
+		defer db.Close()
+		log.Printf("yogaalliance: INSERT mode → DB (source=%s)", srcTag)
+	}
+
 	outPath := *out
-	if outPath == "" {
-		outPath = *mode + "s.csv"
+	if outPath == "" && !*doInsert {
+		outPath = "teachers.csv"
 	}
 
 	client := newClient()
@@ -138,29 +176,27 @@ func main() {
 	if *idsFile != "" {
 		ids = readLines(*idsFile)
 	} else {
-		ids = crawlSitemapIDs(client, *mode)
+		ids = crawlSitemapIDs(client)
 	}
 	if *limit > 0 && len(ids) > *limit {
 		ids = ids[:*limit]
 	}
-	log.Printf("yogaalliance: %s — %d IDs to fetch (concurrency=%d) → %s", *mode, len(ids), *conc, outPath)
+	log.Printf("yogaalliance: teacher — %d IDs (concurrency=%d, insert=%v, csv=%q)", len(ids), *conc, *doInsert, outPath)
 
-	f, err := os.Create(outPath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer f.Close()
-	w := csv.NewWriter(f)
-	defer w.Flush()
-	var mu sync.Mutex // guards csv writer
-
-	if *mode == "teacher" {
-		w.Write([]string{"id", "name", "email", "email_published", "city", "state", "country", "address", "instagram", "designation", "languages", "yoga_types", "teaching_hours"})
-	} else {
-		w.Write([]string{"id", "name", "address", "facebook", "instagram", "designation", "languages", "yoga_types", "trainer_ids"})
+	var w *csv.Writer
+	var csvMu sync.Mutex
+	if outPath != "" {
+		f, err := os.Create(outPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		w = csv.NewWriter(f)
+		defer w.Flush()
+		w.Write([]string{"id", "name", "email", "email_published", "city", "state", "country", "address", "school_name", "school_address", "instagram", "designation", "languages", "yoga_types", "yacep", "teaching_hours"})
 	}
 
-	var done, ok, withEmail int64
+	var done, ok, withEmail, inserted int64
 	jobs := make(chan string, *conc*2)
 	var wg sync.WaitGroup
 	for i := 0; i < *conc; i++ {
@@ -168,22 +204,31 @@ func main() {
 		go func() {
 			defer wg.Done()
 			for id := range jobs {
-				row, hasEmail := fetchOne(client, *mode, id)
+				t := fetchTeacher(client, id)
 				n := atomic.AddInt64(&done, 1)
-				if row != nil {
+				if t != nil {
 					atomic.AddInt64(&ok, 1)
-					if hasEmail {
+					if t.email != "" {
 						atomic.AddInt64(&withEmail, 1)
 					}
-					mu.Lock()
-					w.Write(row)
-					if n%500 == 0 {
-						w.Flush()
+					if w != nil {
+						csvMu.Lock()
+						w.Write(t.row())
+						if n%500 == 0 {
+							w.Flush()
+						}
+						csvMu.Unlock()
 					}
-					mu.Unlock()
+					if db != nil {
+						if err := upsertTeacher(db, t); err != nil {
+							log.Printf("  upsert %s failed: %v", t.id, err)
+						} else {
+							atomic.AddInt64(&inserted, 1)
+						}
+					}
 				}
 				if n%1000 == 0 {
-					log.Printf("  progress: %d/%d done, %d ok, %d with-email", n, len(ids), atomic.LoadInt64(&ok), atomic.LoadInt64(&withEmail))
+					log.Printf("  progress: %d/%d done, %d ok, %d email, %d inserted", n, len(ids), atomic.LoadInt64(&ok), atomic.LoadInt64(&withEmail), atomic.LoadInt64(&inserted))
 				}
 			}
 		}()
@@ -193,8 +238,18 @@ func main() {
 	}
 	close(jobs)
 	wg.Wait()
-	w.Flush()
-	log.Printf("DONE: %d fetched, %d records written, %d with email → %s", done, ok, withEmail, outPath)
+	if w != nil {
+		w.Flush()
+	}
+	log.Printf("DONE: %d fetched, %d ok, %d with email, %d inserted", done, ok, withEmail, inserted)
+}
+
+func (t *teacher) row() []string {
+	return []string{
+		t.id, t.name, t.email, strconv.FormatBool(t.emailPublished), t.city, t.state, t.country, t.address,
+		t.schoolName, t.schoolAddr, t.instagram, t.designation, t.languages, t.yogaTypes,
+		strconv.FormatBool(t.yacep), strconv.FormatFloat(t.teachingHours, 'f', -1, 64),
+	}
 }
 
 func newClient() *http.Client {
@@ -202,8 +257,6 @@ func newClient() *http.Client {
 	return &http.Client{Jar: jar, Timeout: 30 * time.Second}
 }
 
-// bootstrap seeds guest cookies (the apex API rejects requests with no session
-// cookies). A single GET to any profile page is enough.
 func bootstrap(c *http.Client) {
 	req, _ := http.NewRequest("GET", bootstrapURL, nil)
 	req.Header.Set("User-Agent", userAgent)
@@ -215,15 +268,11 @@ func bootstrap(c *http.Client) {
 	resp.Body.Close()
 }
 
-func crawlSitemapIDs(c *http.Client, mode string) []string {
-	want := "contact" // teachers
-	if mode == "school" {
-		want = "account"
-	}
+func crawlSitemapIDs(c *http.Client) []string {
 	idxBody := httpGet(c, sitemapIndex)
 	var subs []string
 	for _, m := range locRe.FindAllStringSubmatch(string(idxBody), -1) {
-		if strings.Contains(m[1], "sitemap-"+want) && !strings.Contains(m[1], "weekly") {
+		if strings.Contains(m[1], "sitemap-contact") && !strings.Contains(m[1], "weekly") {
 			subs = append(subs, m[1])
 		}
 	}
@@ -237,88 +286,154 @@ func crawlSitemapIDs(c *http.Client, mode string) []string {
 				ids = append(ids, m[1])
 			}
 		}
-		log.Printf("  sitemap %s → %d unique IDs so far", sm[strings.LastIndex(sm, "/")+1:], len(ids))
+		log.Printf("  %s → %d unique IDs so far", sm[strings.LastIndex(sm, "/")+1:], len(ids))
 	}
 	return ids
 }
 
-func fetchOne(c *http.Client, mode, id string) ([]string, bool) {
-	var class, method, pkey string
-	if mode == "school" {
-		class, method, pkey = classSchool, methodSchool, "schoolId"
-	} else {
-		class, method, pkey = classTeacher, methodTeacher, "teacherId"
-	}
+func fetchTeacher(c *http.Client, id string) *teacher {
 	reqBody, _ := json.Marshal(apexReq{
-		Classname: class, Method: method, Params: map[string]any{pkey: id},
+		Classname: classTeacher, Method: methodTeacher, Params: map[string]any{"teacherId": id},
 	})
-
-	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {
 		req, _ := http.NewRequest("POST", apexURL, bytes.NewReader(reqBody))
 		req.Header.Set("User-Agent", userAgent)
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 		resp, err := c.Do(req)
 		if err != nil {
-			lastErr = err
 			time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
 			continue
 		}
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if resp.StatusCode != 200 {
-			lastErr = fmt.Errorf("http %d", resp.StatusCode)
 			time.Sleep(time.Duration(attempt+1) * 400 * time.Millisecond)
 			continue
 		}
-		if mode == "school" {
-			return parseSchool(body)
+		var r teacherResp
+		if json.Unmarshal(body, &r) != nil || r.ReturnValue.Id == "" {
+			return nil
 		}
-		return parseTeacher(body)
-	}
-	_ = lastErr
-	return nil, false
-}
-
-func parseSchool(body []byte) ([]string, bool) {
-	var r schoolResp
-	if json.Unmarshal(body, &r) != nil || r.ReturnValue.Id == "" {
-		return nil, false
-	}
-	v := r.ReturnValue
-	var tids []string
-	for _, t := range v.TrainerDetails {
-		if t.TrainerId != "" {
-			tids = append(tids, t.TrainerId)
+		v := r.ReturnValue
+		name := clean(v.DirectoryName)
+		if name == "" {
+			name = clean(strings.TrimSpace(v.FirstName + " " + v.LastName))
+		}
+		schoolName, schoolAddr := pickSchool(v.TeachingHistory)
+		return &teacher{
+			id: v.Id, name: name, email: strings.TrimSpace(v.Email), emailPublished: v.EmailPublished,
+			city: clean(v.MailingCity), state: clean(v.MailingState), country: clean(v.MailingCountry),
+			address: clean(v.Address), schoolName: schoolName, schoolAddr: schoolAddr,
+			instagram: strings.TrimSpace(v.Instagram), designation: clean(v.Designation),
+			languages: clean(v.Languages), yogaTypes: clean(v.TypesOfYoga), biography: clean(v.Biography),
+			yacep: v.IsYACEP, online: v.OfferOnline, teachingHours: v.TeachingHours,
 		}
 	}
-	return []string{
-		v.Id, clean(v.DirectoryName), clean(v.Address), v.Facebook, v.Instagram,
-		clean(v.Designation), clean(v.Languages), clean(v.TypesOfYoga), strings.Join(tids, ";"),
-	}, false
+	return nil
 }
 
-func parseTeacher(body []byte) ([]string, bool) {
-	var r teacherResp
-	if json.Unmarshal(body, &r) != nil || r.ReturnValue.Id == "" {
-		return nil, false
+// pickSchool returns the teacher's primary school: the first "Current" location
+// that has a real street address, else the first Current, else the first.
+func pickSchool(hist []teachingLocation) (name, addr string) {
+	var fallback *teachingLocation
+	for i := range hist {
+		h := &hist[i]
+		if fallback == nil {
+			fallback = h
+		}
+		if strings.EqualFold(h.StatusLabel, "Current") {
+			if strings.TrimSpace(h.GoogleAddress) != "" {
+				return clean(h.LocationName), clean(h.GoogleAddress)
+			}
+			if name == "" {
+				name, addr = clean(h.LocationName), clean(h.GoogleAddress)
+			}
+		}
 	}
-	v := r.ReturnValue
-	name := clean(v.DirectoryName)
-	if name == "" {
-		name = clean(strings.TrimSpace(v.FirstName + " " + v.LastName))
+	if name != "" {
+		return name, addr
 	}
-	return []string{
-		v.Id, name, strings.TrimSpace(v.Email), strconv.FormatBool(v.EmailPublished),
-		clean(v.MailingCity), clean(v.MailingState), clean(v.MailingCountry), clean(v.Address),
-		v.Instagram, clean(v.Designation), clean(v.Languages), clean(v.TypesOfYoga),
-		strconv.FormatFloat(v.TeachingHours, 'f', -1, 64),
-	}, strings.TrimSpace(v.Email) != ""
+	if fallback != nil {
+		return clean(fallback.LocationName), clean(fallback.GoogleAddress)
+	}
+	return "", ""
+}
+
+// upsertTeacher writes one teacher into the existing schema, tagged source=yogaalliance.
+func upsertTeacher(db *sql.DB, t *teacher) error {
+	bizName := t.schoolName
+	if bizName == "" {
+		bizName = t.name
+	}
+	addr := t.address
+	if addr == "" {
+		addr = t.schoolAddr
+	}
+	domain := strings.ToLower(t.id) + ".ryt.yogaalliance.org"
+	profileURL := "https://app.yogaalliance.org/teacherpublicprofile?id=" + t.id
+
+	social := map[string]string{}
+	if t.instagram != "" {
+		social["instagram"] = t.instagram
+	}
+	socialJSON, _ := json.Marshal(social)
+
+	var bizID int64
+	err := db.QueryRow(`
+		INSERT INTO business_listings
+		  (domain, business_name, contact_name, address, city, country, description,
+		   social_links, niche_category, off_niche, category, website, created_at, updated_at)
+		VALUES ($1,$2,$3,NULLIF($4,''),NULLIF($5,''),NULLIF($6,''),NULLIF($7,''),
+		   $8::jsonb,'yoga',false,'yogaalliance',$9,NOW(),NOW())
+		ON CONFLICT (domain) DO UPDATE SET
+		  business_name  = COALESCE(NULLIF(EXCLUDED.business_name,''), business_listings.business_name),
+		  contact_name   = COALESCE(NULLIF(EXCLUDED.contact_name,''),  business_listings.contact_name),
+		  address        = COALESCE(business_listings.address, EXCLUDED.address),
+		  city           = COALESCE(business_listings.city,    EXCLUDED.city),
+		  country        = COALESCE(business_listings.country, EXCLUDED.country),
+		  niche_category = 'yoga', off_niche = false, category = 'yogaalliance',
+		  updated_at     = NOW()
+		RETURNING id`,
+		domain, bizName, t.name, addr, t.city, t.country, t.biography, string(socialJSON), profileURL,
+	).Scan(&bizID)
+	if err != nil {
+		return fmt.Errorf("business_listings upsert: %w", err)
+	}
+
+	if t.email == "" {
+		return nil
+	}
+	at := strings.LastIndex(t.email, "@")
+	if at < 1 {
+		return nil
+	}
+	emailDomain := strings.ToLower(t.email[at+1:])
+	localPart := t.email[:at]
+
+	var emailID int64
+	err = db.QueryRow(`
+		INSERT INTO emails (email, domain, local_part, free_email, created_at)
+		VALUES ($1,$2,$3,$4,NOW())
+		ON CONFLICT (email) DO UPDATE SET domain = EXCLUDED.domain
+		RETURNING id`,
+		strings.ToLower(t.email), emailDomain, localPart, freeMail[emailDomain],
+	).Scan(&emailID)
+	if err != nil {
+		return fmt.Errorf("emails upsert: %w", err)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO business_emails (business_id, email_id, source)
+		VALUES ($1,$2,$3) ON CONFLICT (business_id, email_id) DO NOTHING`,
+		bizID, emailID, srcTag)
+	if err != nil {
+		return fmt.Errorf("business_emails link: %w", err)
+	}
+	return nil
 }
 
 func clean(s string) string {
 	s = tagsRe.ReplaceAllString(s, " ")
-	s = strings.ReplaceAll(s, " ", " ")
 	return strings.TrimSpace(spacesRe.ReplaceAllString(s, " "))
 }
 

--- a/docker-compose.yogaalliance.yaml
+++ b/docker-compose.yogaalliance.yaml
@@ -1,0 +1,26 @@
+# Dedicated one-shot crawler container for the Yoga Alliance directory.
+# Runs on kurama (Dokploy) where it has Postgres access, harvests the in-niche
+# RYT/RYS directory via the guest Apex API, and inserts straight into the
+# existing tables tagged source='yogaalliance'. restart:"no" — it's a batch job
+# that exits when the ~78K-teacher harvest completes (re-run to refresh).
+#
+# Deploy via Dokploy as a separate compose target, or locally on kurama:
+#   POSTGRES_DSN=... docker compose -f docker-compose.yogaalliance.yaml up --build
+#
+# Rollback/source: every row it writes is tagged via business_emails.source =
+# 'yogaalliance' + business_listings.category = 'yogaalliance' + a
+# *.ryt.yogaalliance.org synthetic domain, so the whole batch is trivially
+# identifiable and deletable if needed.
+
+services:
+  yogaalliance:
+    build:
+      context: .
+      dockerfile: Dockerfile.yogaalliance
+    image: ghcr.mcpke.dev/yogaalliance-crawler:${YA_TAG:-v1}
+    pull_policy: never
+    environment:
+      POSTGRES_DSN: ${POSTGRES_DSN}
+      TZ: Asia/Jakarta
+    command: ["-mode", "teacher", "-insert", "-concurrency", "8"]
+    restart: "no"


### PR DESCRIPTION
Adds `cmd/yogaalliance` — a guest-API crawler for the Yoga Alliance RYT/RYS directory, plus DB-insert mode and a dedicated container.

## What
- **100% in-niche** yoga teacher/school contacts (no spa/massage), many with **published emails** (gmail/yahoo dominant) + city + country.
- **Uses existing tables** (no migration): `emails` + `business_listings` + `business_emails`, tagged `source='yogaalliance'`.
- Each teacher **assigned to their school** via `teachingHistoryList`.
- Solves the SERP email-dork data-quality gap (~10% address / ~0% niche) with a curated source.

## API (reverse-engineered, guest, no auth)
`POST /webruntime/api/apex/execute` → `getTeacherDetails(teacherId)`; IDs from `sitemap.xml` (contact-*).

## Rollback
Every row tagged (`business_emails.source='yogaalliance'`, `category='yogaalliance'`, `*.ryt.yogaalliance.org` domain) → batch is trivially identifiable + deletable.

## Validation
Full crawl in progress on Mac: 72K+ teachers fetched, ~99% with email. `go build`/`go vet` OK.