### PR TITLE
fix(db): skip no-op ADD COLUMN migrations to stop reenrich boot lock-stall

### DIFF
--- a/Dockerfile.yogaalliance
+++ b/Dockerfile.yogaalliance
@@ -1,0 +1,24 @@
+# Dedicated image for the Yoga Alliance directory crawler (cmd/yogaalliance).
+# Pure-Go HTTP crawler — NO Camoufox/playwright, so it builds in seconds and
+# the image is tiny (~20MB). Runs on the server where it has Postgres access
+# and inserts in-niche yoga teacher/school records straight into the existing
+# tables (business_listings + emails + business_emails, source='yogaalliance').
+#
+# Build:  docker build -f Dockerfile.yogaalliance -t ghcr.mcpke.dev/yogaalliance-crawler:v1 .
+# Run:    docker run --rm -e POSTGRES_DSN=... ghcr.mcpke.dev/yogaalliance-crawler:v1 \
+#           -mode teacher -insert -concurrency 8
+
+FROM golang:1.25-alpine AS build
+WORKDIR /src
+COPY go.mod go.sum ./
+RUN go mod download
+COPY . .
+RUN CGO_ENABLED=0 go build -trimpath -ldflags="-w -s" -o /yoga ./cmd/yogaalliance
+
+FROM alpine:3.20
+RUN apk add --no-cache ca-certificates tzdata && adduser -D -u 10001 yoga
+USER yoga
+COPY --from=build /yoga /usr/local/bin/yoga
+ENTRYPOINT ["yoga"]
+# Default: crawl all teachers and insert into the DB. Override args at runtime.
+CMD ["-mode", "teacher", "-insert", "-concurrency", "8"]

--- a/cmd/backfill-address-fields/main.go
+++ b/cmd/backfill-address-fields/main.go
@@ -1,0 +1,297 @@
+//go:build playwright
+
+// Command backfill-address-fields sweeps business_listings rows whose country
+// and/or city columns are NULL but whose address column contains parseable
+// data, and fills them via scraper.ParseAddressFallback. Pure offline — no
+// network calls.
+//
+// Use case: sprint 2 added a per-row offline pre-pass inside the reenrich
+// worker, which fixes rows organically as workers claim them. But rows
+// already above the reenrich score threshold (sufficiently complete that
+// they never get claimed) stay stuck with NULL geo. This binary sweeps
+// them in one pass.
+//
+// Usage:
+//
+//	./backfill-address-fields                                 # dry-run, full table
+//	./backfill-address-fields -dry-run=false                  # live, full table
+//	./backfill-address-fields -batch 500 -max 20 -sleep-ms 200
+//	./backfill-address-fields -config path/to/config.yaml -dry-run=false
+//
+// Safe to run alongside live reenrich workers — UPDATE uses COALESCE so it
+// will never overwrite a non-NULL existing column.
+package main
+
+import (
+	"context"
+	"database/sql"
+	"flag"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/sadewadee/serp-scraper/internal/config"
+	"github.com/sadewadee/serp-scraper/internal/db"
+	"github.com/sadewadee/serp-scraper/internal/scraper"
+)
+
+type backfillRow struct {
+	ID      int64
+	Address string
+	Country sql.NullString
+	City    sql.NullString
+}
+
+type backfillUpdate struct {
+	ID      int64
+	Country sql.NullString
+	City    sql.NullString
+}
+
+type backfiller struct {
+	db     *sql.DB
+	dryRun bool
+
+	// running totals
+	totalScanned int64
+	totalUpdated int64
+	totalCountry int64
+	totalCity    int64
+}
+
+func main() {
+	dryRun := flag.Bool("dry-run", true, "preview without writing (default true — explicit -dry-run=false to mutate)")
+	batchSize := flag.Int("batch", 1000, "rows per scan + update batch")
+	maxBatches := flag.Int("max", 0, "max batches (0 = unlimited)")
+	sleepMs := flag.Int("sleep-ms", 100, "sleep between batches (ms)")
+	configPath := flag.String("config", "config.yaml", "config file path")
+	flag.Parse()
+
+	logger := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
+	slog.SetDefault(logger)
+
+	cfg, err := config.Load(*configPath)
+	if err != nil {
+		slog.Error("backfill: config load failed", "error", err, "path", *configPath)
+		os.Exit(1)
+	}
+
+	database, err := db.Open(cfg)
+	if err != nil {
+		slog.Error("backfill: db open failed", "error", err)
+		os.Exit(1)
+	}
+	defer database.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	sigCh := make(chan os.Signal, 1)
+	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
+	go func() {
+		sig := <-sigCh
+		slog.Info("backfill: signal received, finishing current batch then stopping", "signal", sig)
+		cancel()
+	}()
+
+	b := &backfiller{db: database, dryRun: *dryRun}
+	mode := "DRY-RUN"
+	if !*dryRun {
+		mode = "LIVE"
+	}
+	slog.Info("backfill: starting",
+		"mode", mode,
+		"batch_size", *batchSize,
+		"max_batches", *maxBatches,
+		"sleep_ms", *sleepMs)
+
+	b.run(ctx, *batchSize, *maxBatches, time.Duration(*sleepMs)*time.Millisecond)
+}
+
+func (b *backfiller) run(ctx context.Context, batchSize, maxBatches int, sleep time.Duration) {
+	var lastID int64
+
+	for batch := 0; ; batch++ {
+		if ctx.Err() != nil {
+			slog.Info("backfill: cancelled by signal")
+			break
+		}
+		if maxBatches > 0 && batch >= maxBatches {
+			slog.Info("backfill: max-batches limit reached", "batch", batch)
+			break
+		}
+
+		rows, err := b.fetchBatch(ctx, lastID, batchSize)
+		if err != nil {
+			slog.Error("backfill: fetch batch failed", "batch", batch, "error", err)
+			return
+		}
+		if len(rows) == 0 {
+			slog.Info("backfill: no more candidate rows", "scanned_total", b.totalScanned)
+			break
+		}
+
+		var updates []backfillUpdate
+		for _, r := range rows {
+			b.totalScanned++
+			lastID = r.ID
+
+			u := computeUpdate(r)
+			if u.Country.Valid || u.City.Valid {
+				updates = append(updates, u)
+				if u.Country.Valid {
+					b.totalCountry++
+				}
+				if u.City.Valid {
+					b.totalCity++
+				}
+			}
+		}
+
+		if b.dryRun {
+			slog.Info("backfill: dry-run batch",
+				"batch", batch,
+				"scanned", len(rows),
+				"would_update", len(updates),
+				"running_country", b.totalCountry,
+				"running_city", b.totalCity)
+		} else {
+			n, err := b.bulkUpdate(ctx, updates)
+			if err != nil {
+				slog.Warn("backfill: bulk update failed — skipping batch", "batch", batch, "error", err)
+			} else {
+				b.totalUpdated += n
+				slog.Info("backfill: live batch applied",
+					"batch", batch,
+					"scanned", len(rows),
+					"updated", n,
+					"running_total", b.totalUpdated)
+			}
+		}
+
+		if sleep > 0 {
+			select {
+			case <-ctx.Done():
+			case <-time.After(sleep):
+			}
+		}
+	}
+
+	mode := "dry-run"
+	if !b.dryRun {
+		mode = "live"
+	}
+	slog.Info("backfill: complete",
+		"mode", mode,
+		"scanned", b.totalScanned,
+		"updated", b.totalUpdated,
+		"country_filled", b.totalCountry,
+		"city_filled", b.totalCity)
+}
+
+// fetchBatch returns the next page of candidate rows in ID order. ID-based
+// pagination (lastID > prev) avoids the seek-position drift that OFFSET
+// suffers on a growing table.
+func (b *backfiller) fetchBatch(ctx context.Context, lastID int64, limit int) ([]backfillRow, error) {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	const q = `
+		SELECT id, address, country, city
+		FROM business_listings
+		WHERE id > $1
+		  AND address IS NOT NULL AND address != ''
+		  AND (country IS NULL OR country = '' OR city IS NULL OR city = '')
+		ORDER BY id
+		LIMIT $2
+	`
+	dbRows, err := b.db.QueryContext(queryCtx, q, lastID, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer dbRows.Close()
+
+	var out []backfillRow
+	for dbRows.Next() {
+		var r backfillRow
+		if err := dbRows.Scan(&r.ID, &r.Address, &r.Country, &r.City); err != nil {
+			return nil, err
+		}
+		out = append(out, r)
+	}
+	return out, dbRows.Err()
+}
+
+// bulkUpdate applies up to len(updates) rows in a single VALUES-based UPDATE
+// statement. COALESCE preserves any non-NULL existing column value so the
+// migration is idempotent and concurrent-write safe with the reenrich worker.
+// 30s statement_timeout caps lock duration on the 478K-row table.
+func (b *backfiller) bulkUpdate(ctx context.Context, updates []backfillUpdate) (int64, error) {
+	if len(updates) == 0 {
+		return 0, nil
+	}
+
+	queryCtx, cancel := context.WithTimeout(ctx, 60*time.Second)
+	defer cancel()
+
+	tx, err := b.db.BeginTx(queryCtx, nil)
+	if err != nil {
+		return 0, err
+	}
+	defer tx.Rollback() //nolint:errcheck
+
+	if _, err := tx.ExecContext(queryCtx, `SET LOCAL statement_timeout = '30000'`); err != nil {
+		return 0, err
+	}
+
+	// Build VALUES list. Use 3 params per row: id, country, city.
+	var sb strings.Builder
+	sb.WriteString(`
+		UPDATE business_listings bl
+		SET country = COALESCE(bl.country, v.new_country),
+		    city    = COALESCE(bl.city,    v.new_city),
+		    updated_at = NOW()
+		FROM (VALUES `)
+
+	args := make([]any, 0, len(updates)*3)
+	for i, u := range updates {
+		if i > 0 {
+			sb.WriteString(", ")
+		}
+		base := i*3 + 1
+		fmt.Fprintf(&sb, "($%d::bigint, $%d::text, $%d::text)", base, base+1, base+2)
+		args = append(args, u.ID, u.Country, u.City)
+	}
+	sb.WriteString(`) AS v(id, new_country, new_city)
+		WHERE bl.id = v.id
+		  AND (bl.country IS NULL OR bl.country = '' OR bl.city IS NULL OR bl.city = '')
+	`)
+
+	res, err := tx.ExecContext(queryCtx, sb.String(), args...)
+	if err != nil {
+		return 0, err
+	}
+	n, _ := res.RowsAffected()
+	if err := tx.Commit(); err != nil {
+		return 0, err
+	}
+	return n, nil
+}
+
+// computeUpdate is the pure decision: given a row, what should be written?
+// Extracted as a free function so it can be unit-tested without a DB.
+func computeUpdate(r backfillRow) backfillUpdate {
+	parsedCountry, parsedCity := scraper.ParseAddressFallback(r.Address)
+	u := backfillUpdate{ID: r.ID}
+	if (!r.Country.Valid || r.Country.String == "") && parsedCountry != "" {
+		u.Country = sql.NullString{String: parsedCountry, Valid: true}
+	}
+	if (!r.City.Valid || r.City.String == "") && parsedCity != "" {
+		u.City = sql.NullString{String: parsedCity, Valid: true}
+	}
+	return u
+}

--- a/cmd/backfill-address-fields/main_test.go
+++ b/cmd/backfill-address-fields/main_test.go
@@ -1,0 +1,125 @@
+//go:build playwright
+
+package main
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestComputeUpdate covers the pure decision logic — what country/city to
+// write back for a given row. SQL ops (fetchBatch, bulkUpdate) are exercised
+// by manual dry-run against staging or production read-only.
+func TestComputeUpdate(t *testing.T) {
+	cases := []struct {
+		name         string
+		row          backfillRow
+		wantCountry  sql.NullString
+		wantCity     sql.NullString
+		wantWriteAny bool // helper assertion: any non-empty result
+	}{
+		{
+			name: "both fields fillable from address",
+			row: backfillRow{
+				ID:      1,
+				Address: "521 Oak Grove Rd, Flat Rock, NC, United States",
+				Country: sql.NullString{Valid: false},
+				City:    sql.NullString{Valid: false},
+			},
+			wantCountry:  sql.NullString{String: "US", Valid: true},
+			wantCity:     sql.NullString{String: "Flat Rock", Valid: true},
+			wantWriteAny: true,
+		},
+		{
+			name: "country already set, only city fillable",
+			row: backfillRow{
+				ID:      2,
+				Address: "521 Oak Grove Rd, Flat Rock, NC, US",
+				Country: sql.NullString{String: "US", Valid: true},
+				City:    sql.NullString{Valid: false},
+			},
+			wantCountry:  sql.NullString{Valid: false},
+			wantCity:     sql.NullString{String: "Flat Rock", Valid: true},
+			wantWriteAny: true,
+		},
+		{
+			name: "both already set — no write needed",
+			row: backfillRow{
+				ID:      3,
+				Address: "521 Oak Grove Rd, Flat Rock, NC, US",
+				Country: sql.NullString{String: "US", Valid: true},
+				City:    sql.NullString{String: "Flat Rock", Valid: true},
+			},
+			wantCountry:  sql.NullString{Valid: false},
+			wantCity:     sql.NullString{Valid: false},
+			wantWriteAny: false,
+		},
+		{
+			name: "address has no extractable signal",
+			row: backfillRow{
+				ID:      4,
+				Address: "Compagnonsplein 1",
+				Country: sql.NullString{Valid: false},
+				City:    sql.NullString{Valid: false},
+			},
+			wantCountry:  sql.NullString{Valid: false},
+			wantCity:     sql.NullString{Valid: false},
+			wantWriteAny: false,
+		},
+		{
+			name: "address resolves country only (non-US format)",
+			row: backfillRow{
+				ID:      5,
+				Address: "Frankfurt, Germany",
+				Country: sql.NullString{Valid: false},
+				City:    sql.NullString{Valid: false},
+			},
+			wantCountry:  sql.NullString{String: "DE", Valid: true},
+			wantCity:     sql.NullString{Valid: false},
+			wantWriteAny: true,
+		},
+		{
+			name: "country is sql.NullString with empty Valid string — treated as missing",
+			row: backfillRow{
+				ID:      6,
+				Address: "1 Main St, Boston, MA, USA",
+				Country: sql.NullString{String: "", Valid: true},
+				City:    sql.NullString{String: "", Valid: true},
+			},
+			wantCountry:  sql.NullString{String: "US", Valid: true},
+			wantCity:     sql.NullString{String: "Boston", Valid: true},
+			wantWriteAny: true,
+		},
+		{
+			name: "ID preserved",
+			row: backfillRow{
+				ID:      99999,
+				Address: "Frankfurt, Germany",
+			},
+			wantCountry:  sql.NullString{String: "DE", Valid: true},
+			wantCity:     sql.NullString{Valid: false},
+			wantWriteAny: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := computeUpdate(tc.row)
+
+			if got.ID != tc.row.ID {
+				t.Errorf("ID = %d; want %d (must preserve)", got.ID, tc.row.ID)
+			}
+			if got.Country != tc.wantCountry {
+				t.Errorf("Country = %+v; want %+v", got.Country, tc.wantCountry)
+			}
+			if got.City != tc.wantCity {
+				t.Errorf("City = %+v; want %+v", got.City, tc.wantCity)
+			}
+
+			gotAnyWrite := got.Country.Valid || got.City.Valid
+			if gotAnyWrite != tc.wantWriteAny {
+				t.Errorf("any-write = %v; want %v", gotAnyWrite, tc.wantWriteAny)
+			}
+		})
+	}
+}

--- a/cmd/yogaalliance/main.go
+++ b/cmd/yogaalliance/main.go
@@ -381,10 +381,10 @@ func upsertTeacher(db *sql.DB, t *teacher) error {
 	var bizID int64
 	err := db.QueryRow(`
 		INSERT INTO business_listings
-		  (domain, business_name, contact_name, address, city, country, description,
+		  (domain, url, business_name, contact_name, address, city, country, description,
 		   social_links, niche_category, off_niche, category, website, created_at, updated_at)
-		VALUES ($1,$2,$3,NULLIF($4,''),NULLIF($5,''),NULLIF($6,''),NULLIF($7,''),
-		   $8::jsonb,'yoga',false,'yogaalliance',$9,NOW(),NOW())
+		VALUES ($1,$2,$3,$4,NULLIF($5,''),NULLIF($6,''),NULLIF($7,''),NULLIF($8,''),
+		   $9::jsonb,'yoga',false,'yogaalliance',$10,NOW(),NOW())
 		ON CONFLICT (domain) DO UPDATE SET
 		  business_name  = COALESCE(NULLIF(EXCLUDED.business_name,''), business_listings.business_name),
 		  contact_name   = COALESCE(NULLIF(EXCLUDED.contact_name,''),  business_listings.contact_name),
@@ -394,7 +394,7 @@ func upsertTeacher(db *sql.DB, t *teacher) error {
 		  niche_category = 'yoga', off_niche = false, category = 'yogaalliance',
 		  updated_at     = NOW()
 		RETURNING id`,
-		domain, bizName, t.name, addr, t.city, t.country, t.biography, string(socialJSON), profileURL,
+		domain, profileURL, bizName, t.name, addr, t.city, t.country, t.biography, string(socialJSON), profileURL,
 	).Scan(&bizID)
 	if err != nil {
 		return fmt.Errorf("business_listings upsert: %w", err)

--- a/cmd/yogaalliance/main.go
+++ b/cmd/yogaalliance/main.go
@@ -1,0 +1,349 @@
+// Command yogaalliance crawls the public Yoga Alliance directory (schools +
+// teachers) via its guest Salesforce LWR Apex API and writes structured,
+// 100%-in-niche records to CSV.
+//
+// Why this exists: the SERP email-dork pipeline yields data-poor rows (only
+// ~10% have an address, niche match ~0%). Yoga Alliance is a curated directory
+// of Registered Yoga Schools (RYS) and Teachers (RYT) — every record is real,
+// in-niche (yoga/wellness/fitness), and TEACHER records expose a published
+// email + city + country directly. No spa/massage contamination.
+//
+// API (reverse-engineered, guest-accessible, no auth/CSRF — just cookies):
+//
+//	POST https://app.yogaalliance.org/webruntime/api/apex/execute?language=en-US&asGuest=true&htmlEncode=false
+//	  body: {"namespace":"","classname":"<HASH>","method":"<M>","isContinuation":false,"params":{...},"cacheable":false}
+//	  school : classname @udd/01pTR000001kCED  method getSchoolDetails  params {"schoolId": "<id>"}
+//	  teacher: classname @udd/01pTR000001kCE1  method getTeacherDetails params {"teacherId":"<id>"}
+//
+// The classname hashes are Salesforce build artifacts and CAN change on a
+// redeploy; if every call starts returning 400, re-capture them from a profile
+// page's network tab and update the constants below.
+//
+// IDs come from the sitemap index at https://app.yogaalliance.org/sitemap.xml
+// (account-*.xml = schools, contact-*.xml = teachers).
+//
+// Build & run (standalone — NOT covered by the playwright tag):
+//
+//	go build -o yoga ./cmd/yogaalliance
+//	./yoga -mode teacher -out teachers.csv -concurrency 12
+//	./yoga -mode school  -out schools.csv  -concurrency 12 -limit 500   # test slice
+package main
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"net/http/cookiejar"
+	"os"
+	"regexp"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+const (
+	apexURL       = "https://app.yogaalliance.org/webruntime/api/apex/execute?language=en-US&asGuest=true&htmlEncode=false"
+	sitemapIndex  = "https://app.yogaalliance.org/sitemap.xml"
+	bootstrapURL  = "https://app.yogaalliance.org/teacherpublicprofile?id=bootstrap"
+	userAgent     = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+	classSchool   = "@udd/01pTR000001kCED"
+	classTeacher  = "@udd/01pTR000001kCE1"
+	methodSchool  = "getSchoolDetails"
+	methodTeacher = "getTeacherDetails"
+)
+
+var (
+	locRe    = regexp.MustCompile(`<loc>([^<]+)</loc>`)
+	idRe     = regexp.MustCompile(`/(?:school|teacher)publicprofile/([A-Za-z0-9]{15,18})/`)
+	tagsRe   = regexp.MustCompile(`<[^>]+>`)
+	spacesRe = regexp.MustCompile(`\s+`)
+)
+
+type apexReq struct {
+	Namespace      string         `json:"namespace"`
+	Classname      string         `json:"classname"`
+	Method         string         `json:"method"`
+	IsContinuation bool           `json:"isContinuation"`
+	Params         map[string]any `json:"params"`
+	Cacheable      bool           `json:"cacheable"`
+}
+
+// schoolResp / teacherResp capture only the fields we persist.
+type schoolResp struct {
+	ReturnValue struct {
+		Id             string `json:"Id"`
+		DirectoryName  string `json:"directoryName"`
+		Address        string `json:"address"`
+		Designation    string `json:"schoolDesignation"`
+		Facebook       string `json:"schoolFacebook"`
+		Instagram      string `json:"schoolInstagram"`
+		Languages      string `json:"languages"`
+		TypesOfYoga    string `json:"typesOfYogaTaught"`
+		Published      bool   `json:"isSchoolProfilePublished"`
+		TrainerDetails []struct {
+			TrainerId            string `json:"trainerId"`
+			TrainerDirectoryName string `json:"trainerDirectoryName"`
+		} `json:"trainerDetailsList"`
+	} `json:"returnValue"`
+}
+
+type teacherResp struct {
+	ReturnValue struct {
+		Id             string  `json:"Id"`
+		DirectoryName  string  `json:"directoryName"`
+		FirstName      string  `json:"firstName"`
+		LastName       string  `json:"lastName"`
+		Email          string  `json:"teacherEmail"`
+		EmailPublished bool    `json:"isEmailPublished"`
+		Address        string  `json:"address"`
+		MailingCity    string  `json:"mailingCity"`
+		MailingState   string  `json:"mailingState"`
+		MailingCountry string  `json:"mailingCountry"`
+		Instagram      string  `json:"teacherInstagram"`
+		Designation    string  `json:"teacherDesignation"`
+		Languages      string  `json:"languages"`
+		TypesOfYoga    string  `json:"typesOfYogaTaught"`
+		TeachingHours  float64 `json:"teachingHours"`
+		Published      bool    `json:"isProfilePublished"`
+	} `json:"returnValue"`
+}
+
+func main() {
+	mode := flag.String("mode", "teacher", "teacher | school")
+	out := flag.String("out", "", "output CSV path (default: <mode>s.csv)")
+	conc := flag.Int("concurrency", 10, "concurrent requests")
+	limit := flag.Int("limit", 0, "max records (0 = all)")
+	idsFile := flag.String("ids", "", "optional file of IDs (one per line); default = crawl sitemap")
+	flag.Parse()
+
+	if *mode != "teacher" && *mode != "school" {
+		log.Fatalf("mode must be teacher or school")
+	}
+	outPath := *out
+	if outPath == "" {
+		outPath = *mode + "s.csv"
+	}
+
+	client := newClient()
+	bootstrap(client)
+
+	var ids []string
+	if *idsFile != "" {
+		ids = readLines(*idsFile)
+	} else {
+		ids = crawlSitemapIDs(client, *mode)
+	}
+	if *limit > 0 && len(ids) > *limit {
+		ids = ids[:*limit]
+	}
+	log.Printf("yogaalliance: %s — %d IDs to fetch (concurrency=%d) → %s", *mode, len(ids), *conc, outPath)
+
+	f, err := os.Create(outPath)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer f.Close()
+	w := csv.NewWriter(f)
+	defer w.Flush()
+	var mu sync.Mutex // guards csv writer
+
+	if *mode == "teacher" {
+		w.Write([]string{"id", "name", "email", "email_published", "city", "state", "country", "address", "instagram", "designation", "languages", "yoga_types", "teaching_hours"})
+	} else {
+		w.Write([]string{"id", "name", "address", "facebook", "instagram", "designation", "languages", "yoga_types", "trainer_ids"})
+	}
+
+	var done, ok, withEmail int64
+	jobs := make(chan string, *conc*2)
+	var wg sync.WaitGroup
+	for i := 0; i < *conc; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for id := range jobs {
+				row, hasEmail := fetchOne(client, *mode, id)
+				n := atomic.AddInt64(&done, 1)
+				if row != nil {
+					atomic.AddInt64(&ok, 1)
+					if hasEmail {
+						atomic.AddInt64(&withEmail, 1)
+					}
+					mu.Lock()
+					w.Write(row)
+					if n%500 == 0 {
+						w.Flush()
+					}
+					mu.Unlock()
+				}
+				if n%1000 == 0 {
+					log.Printf("  progress: %d/%d done, %d ok, %d with-email", n, len(ids), atomic.LoadInt64(&ok), atomic.LoadInt64(&withEmail))
+				}
+			}
+		}()
+	}
+	for _, id := range ids {
+		jobs <- id
+	}
+	close(jobs)
+	wg.Wait()
+	w.Flush()
+	log.Printf("DONE: %d fetched, %d records written, %d with email → %s", done, ok, withEmail, outPath)
+}
+
+func newClient() *http.Client {
+	jar, _ := cookiejar.New(nil)
+	return &http.Client{Jar: jar, Timeout: 30 * time.Second}
+}
+
+// bootstrap seeds guest cookies (the apex API rejects requests with no session
+// cookies). A single GET to any profile page is enough.
+func bootstrap(c *http.Client) {
+	req, _ := http.NewRequest("GET", bootstrapURL, nil)
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := c.Do(req)
+	if err != nil {
+		log.Fatalf("bootstrap failed: %v", err)
+	}
+	io.Copy(io.Discard, resp.Body)
+	resp.Body.Close()
+}
+
+func crawlSitemapIDs(c *http.Client, mode string) []string {
+	want := "contact" // teachers
+	if mode == "school" {
+		want = "account"
+	}
+	idxBody := httpGet(c, sitemapIndex)
+	var subs []string
+	for _, m := range locRe.FindAllStringSubmatch(string(idxBody), -1) {
+		if strings.Contains(m[1], "sitemap-"+want) && !strings.Contains(m[1], "weekly") {
+			subs = append(subs, m[1])
+		}
+	}
+	seen := map[string]bool{}
+	var ids []string
+	for _, sm := range subs {
+		body := httpGet(c, sm)
+		for _, m := range idRe.FindAllStringSubmatch(string(body), -1) {
+			if !seen[m[1]] {
+				seen[m[1]] = true
+				ids = append(ids, m[1])
+			}
+		}
+		log.Printf("  sitemap %s → %d unique IDs so far", sm[strings.LastIndex(sm, "/")+1:], len(ids))
+	}
+	return ids
+}
+
+func fetchOne(c *http.Client, mode, id string) ([]string, bool) {
+	var class, method, pkey string
+	if mode == "school" {
+		class, method, pkey = classSchool, methodSchool, "schoolId"
+	} else {
+		class, method, pkey = classTeacher, methodTeacher, "teacherId"
+	}
+	reqBody, _ := json.Marshal(apexReq{
+		Classname: class, Method: method, Params: map[string]any{pkey: id},
+	})
+
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		req, _ := http.NewRequest("POST", apexURL, bytes.NewReader(reqBody))
+		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		resp, err := c.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			lastErr = fmt.Errorf("http %d", resp.StatusCode)
+			time.Sleep(time.Duration(attempt+1) * 400 * time.Millisecond)
+			continue
+		}
+		if mode == "school" {
+			return parseSchool(body)
+		}
+		return parseTeacher(body)
+	}
+	_ = lastErr
+	return nil, false
+}
+
+func parseSchool(body []byte) ([]string, bool) {
+	var r schoolResp
+	if json.Unmarshal(body, &r) != nil || r.ReturnValue.Id == "" {
+		return nil, false
+	}
+	v := r.ReturnValue
+	var tids []string
+	for _, t := range v.TrainerDetails {
+		if t.TrainerId != "" {
+			tids = append(tids, t.TrainerId)
+		}
+	}
+	return []string{
+		v.Id, clean(v.DirectoryName), clean(v.Address), v.Facebook, v.Instagram,
+		clean(v.Designation), clean(v.Languages), clean(v.TypesOfYoga), strings.Join(tids, ";"),
+	}, false
+}
+
+func parseTeacher(body []byte) ([]string, bool) {
+	var r teacherResp
+	if json.Unmarshal(body, &r) != nil || r.ReturnValue.Id == "" {
+		return nil, false
+	}
+	v := r.ReturnValue
+	name := clean(v.DirectoryName)
+	if name == "" {
+		name = clean(strings.TrimSpace(v.FirstName + " " + v.LastName))
+	}
+	return []string{
+		v.Id, name, strings.TrimSpace(v.Email), strconv.FormatBool(v.EmailPublished),
+		clean(v.MailingCity), clean(v.MailingState), clean(v.MailingCountry), clean(v.Address),
+		v.Instagram, clean(v.Designation), clean(v.Languages), clean(v.TypesOfYoga),
+		strconv.FormatFloat(v.TeachingHours, 'f', -1, 64),
+	}, strings.TrimSpace(v.Email) != ""
+}
+
+func clean(s string) string {
+	s = tagsRe.ReplaceAllString(s, " ")
+	s = strings.ReplaceAll(s, " ", " ")
+	return strings.TrimSpace(spacesRe.ReplaceAllString(s, " "))
+}
+
+func httpGet(c *http.Client, url string) []byte {
+	req, _ := http.NewRequest("GET", url, nil)
+	req.Header.Set("User-Agent", userAgent)
+	resp, err := c.Do(req)
+	if err != nil {
+		log.Fatalf("GET %s: %v", url, err)
+	}
+	defer resp.Body.Close()
+	b, _ := io.ReadAll(resp.Body)
+	return b
+}
+
+func readLines(path string) []string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		log.Fatal(err)
+	}
+	var out []string
+	for _, ln := range strings.Split(string(b), "\n") {
+		if s := strings.TrimSpace(ln); s != "" {
+			out = append(out, s)
+		}
+	}
+	return out
+}

--- a/cmd/yogaalliance/main.go
+++ b/cmd/yogaalliance/main.go
@@ -1,36 +1,44 @@
-// Command yogaalliance crawls the public Yoga Alliance directory (schools +
-// teachers) via its guest Salesforce LWR Apex API and writes structured,
-// 100%-in-niche records to CSV.
+// Command yogaalliance crawls the public Yoga Alliance directory (teachers +
+// schools) via its guest Salesforce LWR Apex API and writes structured,
+// 100%-in-niche records to CSV and/or directly into the existing database.
 //
-// Why this exists: the SERP email-dork pipeline yields data-poor rows (only
-// ~10% have an address, niche match ~0%). Yoga Alliance is a curated directory
-// of Registered Yoga Schools (RYS) and Teachers (RYT) — every record is real,
-// in-niche (yoga/wellness/fitness), and TEACHER records expose a published
-// email + city + country directly. No spa/massage contamination.
+// Why: the SERP email-dork pipeline yields data-poor rows (~10% address, ~0%
+// niche match). Yoga Alliance is a curated directory of Registered Yoga
+// Teachers (RYT) and Schools (RYS) — every record is real and in-niche
+// (yoga/wellness/fitness; no spa/massage). TEACHER records expose a published
+// email + city + country + their school directly.
 //
-// API (reverse-engineered, guest-accessible, no auth/CSRF — just cookies):
+// API (guest, no auth/CSRF — just cookies):
 //
 //	POST https://app.yogaalliance.org/webruntime/api/apex/execute?language=en-US&asGuest=true&htmlEncode=false
-//	  body: {"namespace":"","classname":"<HASH>","method":"<M>","isContinuation":false,"params":{...},"cacheable":false}
-//	  school : classname @udd/01pTR000001kCED  method getSchoolDetails  params {"schoolId": "<id>"}
 //	  teacher: classname @udd/01pTR000001kCE1  method getTeacherDetails params {"teacherId":"<id>"}
+//	  school : classname @udd/01pTR000001kCED  method getSchoolDetails  params {"schoolId":"<id>"}
 //
-// The classname hashes are Salesforce build artifacts and CAN change on a
-// redeploy; if every call starts returning 400, re-capture them from a profile
-// page's network tab and update the constants below.
+// Teacher IDs come from app.yogaalliance.org/sitemap.xml (contact-*.xml). The
+// account-*.xml "schools" are mostly individual household accounts that
+// getSchoolDetails rejects, so the default crawl is teachers — each teacher
+// record carries its school via teachingHistoryList ("assign to school").
 //
-// IDs come from the sitemap index at https://app.yogaalliance.org/sitemap.xml
-// (account-*.xml = schools, contact-*.xml = teachers).
+// DB mapping (uses EXISTING tables — no migration):
+//   - emails              ← teacher email (UNIQUE email)
+//   - business_listings   ← one row per teacher; business_name = school (if the
+//     teacher has one) else teacher name; contact_name =
+//     teacher; niche_category='yoga'; off_niche=false;
+//     category='yogaalliance'; synthetic unique domain
+//     "<id>.ryt.yogaalliance.org"
+//   - business_emails     ← link, source='yogaalliance'  ← the source tag
 //
-// Build & run (standalone — NOT covered by the playwright tag):
+// Build & run:
 //
 //	go build -o yoga ./cmd/yogaalliance
-//	./yoga -mode teacher -out teachers.csv -concurrency 12
-//	./yoga -mode school  -out schools.csv  -concurrency 12 -limit 500   # test slice
+//	./yoga -mode teacher -out teachers.csv -concurrency 12               # CSV only
+//	./yoga -mode teacher -insert -concurrency 8                          # → DB (POSTGRES_DSN)
+//	./yoga -mode teacher -insert -dsn "postgres://..." -limit 200        # test slice
 package main
 
 import (
 	"bytes"
+	"database/sql"
 	"encoding/csv"
 	"encoding/json"
 	"flag"
@@ -46,6 +54,8 @@ import (
 	"sync"
 	"sync/atomic"
 	"time"
+
+	_ "github.com/lib/pq"
 )
 
 const (
@@ -57,6 +67,7 @@ const (
 	classTeacher  = "@udd/01pTR000001kCE1"
 	methodSchool  = "getSchoolDetails"
 	methodTeacher = "getTeacherDetails"
+	srcTag        = "yogaalliance"
 )
 
 var (
@@ -64,6 +75,12 @@ var (
 	idRe     = regexp.MustCompile(`/(?:school|teacher)publicprofile/([A-Za-z0-9]{15,18})/`)
 	tagsRe   = regexp.MustCompile(`<[^>]+>`)
 	spacesRe = regexp.MustCompile(`\s+`)
+	freeMail = map[string]bool{
+		"gmail.com": true, "yahoo.com": true, "hotmail.com": true, "outlook.com": true,
+		"aol.com": true, "icloud.com": true, "me.com": true, "mac.com": true,
+		"live.com": true, "msn.com": true, "comcast.net": true, "gmx.com": true,
+		"protonmail.com": true, "ymail.com": true, "yahoo.co.uk": true,
+	}
 )
 
 type apexReq struct {
@@ -75,60 +92,81 @@ type apexReq struct {
 	Cacheable      bool           `json:"cacheable"`
 }
 
-// schoolResp / teacherResp capture only the fields we persist.
-type schoolResp struct {
-	ReturnValue struct {
-		Id             string `json:"Id"`
-		DirectoryName  string `json:"directoryName"`
-		Address        string `json:"address"`
-		Designation    string `json:"schoolDesignation"`
-		Facebook       string `json:"schoolFacebook"`
-		Instagram      string `json:"schoolInstagram"`
-		Languages      string `json:"languages"`
-		TypesOfYoga    string `json:"typesOfYogaTaught"`
-		Published      bool   `json:"isSchoolProfilePublished"`
-		TrainerDetails []struct {
-			TrainerId            string `json:"trainerId"`
-			TrainerDirectoryName string `json:"trainerDirectoryName"`
-		} `json:"trainerDetailsList"`
-	} `json:"returnValue"`
+type teachingLocation struct {
+	LocationName  string `json:"locationName"`
+	GoogleAddress string `json:"googleAddress"`
+	StatusLabel   string `json:"statusLabel"`
 }
 
 type teacherResp struct {
 	ReturnValue struct {
-		Id             string  `json:"Id"`
-		DirectoryName  string  `json:"directoryName"`
-		FirstName      string  `json:"firstName"`
-		LastName       string  `json:"lastName"`
-		Email          string  `json:"teacherEmail"`
-		EmailPublished bool    `json:"isEmailPublished"`
-		Address        string  `json:"address"`
-		MailingCity    string  `json:"mailingCity"`
-		MailingState   string  `json:"mailingState"`
-		MailingCountry string  `json:"mailingCountry"`
-		Instagram      string  `json:"teacherInstagram"`
-		Designation    string  `json:"teacherDesignation"`
-		Languages      string  `json:"languages"`
-		TypesOfYoga    string  `json:"typesOfYogaTaught"`
-		TeachingHours  float64 `json:"teachingHours"`
-		Published      bool    `json:"isProfilePublished"`
+		Id              string             `json:"Id"`
+		DirectoryName   string             `json:"directoryName"`
+		FirstName       string             `json:"firstName"`
+		LastName        string             `json:"lastName"`
+		Email           string             `json:"teacherEmail"`
+		EmailPublished  bool               `json:"isEmailPublished"`
+		Address         string             `json:"address"`
+		MailingCity     string             `json:"mailingCity"`
+		MailingState    string             `json:"mailingState"`
+		MailingCountry  string             `json:"mailingCountry"`
+		Instagram       string             `json:"teacherInstagram"`
+		Designation     string             `json:"teacherDesignation"`
+		Languages       string             `json:"languages"`
+		TypesOfYoga     string             `json:"typesOfYogaTaught"`
+		Biography       string             `json:"biography"`
+		TeachingHours   float64            `json:"teachingHours"`
+		OfferOnline     bool               `json:"offerOnlineClasses"`
+		IsYACEP         bool               `json:"isYACEP"`
+		MembershipBegin string             `json:"originalMembershipBeginDate"`
+		Published       bool               `json:"isProfilePublished"`
+		TeachingHistory []teachingLocation `json:"teachingHistoryList"`
 	} `json:"returnValue"`
+}
+
+type teacher struct {
+	id, name, email, city, state, country, address string
+	instagram, designation, languages, yogaTypes   string
+	biography, schoolName, schoolAddr              string
+	emailPublished, yacep, online                  bool
+	teachingHours                                  float64
 }
 
 func main() {
 	mode := flag.String("mode", "teacher", "teacher | school")
-	out := flag.String("out", "", "output CSV path (default: <mode>s.csv)")
+	out := flag.String("out", "", "output CSV path ('' = none when -insert, else <mode>s.csv)")
 	conc := flag.Int("concurrency", 10, "concurrent requests")
 	limit := flag.Int("limit", 0, "max records (0 = all)")
 	idsFile := flag.String("ids", "", "optional file of IDs (one per line); default = crawl sitemap")
+	doInsert := flag.Bool("insert", false, "upsert into business_listings/emails/business_emails")
+	dsn := flag.String("dsn", os.Getenv("POSTGRES_DSN"), "Postgres DSN (default $POSTGRES_DSN)")
 	flag.Parse()
 
-	if *mode != "teacher" && *mode != "school" {
-		log.Fatalf("mode must be teacher or school")
+	if *mode != "teacher" {
+		log.Fatalf("only -mode teacher is supported (account sitemap is mostly non-school households; schools come via teacher teachingHistory)")
 	}
+
+	var db *sql.DB
+	if *doInsert {
+		if *dsn == "" {
+			log.Fatal("-insert requires -dsn or $POSTGRES_DSN")
+		}
+		var err error
+		db, err = sql.Open("postgres", *dsn)
+		if err != nil {
+			log.Fatalf("db open: %v", err)
+		}
+		db.SetMaxOpenConns(*conc + 2)
+		if err := db.Ping(); err != nil {
+			log.Fatalf("db ping: %v", err)
+		}
+		defer db.Close()
+		log.Printf("yogaalliance: INSERT mode → DB (source=%s)", srcTag)
+	}
+
 	outPath := *out
-	if outPath == "" {
-		outPath = *mode + "s.csv"
+	if outPath == "" && !*doInsert {
+		outPath = "teachers.csv"
 	}
 
 	client := newClient()
@@ -138,29 +176,27 @@ func main() {
 	if *idsFile != "" {
 		ids = readLines(*idsFile)
 	} else {
-		ids = crawlSitemapIDs(client, *mode)
+		ids = crawlSitemapIDs(client)
 	}
 	if *limit > 0 && len(ids) > *limit {
 		ids = ids[:*limit]
 	}
-	log.Printf("yogaalliance: %s — %d IDs to fetch (concurrency=%d) → %s", *mode, len(ids), *conc, outPath)
+	log.Printf("yogaalliance: teacher — %d IDs (concurrency=%d, insert=%v, csv=%q)", len(ids), *conc, *doInsert, outPath)
 
-	f, err := os.Create(outPath)
-	if err != nil {
-		log.Fatal(err)
-	}
-	defer f.Close()
-	w := csv.NewWriter(f)
-	defer w.Flush()
-	var mu sync.Mutex // guards csv writer
-
-	if *mode == "teacher" {
-		w.Write([]string{"id", "name", "email", "email_published", "city", "state", "country", "address", "instagram", "designation", "languages", "yoga_types", "teaching_hours"})
-	} else {
-		w.Write([]string{"id", "name", "address", "facebook", "instagram", "designation", "languages", "yoga_types", "trainer_ids"})
+	var w *csv.Writer
+	var csvMu sync.Mutex
+	if outPath != "" {
+		f, err := os.Create(outPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		w = csv.NewWriter(f)
+		defer w.Flush()
+		w.Write([]string{"id", "name", "email", "email_published", "city", "state", "country", "address", "school_name", "school_address", "instagram", "designation", "languages", "yoga_types", "yacep", "teaching_hours"})
 	}
 
-	var done, ok, withEmail int64
+	var done, ok, withEmail, inserted int64
 	jobs := make(chan string, *conc*2)
 	var wg sync.WaitGroup
 	for i := 0; i < *conc; i++ {
@@ -168,22 +204,31 @@ func main() {
 		go func() {
 			defer wg.Done()
 			for id := range jobs {
-				row, hasEmail := fetchOne(client, *mode, id)
+				t := fetchTeacher(client, id)
 				n := atomic.AddInt64(&done, 1)
-				if row != nil {
+				if t != nil {
 					atomic.AddInt64(&ok, 1)
-					if hasEmail {
+					if t.email != "" {
 						atomic.AddInt64(&withEmail, 1)
 					}
-					mu.Lock()
-					w.Write(row)
-					if n%500 == 0 {
-						w.Flush()
+					if w != nil {
+						csvMu.Lock()
+						w.Write(t.row())
+						if n%500 == 0 {
+							w.Flush()
+						}
+						csvMu.Unlock()
 					}
-					mu.Unlock()
+					if db != nil {
+						if err := upsertTeacher(db, t); err != nil {
+							log.Printf("  upsert %s failed: %v", t.id, err)
+						} else {
+							atomic.AddInt64(&inserted, 1)
+						}
+					}
 				}
 				if n%1000 == 0 {
-					log.Printf("  progress: %d/%d done, %d ok, %d with-email", n, len(ids), atomic.LoadInt64(&ok), atomic.LoadInt64(&withEmail))
+					log.Printf("  progress: %d/%d done, %d ok, %d email, %d inserted", n, len(ids), atomic.LoadInt64(&ok), atomic.LoadInt64(&withEmail), atomic.LoadInt64(&inserted))
 				}
 			}
 		}()
@@ -193,8 +238,18 @@ func main() {
 	}
 	close(jobs)
 	wg.Wait()
-	w.Flush()
-	log.Printf("DONE: %d fetched, %d records written, %d with email → %s", done, ok, withEmail, outPath)
+	if w != nil {
+		w.Flush()
+	}
+	log.Printf("DONE: %d fetched, %d ok, %d with email, %d inserted", done, ok, withEmail, inserted)
+}
+
+func (t *teacher) row() []string {
+	return []string{
+		t.id, t.name, t.email, strconv.FormatBool(t.emailPublished), t.city, t.state, t.country, t.address,
+		t.schoolName, t.schoolAddr, t.instagram, t.designation, t.languages, t.yogaTypes,
+		strconv.FormatBool(t.yacep), strconv.FormatFloat(t.teachingHours, 'f', -1, 64),
+	}
 }
 
 func newClient() *http.Client {
@@ -202,8 +257,6 @@ func newClient() *http.Client {
 	return &http.Client{Jar: jar, Timeout: 30 * time.Second}
 }
 
-// bootstrap seeds guest cookies (the apex API rejects requests with no session
-// cookies). A single GET to any profile page is enough.
 func bootstrap(c *http.Client) {
 	req, _ := http.NewRequest("GET", bootstrapURL, nil)
 	req.Header.Set("User-Agent", userAgent)
@@ -215,15 +268,11 @@ func bootstrap(c *http.Client) {
 	resp.Body.Close()
 }
 
-func crawlSitemapIDs(c *http.Client, mode string) []string {
-	want := "contact" // teachers
-	if mode == "school" {
-		want = "account"
-	}
+func crawlSitemapIDs(c *http.Client) []string {
 	idxBody := httpGet(c, sitemapIndex)
 	var subs []string
 	for _, m := range locRe.FindAllStringSubmatch(string(idxBody), -1) {
-		if strings.Contains(m[1], "sitemap-"+want) && !strings.Contains(m[1], "weekly") {
+		if strings.Contains(m[1], "sitemap-contact") && !strings.Contains(m[1], "weekly") {
 			subs = append(subs, m[1])
 		}
 	}
@@ -237,88 +286,154 @@ func crawlSitemapIDs(c *http.Client, mode string) []string {
 				ids = append(ids, m[1])
 			}
 		}
-		log.Printf("  sitemap %s → %d unique IDs so far", sm[strings.LastIndex(sm, "/")+1:], len(ids))
+		log.Printf("  %s → %d unique IDs so far", sm[strings.LastIndex(sm, "/")+1:], len(ids))
 	}
 	return ids
 }
 
-func fetchOne(c *http.Client, mode, id string) ([]string, bool) {
-	var class, method, pkey string
-	if mode == "school" {
-		class, method, pkey = classSchool, methodSchool, "schoolId"
-	} else {
-		class, method, pkey = classTeacher, methodTeacher, "teacherId"
-	}
+func fetchTeacher(c *http.Client, id string) *teacher {
 	reqBody, _ := json.Marshal(apexReq{
-		Classname: class, Method: method, Params: map[string]any{pkey: id},
+		Classname: classTeacher, Method: methodTeacher, Params: map[string]any{"teacherId": id},
 	})
-
-	var lastErr error
 	for attempt := 0; attempt < 3; attempt++ {
 		req, _ := http.NewRequest("POST", apexURL, bytes.NewReader(reqBody))
 		req.Header.Set("User-Agent", userAgent)
 		req.Header.Set("Content-Type", "application/json; charset=utf-8")
 		resp, err := c.Do(req)
 		if err != nil {
-			lastErr = err
 			time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
 			continue
 		}
 		body, _ := io.ReadAll(resp.Body)
 		resp.Body.Close()
 		if resp.StatusCode != 200 {
-			lastErr = fmt.Errorf("http %d", resp.StatusCode)
 			time.Sleep(time.Duration(attempt+1) * 400 * time.Millisecond)
 			continue
 		}
-		if mode == "school" {
-			return parseSchool(body)
+		var r teacherResp
+		if json.Unmarshal(body, &r) != nil || r.ReturnValue.Id == "" {
+			return nil
 		}
-		return parseTeacher(body)
-	}
-	_ = lastErr
-	return nil, false
-}
-
-func parseSchool(body []byte) ([]string, bool) {
-	var r schoolResp
-	if json.Unmarshal(body, &r) != nil || r.ReturnValue.Id == "" {
-		return nil, false
-	}
-	v := r.ReturnValue
-	var tids []string
-	for _, t := range v.TrainerDetails {
-		if t.TrainerId != "" {
-			tids = append(tids, t.TrainerId)
+		v := r.ReturnValue
+		name := clean(v.DirectoryName)
+		if name == "" {
+			name = clean(strings.TrimSpace(v.FirstName + " " + v.LastName))
+		}
+		schoolName, schoolAddr := pickSchool(v.TeachingHistory)
+		return &teacher{
+			id: v.Id, name: name, email: strings.TrimSpace(v.Email), emailPublished: v.EmailPublished,
+			city: clean(v.MailingCity), state: clean(v.MailingState), country: clean(v.MailingCountry),
+			address: clean(v.Address), schoolName: schoolName, schoolAddr: schoolAddr,
+			instagram: strings.TrimSpace(v.Instagram), designation: clean(v.Designation),
+			languages: clean(v.Languages), yogaTypes: clean(v.TypesOfYoga), biography: clean(v.Biography),
+			yacep: v.IsYACEP, online: v.OfferOnline, teachingHours: v.TeachingHours,
 		}
 	}
-	return []string{
-		v.Id, clean(v.DirectoryName), clean(v.Address), v.Facebook, v.Instagram,
-		clean(v.Designation), clean(v.Languages), clean(v.TypesOfYoga), strings.Join(tids, ";"),
-	}, false
+	return nil
 }
 
-func parseTeacher(body []byte) ([]string, bool) {
-	var r teacherResp
-	if json.Unmarshal(body, &r) != nil || r.ReturnValue.Id == "" {
-		return nil, false
+// pickSchool returns the teacher's primary school: the first "Current" location
+// that has a real street address, else the first Current, else the first.
+func pickSchool(hist []teachingLocation) (name, addr string) {
+	var fallback *teachingLocation
+	for i := range hist {
+		h := &hist[i]
+		if fallback == nil {
+			fallback = h
+		}
+		if strings.EqualFold(h.StatusLabel, "Current") {
+			if strings.TrimSpace(h.GoogleAddress) != "" {
+				return clean(h.LocationName), clean(h.GoogleAddress)
+			}
+			if name == "" {
+				name, addr = clean(h.LocationName), clean(h.GoogleAddress)
+			}
+		}
 	}
-	v := r.ReturnValue
-	name := clean(v.DirectoryName)
-	if name == "" {
-		name = clean(strings.TrimSpace(v.FirstName + " " + v.LastName))
+	if name != "" {
+		return name, addr
 	}
-	return []string{
-		v.Id, name, strings.TrimSpace(v.Email), strconv.FormatBool(v.EmailPublished),
-		clean(v.MailingCity), clean(v.MailingState), clean(v.MailingCountry), clean(v.Address),
-		v.Instagram, clean(v.Designation), clean(v.Languages), clean(v.TypesOfYoga),
-		strconv.FormatFloat(v.TeachingHours, 'f', -1, 64),
-	}, strings.TrimSpace(v.Email) != ""
+	if fallback != nil {
+		return clean(fallback.LocationName), clean(fallback.GoogleAddress)
+	}
+	return "", ""
+}
+
+// upsertTeacher writes one teacher into the existing schema, tagged source=yogaalliance.
+func upsertTeacher(db *sql.DB, t *teacher) error {
+	bizName := t.schoolName
+	if bizName == "" {
+		bizName = t.name
+	}
+	addr := t.address
+	if addr == "" {
+		addr = t.schoolAddr
+	}
+	domain := strings.ToLower(t.id) + ".ryt.yogaalliance.org"
+	profileURL := "https://app.yogaalliance.org/teacherpublicprofile?id=" + t.id
+
+	social := map[string]string{}
+	if t.instagram != "" {
+		social["instagram"] = t.instagram
+	}
+	socialJSON, _ := json.Marshal(social)
+
+	var bizID int64
+	err := db.QueryRow(`
+		INSERT INTO business_listings
+		  (domain, business_name, contact_name, address, city, country, description,
+		   social_links, niche_category, off_niche, category, website, created_at, updated_at)
+		VALUES ($1,$2,$3,NULLIF($4,''),NULLIF($5,''),NULLIF($6,''),NULLIF($7,''),
+		   $8::jsonb,'yoga',false,'yogaalliance',$9,NOW(),NOW())
+		ON CONFLICT (domain) DO UPDATE SET
+		  business_name  = COALESCE(NULLIF(EXCLUDED.business_name,''), business_listings.business_name),
+		  contact_name   = COALESCE(NULLIF(EXCLUDED.contact_name,''),  business_listings.contact_name),
+		  address        = COALESCE(business_listings.address, EXCLUDED.address),
+		  city           = COALESCE(business_listings.city,    EXCLUDED.city),
+		  country        = COALESCE(business_listings.country, EXCLUDED.country),
+		  niche_category = 'yoga', off_niche = false, category = 'yogaalliance',
+		  updated_at     = NOW()
+		RETURNING id`,
+		domain, bizName, t.name, addr, t.city, t.country, t.biography, string(socialJSON), profileURL,
+	).Scan(&bizID)
+	if err != nil {
+		return fmt.Errorf("business_listings upsert: %w", err)
+	}
+
+	if t.email == "" {
+		return nil
+	}
+	at := strings.LastIndex(t.email, "@")
+	if at < 1 {
+		return nil
+	}
+	emailDomain := strings.ToLower(t.email[at+1:])
+	localPart := t.email[:at]
+
+	var emailID int64
+	err = db.QueryRow(`
+		INSERT INTO emails (email, domain, local_part, free_email, created_at)
+		VALUES ($1,$2,$3,$4,NOW())
+		ON CONFLICT (email) DO UPDATE SET domain = EXCLUDED.domain
+		RETURNING id`,
+		strings.ToLower(t.email), emailDomain, localPart, freeMail[emailDomain],
+	).Scan(&emailID)
+	if err != nil {
+		return fmt.Errorf("emails upsert: %w", err)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO business_emails (business_id, email_id, source)
+		VALUES ($1,$2,$3) ON CONFLICT (business_id, email_id) DO NOTHING`,
+		bizID, emailID, srcTag)
+	if err != nil {
+		return fmt.Errorf("business_emails link: %w", err)
+	}
+	return nil
 }
 
 func clean(s string) string {
 	s = tagsRe.ReplaceAllString(s, " ")
-	s = strings.ReplaceAll(s, " ", " ")
 	return strings.TrimSpace(spacesRe.ReplaceAllString(s, " "))
 }
 

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -2,23 +2,23 @@
 # registry. The push is done MANUALLY (not here) because the Traefik ingress in
 # front of ghcr.mcpke.dev kills large blob uploads at ~60s ("client disconnected"
 # 500 → docker retries forever). Proven push path instead:
-#   kurama: docker save ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.3-niche | gzip
+#   kurama: docker save ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.4-niche | gzip
 #         | ssh (via Mac) hachibi: docker load
-#   hachibi: docker tag …:v0.8.3-niche localhost:32769/foxhound-serp-scraper:v0.8.3-niche
+#   hachibi: docker tag …:v0.8.4-niche localhost:32769/foxhound-serp-scraper:v0.8.4-niche
 #          && docker push localhost:32769/…   (no Traefik, no auth, no timeout)
 #
 # Tag produced (foxhound v0.0.27 — REAL TLS-renegotiation panic fix per issue #43;
 # v0.0.22/v0.0.24 both still panicked. Plus niche feature):
-#   ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.3-niche
+#   ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.4-niche
 #
-# Deploy: set IMAGE_TAG=v0.8.3-niche on the serp stack and redeploy.
+# Deploy: set IMAGE_TAG=v0.8.4-niche on the serp stack and redeploy.
 
 services:
   builder:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.3-niche
+    image: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.4-niche
     # Override Dockerfile ENTRYPOINT so the container exits 0 once the image is
     # built (we only produce the image layer set here; we don't run the binary).
     entrypoint: [""]

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -1,46 +1,25 @@
-# Build-only compose for kurama. Builds the image then pushes it to the
-# self-hosted kremlit registry (ghcr.mcpke.dev) so the production serp
-# stack can pull it.
+# Build-only compose for kurama. Builds the image and tags it for the kremlit
+# registry. The push is done MANUALLY (not here) because the Traefik ingress in
+# front of ghcr.mcpke.dev kills large blob uploads at ~60s ("client disconnected"
+# 500 → docker retries forever). Proven push path instead:
+#   kurama: docker save ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.2-niche | gzip
+#         | ssh (via Mac) hachibi: docker load
+#   hachibi: docker tag …:v0.8.2-niche localhost:32769/foxhound-serp-scraper:v0.8.2-niche
+#          && docker push localhost:32769/…   (no Traefik, no auth, no timeout)
 #
-# Usage (on kurama, or via the Dokploy build target serp-build-v071fix):
-#   git fetch origin && git checkout feat/api-niche-classifier
-#   export KREMLIT_USER=docker KREMLIT_PASS=<registry password>
-#   docker compose -f docker-compose.build.yaml up --abort-on-container-exit
+# Tag produced (foxhound v0.0.22 — TLS-renegotiation-panic-free, niche feature):
+#   ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.2-niche
 #
-# Tag produced:
-#   ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.1-niche
-#
-# After a successful push, deploy by setting IMAGE_TAG=v0.8.1-niche on the
-# serp stack and redeploying via Dokploy (pull_policy: always picks it up).
-# v0.8.1-niche is immutable — it does not overwrite :v0.7.1 or :v0.8.0-canary.
+# Deploy: set IMAGE_TAG=v0.8.2-niche on the serp stack and redeploy.
 
 services:
   builder:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.1-niche
-    # Override Dockerfile ENTRYPOINT so the container exits 0 once the
-    # image is built (we're not running the binary here, just producing
-    # the image layer set).
+    image: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.2-niche
+    # Override Dockerfile ENTRYPOINT so the container exits 0 once the image is
+    # built (we only produce the image layer set here; we don't run the binary).
     entrypoint: [""]
     command: ["true"]
-    restart: "no"
-
-  pusher:
-    image: docker:24-cli
-    depends_on:
-      builder:
-        condition: service_completed_successfully
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-    environment:
-      KREMLIT_USER: ${KREMLIT_USER}
-      KREMLIT_PASS: ${KREMLIT_PASS}
-    command: >
-      sh -c "
-      echo \"$$KREMLIT_PASS\" | docker login ghcr.mcpke.dev -u \"$$KREMLIT_USER\" --password-stdin &&
-      docker push ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.1-niche &&
-      echo 'PUSH COMPLETE: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.1-niche'
-      "
     restart: "no"

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -1,24 +1,25 @@
-# Build-only compose for kurama. Runs docker build then pushes to ghcr.io.
+# Build-only compose for kurama. Builds the image then pushes it to the
+# self-hosted kremlit registry (ghcr.mcpke.dev) so the production serp
+# stack can pull it.
 #
-# Usage (on kurama, from /home/sadewa/serp-scraper-canary or equivalent):
-#   git fetch origin && git checkout canary/v0.8.0-country-extraction
-#   export GHCR_PAT=<your-personal-access-token-with-write:packages>
+# Usage (on kurama, or via the Dokploy build target serp-build-v071fix):
+#   git fetch origin && git checkout feat/api-niche-classifier
+#   export KREMLIT_USER=docker KREMLIT_PASS=<registry password>
 #   docker compose -f docker-compose.build.yaml up --abort-on-container-exit
 #
-# Tags produced:
-#   ghcr.io/sadewadee/foxhound-serp-scraper:canary-v0.8.0-country-extraction
-#   ghcr.io/sadewadee/foxhound-serp-scraper:canary-latest
+# Tag produced:
+#   ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.1-niche
 #
-# After successful push, redeploy the canary stack via Dokploy pointing at
-# either tag. The :canary-latest moving tag is convenient for redeploys
-# while iterating; the version-specific tag is the rollback anchor.
+# After a successful push, deploy by setting IMAGE_TAG=v0.8.1-niche on the
+# serp stack and redeploying via Dokploy (pull_policy: always picks it up).
+# v0.8.1-niche is immutable — it does not overwrite :v0.7.1 or :v0.8.0-canary.
 
 services:
   builder:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.io/sadewadee/foxhound-serp-scraper:canary-v0.8.0-country-extraction
+    image: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.1-niche
     # Override Dockerfile ENTRYPOINT so the container exits 0 once the
     # image is built (we're not running the binary here, just producing
     # the image layer set).
@@ -26,35 +27,20 @@ services:
     command: ["true"]
     restart: "no"
 
-  retagger:
+  pusher:
     image: docker:24-cli
     depends_on:
       builder:
         condition: service_completed_successfully
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: >
-      sh -c "
-      docker tag ghcr.io/sadewadee/foxhound-serp-scraper:canary-v0.8.0-country-extraction
-                 ghcr.io/sadewadee/foxhound-serp-scraper:canary-latest
-      "
-    restart: "no"
-
-  pusher:
-    image: docker:24-cli
-    depends_on:
-      retagger:
-        condition: service_completed_successfully
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      GHCR_USER: sadewadee
-      GHCR_PAT: ${GHCR_PAT}
+      KREMLIT_USER: ${KREMLIT_USER}
+      KREMLIT_PASS: ${KREMLIT_PASS}
     command: >
       sh -c "
-      echo \"$$GHCR_PAT\" | docker login ghcr.io -u \"$$GHCR_USER\" --password-stdin &&
-      docker push ghcr.io/sadewadee/foxhound-serp-scraper:canary-v0.8.0-country-extraction &&
-      docker push ghcr.io/sadewadee/foxhound-serp-scraper:canary-latest &&
-      echo 'PUSH COMPLETE: canary-v0.8.0-country-extraction + canary-latest'
+      echo \"$$KREMLIT_PASS\" | docker login ghcr.mcpke.dev -u \"$$KREMLIT_USER\" --password-stdin &&
+      docker push ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.1-niche &&
+      echo 'PUSH COMPLETE: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.1-niche'
       "
     restart: "no"

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -1,0 +1,60 @@
+# Build-only compose for kurama. Runs docker build then pushes to ghcr.io.
+#
+# Usage (on kurama, from /home/sadewa/serp-scraper-canary or equivalent):
+#   git fetch origin && git checkout canary/v0.8.0-country-extraction
+#   export GHCR_PAT=<your-personal-access-token-with-write:packages>
+#   docker compose -f docker-compose.build.yaml up --abort-on-container-exit
+#
+# Tags produced:
+#   ghcr.io/sadewadee/foxhound-serp-scraper:canary-v0.8.0-country-extraction
+#   ghcr.io/sadewadee/foxhound-serp-scraper:canary-latest
+#
+# After successful push, redeploy the canary stack via Dokploy pointing at
+# either tag. The :canary-latest moving tag is convenient for redeploys
+# while iterating; the version-specific tag is the rollback anchor.
+
+services:
+  builder:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: ghcr.io/sadewadee/foxhound-serp-scraper:canary-v0.8.0-country-extraction
+    # Override Dockerfile ENTRYPOINT so the container exits 0 once the
+    # image is built (we're not running the binary here, just producing
+    # the image layer set).
+    entrypoint: [""]
+    command: ["true"]
+    restart: "no"
+
+  retagger:
+    image: docker:24-cli
+    depends_on:
+      builder:
+        condition: service_completed_successfully
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    command: >
+      sh -c "
+      docker tag ghcr.io/sadewadee/foxhound-serp-scraper:canary-v0.8.0-country-extraction
+                 ghcr.io/sadewadee/foxhound-serp-scraper:canary-latest
+      "
+    restart: "no"
+
+  pusher:
+    image: docker:24-cli
+    depends_on:
+      retagger:
+        condition: service_completed_successfully
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    environment:
+      GHCR_USER: sadewadee
+      GHCR_PAT: ${GHCR_PAT}
+    command: >
+      sh -c "
+      echo \"$$GHCR_PAT\" | docker login ghcr.io -u \"$$GHCR_USER\" --password-stdin &&
+      docker push ghcr.io/sadewadee/foxhound-serp-scraper:canary-v0.8.0-country-extraction &&
+      docker push ghcr.io/sadewadee/foxhound-serp-scraper:canary-latest &&
+      echo 'PUSH COMPLETE: canary-v0.8.0-country-extraction + canary-latest'
+      "
+    restart: "no"

--- a/docker-compose.build.yaml
+++ b/docker-compose.build.yaml
@@ -2,22 +2,23 @@
 # registry. The push is done MANUALLY (not here) because the Traefik ingress in
 # front of ghcr.mcpke.dev kills large blob uploads at ~60s ("client disconnected"
 # 500 → docker retries forever). Proven push path instead:
-#   kurama: docker save ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.2-niche | gzip
+#   kurama: docker save ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.3-niche | gzip
 #         | ssh (via Mac) hachibi: docker load
-#   hachibi: docker tag …:v0.8.2-niche localhost:32769/foxhound-serp-scraper:v0.8.2-niche
+#   hachibi: docker tag …:v0.8.3-niche localhost:32769/foxhound-serp-scraper:v0.8.3-niche
 #          && docker push localhost:32769/…   (no Traefik, no auth, no timeout)
 #
-# Tag produced (foxhound v0.0.22 — TLS-renegotiation-panic-free, niche feature):
-#   ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.2-niche
+# Tag produced (foxhound v0.0.27 — REAL TLS-renegotiation panic fix per issue #43;
+# v0.0.22/v0.0.24 both still panicked. Plus niche feature):
+#   ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.3-niche
 #
-# Deploy: set IMAGE_TAG=v0.8.2-niche on the serp stack and redeploy.
+# Deploy: set IMAGE_TAG=v0.8.3-niche on the serp stack and redeploy.
 
 services:
   builder:
     build:
       context: .
       dockerfile: Dockerfile
-    image: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.2-niche
+    image: ghcr.mcpke.dev/foxhound-serp-scraper:v0.8.3-niche
     # Override Dockerfile ENTRYPOINT so the container exits 0 once the image is
     # built (we only produce the image layer set here; we don't run the binary).
     entrypoint: [""]

--- a/docker-compose.registry.yaml
+++ b/docker-compose.registry.yaml
@@ -19,10 +19,11 @@
 # `docker-compose.yaml` (build-based) remains the default for local dev.
 #
 # Scaling:
-#   SERP_WORKER_COUNT=2     → 2 SERP containers
-#   ENRICH_WORKER_COUNT=4   → 4 Enrich containers
-#   SERP_CONCURRENCY=4      → 4 browser tabs per SERP container
-#   ENRICH_CONCURRENCY=20   → 20 concurrent fetchers per Enrich container
+#   SERP_WORKER_COUNT=2       → 2 SERP containers
+#   ENRICH_WORKER_COUNT=2     → 2 Enrich containers
+#   REENRICH_WORKER_COUNT=3   → 3 Reenrich containers × 3 goroutines = 9 reenrich workers
+#   SERP_CONCURRENCY=4        → 4 browser tabs per SERP container
+#   ENRICH_CONCURRENCY=20     → 20 concurrent fetchers per Enrich container
 
 services:
 
@@ -238,7 +239,7 @@ services:
       - scraper-network
     deploy:
       mode: replicated
-      replicas: ${ENRICH_WORKER_COUNT:-4}
+      replicas: ${ENRICH_WORKER_COUNT:-2}
       resources:
         limits:
           cpus: "1"
@@ -274,10 +275,10 @@ services:
       BROWSER_TIMEOUT_SEC: "${BROWSER_TIMEOUT_SEC:-60}"
       BETA_FEATURES: "${BETA_FEATURES:-0}"
       TZ: "${TZ:-Asia/Jakarta}"
-      REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-1}"
+      REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-3}"
       REENRICH_SCORE: "${REENRICH_SCORE:-90}"
     shm_size: "512mb"
-    command: ["run", "-stage", "reenrich", "-workers", "${REENRICH_WORKER_COUNT:-1}"]
+    command: ["run", "-stage", "reenrich", "-workers", "${REENRICH_WORKER_COUNT:-3}"]
     healthcheck:
       test: ["CMD-SHELL", "test -f /tmp/worker-healthy && test $(( $(date +%s) - $(stat -c %Y /tmp/worker-healthy) )) -lt 120"]
       interval: 30s
@@ -288,7 +289,7 @@ services:
       - scraper-network
     deploy:
       mode: replicated
-      replicas: ${REENRICH_WORKER_COUNT:-1}
+      replicas: ${REENRICH_WORKER_COUNT:-3}
       resources:
         limits:
           cpus: "1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,10 +1,11 @@
 # docker-compose.yaml — Production deployment
 #
 # Scaling:
-#   SERP_WORKER_COUNT=2     → 2 SERP containers
-#   ENRICH_WORKER_COUNT=4   → 4 Enrich containers
-#   SERP_CONCURRENCY=4      → 4 browser tabs per SERP container
-#   ENRICH_CONCURRENCY=20   → 20 concurrent fetchers per Enrich container
+#   SERP_WORKER_COUNT=2       → 2 SERP containers
+#   ENRICH_WORKER_COUNT=2     → 2 Enrich containers
+#   REENRICH_WORKER_COUNT=3   → 3 Reenrich containers × 3 goroutines = 9 reenrich workers
+#   SERP_CONCURRENCY=4        → 4 browser tabs per SERP container
+#   ENRICH_CONCURRENCY=20     → 20 concurrent fetchers per Enrich container
 
 services:
 
@@ -220,7 +221,7 @@ services:
       - scraper-network
     deploy:
       mode: replicated
-      replicas: ${ENRICH_WORKER_COUNT:-4}
+      replicas: ${ENRICH_WORKER_COUNT:-2}
       resources:
         limits:
           cpus: "1"
@@ -256,10 +257,10 @@ services:
       BROWSER_TIMEOUT_SEC: "${BROWSER_TIMEOUT_SEC:-60}"
       BETA_FEATURES: "${BETA_FEATURES:-0}"
       TZ: "${TZ:-Asia/Jakarta}"
-      REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-1}"
+      REENRICH_WORKER_COUNT: "${REENRICH_WORKER_COUNT:-3}"
       REENRICH_SCORE: "${REENRICH_SCORE:-90}"
     shm_size: "512mb"
-    command: ["run", "-stage", "reenrich", "-workers", "${REENRICH_WORKER_COUNT:-1}"]
+    command: ["run", "-stage", "reenrich", "-workers", "${REENRICH_WORKER_COUNT:-3}"]
     healthcheck:
       test: ["CMD-SHELL", "test -f /tmp/worker-healthy && test $(( $(date +%s) - $(stat -c %Y /tmp/worker-healthy) )) -lt 120"]
       interval: 30s
@@ -270,7 +271,7 @@ services:
       - scraper-network
     deploy:
       mode: replicated
-      replicas: ${REENRICH_WORKER_COUNT:-1}
+      replicas: ${REENRICH_WORKER_COUNT:-3}
       resources:
         limits:
           cpus: "1"

--- a/docker-compose.yogaalliance.yaml
+++ b/docker-compose.yogaalliance.yaml
@@ -1,0 +1,26 @@
+# Dedicated one-shot crawler container for the Yoga Alliance directory.
+# Runs on kurama (Dokploy) where it has Postgres access, harvests the in-niche
+# RYT/RYS directory via the guest Apex API, and inserts straight into the
+# existing tables tagged source='yogaalliance'. restart:"no" — it's a batch job
+# that exits when the ~78K-teacher harvest completes (re-run to refresh).
+#
+# Deploy via Dokploy as a separate compose target, or locally on kurama:
+#   POSTGRES_DSN=... docker compose -f docker-compose.yogaalliance.yaml up --build
+#
+# Rollback/source: every row it writes is tagged via business_emails.source =
+# 'yogaalliance' + business_listings.category = 'yogaalliance' + a
+# *.ryt.yogaalliance.org synthetic domain, so the whole batch is trivially
+# identifiable and deletable if needed.
+
+services:
+  yogaalliance:
+    build:
+      context: .
+      dockerfile: Dockerfile.yogaalliance
+    image: ghcr.mcpke.dev/yogaalliance-crawler:${YA_TAG:-v1}
+    pull_policy: never
+    environment:
+      POSTGRES_DSN: ${POSTGRES_DSN}
+      TZ: Asia/Jakarta
+    command: ["-mode", "teacher", "-insert", "-concurrency", "8"]
+    restart: "no"

--- a/docs/api-response.md
+++ b/docs/api-response.md
@@ -264,7 +264,42 @@ Semua V2 list/single response dibungkus:
 
 ### `GET /api/v2/results`
 
-Query: `page`, `per_page≤200`, `domain`, `has_email`, `email`, `email_provider`, `email_status`, `search`
+Query (semua optional, kecuali pagination):
+
+| Param | Tipe | Catatan |
+|---|---|---|
+| `page` | int | OFFSET mode. Default 1. Tidak dipakai jika `cursor` di-set. |
+| `per_page` | int | Default 50, max 200. |
+| `cursor` | base64 | **Cursor mode** — keyset pagination O(log N). Opaque value dari response sebelumnya. Lihat bawah. |
+| `cursor_dir` | `next`\|`prev` | Default `next`. Hanya berlaku bila `cursor` di-set. |
+| `sort` | string | OFFSET mode only. Whitelist: `id_desc` (default), `id_asc`, `updated_desc`, `updated_asc`, `created_desc`, `created_asc`. Cursor mode dipaksa `id_desc` agar keyset boundary konsisten. |
+| `domain` | string | Match exact `bl.domain`. |
+| `country` | string | ISO alpha-2, case-insensitive (`id` ≡ `ID`). |
+| `city` | string | Prefix ILIKE — `?city=Berlin` cocok dengan "Berlin", "Berlin-Mitte". |
+| `has_email` | `true` | Hanya yang punya minimal 1 email. |
+| `has_phone` | `true` | Hanya yang `phone` non-empty. |
+| `has_social` | `true` | Hanya yang `social_links` non-empty (`{}` dianggap kosong). |
+| `email` | string | Match exact email address. |
+| `email_provider` | string | Match suffix — `?email_provider=gmail.com` cocok dengan `*@gmail.com`. |
+| `email_status` | string | Filter `validation_status` (`valid`, `pending`, `invalid`, dst). |
+| `search` | string | ILIKE `%x%` pada `business_name`. |
+
+**Cursor mode response** (saat `cursor` di-set) — tanpa `meta`, ganti dengan `next_cursor` + `has_more`:
+
+```json
+{
+  "data": [ /* V2BusinessListing[], lihat schema di bawah */ ],
+  "next_cursor": "eyJpZCI6MTIyOTV9",
+  "has_more": true
+}
+```
+
+- `next_cursor` opaque — perlakukan sebagai black box. Pakai persis di request berikutnya: `?cursor=<next_cursor>&per_page=...`.
+- Kalau `has_more=false`, `next_cursor` kosong → akhir hasil.
+- Cursor mode TIDAK mengembalikan `meta.total`. Kalau butuh total, panggil `GET /api/v2/results/count?<filter>` terpisah (cached 60s).
+- Cursor malformed → HTTP 400 `{"error":{"code":"invalid_cursor",...}}`.
+
+**OFFSET mode response** (default, saat `cursor` tidak di-set):
 
 ```json
 {

--- a/docs/api-response.md
+++ b/docs/api-response.md
@@ -283,6 +283,8 @@ Query (semua optional, kecuali pagination):
 | `email_provider` | string | Match suffix — `?email_provider=gmail.com` cocok dengan `*@gmail.com`. |
 | `email_status` | string | Filter `validation_status` (`valid`, `pending`, `invalid`, dst). |
 | `search` | string | ILIKE `%x%` pada `business_name`. |
+| `niche` | string | Filter `niche_category` eksak: `yoga`, `pilates`, `fitness`, `wellness`, `meditation`, `healing`, `ayurveda`, `spa`. |
+| `include_off_niche` | `true` | **Default tertutup**: off_niche rows (Hotel/AutoDealer/Dentist/dst) di-filter habis. Set `true` untuk lihat semua row apa adanya (debugging/manual review). |
 
 **Cursor mode response** (saat `cursor` di-set) — tanpa `meta`, ganti dengan `next_cursor` + `has_more`:
 

--- a/docs/superpowers/plans/2026-05-14-api-endpoint-caching-plan.md
+++ b/docs/superpowers/plans/2026-05-14-api-endpoint-caching-plan.md
@@ -1,0 +1,1161 @@
+# API Endpoint Caching Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate timeouts on `/api/v2/{stats,queries,results}` under high-traffic + large-data scenarios by adding Redis-backed caching, statement_timeout protection, and cursor pagination.
+
+**Architecture:** Three layers. (1) Shared `cache.go` helper providing `cachedCount`, `trySingleFlight`, `waitForCache`. (2) Endpoint-specific cache usage — `/api/v2/stats` wraps full response, `/api/v2/queries` caches count + adds statement_timeout, `/api/v2/results` adds cursor pagination as additive query param. (3) Observability via `X-Cache` response header (`HIT|MISS|WAITED|BYPASS`).
+
+**Tech Stack:** Go 1.25, `database/sql`, `github.com/redis/go-redis/v9` (already used), `github.com/alicebob/miniredis/v2` (new test-only dep). No production-binary deps added.
+
+**Spec:** `docs/superpowers/specs/2026-05-14-api-endpoint-caching-design.md`
+
+---
+
+## Test Strategy (read before starting)
+
+**TDD discipline applies to pure-logic code. Redis-coordination tests use `miniredis`. DB-touching code is verified manually via `X-Cache` header + staging traffic.**
+
+| Code type | Test approach |
+|---|---|
+| `buildCountCacheKey`, `encodeCursor`, `decodeCursor` | Standard unit tests, no deps |
+| `trySingleFlight`, `waitForCache` | `miniredis` (test-only dep) |
+| `cachedCount` (touches DB) | Manual verification + staging — no `sqlmock` to keep test surface small |
+| Handler glue | Manual verification via dashboard polling + `X-Cache` header in browser DevTools |
+
+This trade-off is deliberate: the cache logic that's hard to test (single-flight race, lock TTL boundary) gets `miniredis` coverage. The glue that's easy to verify manually doesn't get a 200-line mock setup. Reference: @superpowers:test-driven-development for the discipline; this plan exercises judgment about test ROI inside that discipline.
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|---|---|---|
+| `internal/api/cache.go` | **Create** | Shared cache helpers: `cachedCount`, `trySingleFlight`, `waitForCache`, `cachedJSON`. Also re-homes `buildCountCacheKey` from `v2_handlers_results.go`. |
+| `internal/api/cache_test.go` | **Create** | Tests for pure functions + miniredis-backed Redis coordination tests. |
+| `internal/api/cursor.go` | **Create** | `encodeCursor`/`decodeCursor` for opaque base64 cursor format. |
+| `internal/api/cursor_test.go` | **Create** | Round-trip + malformed input tests for cursor codec. |
+| `internal/api/v2_handlers_results.go` | **Modify** | (a) Remove `buildCountCacheKey` (moved). (b) Refactor `cachedFilteredCount` to call new `cachedCount`. (c) Add cursor branch to `handleV2ListResults`. |
+| `internal/api/v2_handlers_queries.go` | **Modify** | Refactor `handleV2ListQueries` to use `cachedCount` + wrap in tx with `statement_timeout=10s`. |
+| `internal/api/v2_handlers_stats.go` | **Modify** | Refactor `handleV2DashboardStats` — extract `computeDashboardStats` from cache-aware wrapper. |
+| `docs/api-response.md` | **Modify** | Document cursor query param + response shape for `/api/v2/results`. |
+| `go.mod`, `go.sum` | **Modify** | Add `github.com/alicebob/miniredis/v2` as test-only dependency. |
+
+---
+
+## Task 1: Shared cache helpers + miniredis dep
+
+**Files:**
+- Create: `internal/api/cache.go`
+- Create: `internal/api/cache_test.go`
+- Modify: `go.mod`, `go.sum`
+- Modify: `internal/api/v2_handlers_results.go:22,30-79` (remove `buildCountCacheKey` + refactor `cachedFilteredCount`)
+
+- [ ] **Step 1: Add miniredis test dependency**
+
+Run:
+```bash
+cd /Users/sadewadee/Downloads/Plugin\ Pro/serp-scraper
+go get -t github.com/alicebob/miniredis/v2@latest
+```
+Expected: `go: added github.com/alicebob/miniredis/v2 vX.Y.Z`. `go.mod` should now contain the dep.
+
+- [ ] **Step 2: Write failing test for `buildCountCacheKey`**
+
+Create `internal/api/cache_test.go`:
+
+```go
+package api
+
+import (
+	"testing"
+)
+
+func TestBuildCountCacheKey_StableAcrossCalls(t *testing.T) {
+	where := "WHERE bl.domain = $1"
+	args := []any{"example.com"}
+	a := buildCountCacheKey(where, args)
+	b := buildCountCacheKey(where, args)
+	if a != b {
+		t.Fatalf("expected stable key, got %q vs %q", a, b)
+	}
+	if a == "" {
+		t.Fatal("expected non-empty key")
+	}
+}
+
+func TestBuildCountCacheKey_DifferentArgs(t *testing.T) {
+	where := "WHERE bl.domain = $1"
+	a := buildCountCacheKey(where, []any{"a.com"})
+	b := buildCountCacheKey(where, []any{"b.com"})
+	if a == b {
+		t.Fatalf("expected different keys for different args")
+	}
+}
+
+// Regression: %v formatting would collide ["a","bc"] with ["ab","c"].
+func TestBuildCountCacheKey_NoTransposeCollision(t *testing.T) {
+	a := buildCountCacheKey("WHERE x = $1 AND y = $2", []any{"a", "bc"})
+	b := buildCountCacheKey("WHERE x = $1 AND y = $2", []any{"ab", "c"})
+	if a == b {
+		t.Fatal("transpose collision — %q must separate args")
+	}
+}
+```
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestBuildCountCacheKey -v
+```
+Expected: FAIL with `undefined: buildCountCacheKey` (function lives in `v2_handlers_results.go` still, but package compiles — wait, it's same package). Actually expect: PASS (function exists in same `package api`). Goal of this step is to capture current behavior before move.
+
+If PASS: tests now codify current behavior. If FAIL: investigate before moving.
+
+- [ ] **Step 3: Create `internal/api/cache.go` with `buildCountCacheKey` moved from results handler**
+
+Create `internal/api/cache.go`:
+
+```go
+package api
+
+import (
+	"context"
+	"crypto/sha1"
+	"database/sql"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// buildCountCacheKey hashes WHERE + args into a stable Redis key.
+// %q separates adjacent string args so ["a","bc"] and ["ab","c"] don't collide.
+func buildCountCacheKey(where string, args []any) string {
+	h := sha1.New()
+	h.Write([]byte(where))
+	for _, a := range args {
+		fmt.Fprintf(h, "|%q|", a)
+	}
+	return "v2:count:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// cachedCount returns COUNT(*) for `SELECT COUNT(*) FROM <fromClause> <where>`.
+// Caches result in Redis with TTL. On query timeout or DB error returns (-1, err)
+// so callers can serve `count_known=false` instead of HTTP 500.
+//
+// fromClause includes any join alias, e.g. "business_listings bl".
+// where includes the leading "WHERE", e.g. "WHERE bl.domain = $1" or "WHERE 1=1".
+func (s *Server) cachedCount(ctx context.Context, fromClause, where string, args []any, ttl, timeout time.Duration) (int, error) {
+	key := buildCountCacheKey(fromClause+"|"+where, args)
+
+	if s.redis != nil {
+		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+			if n, perr := strconv.Atoi(v); perr == nil {
+				return n, nil
+			}
+		}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return -1, err
+	}
+	defer tx.Rollback()
+
+	timeoutMs := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = '%d'", timeoutMs)); err != nil {
+		return -1, err
+	}
+
+	var total int
+	q := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", fromClause, where)
+	if err := tx.QueryRowContext(ctx, q, args...).Scan(&total); err != nil {
+		return -1, err
+	}
+	if err := tx.Commit(); err != nil {
+		return -1, err
+	}
+
+	if s.redis != nil {
+		_ = s.redis.Set(ctx, key, strconv.Itoa(total), ttl).Err()
+	}
+	return total, nil
+}
+
+// trySingleFlight acquires a Redis NX EX lock for the given key.
+// Returns true if caller should compute the value, false if another caller
+// is already computing. lockTTL bounds the maximum work duration.
+func (s *Server) trySingleFlight(ctx context.Context, key string, lockTTL time.Duration) bool {
+	if s.redis == nil {
+		return true // no Redis = no coordination = every caller computes
+	}
+	ok, err := s.redis.SetNX(ctx, key+":lock", "1", lockTTL).Result()
+	if err != nil {
+		slog.Debug("single-flight lock error", "key", key, "error", err)
+		return true // Redis errored — degrade to compute-anyway
+	}
+	return ok
+}
+
+// releaseSingleFlight removes the lock. Best-effort; lock TTL is the safety net.
+func (s *Server) releaseSingleFlight(ctx context.Context, key string) {
+	if s.redis == nil {
+		return
+	}
+	_ = s.redis.Del(ctx, key+":lock").Err()
+}
+
+// waitForCache polls a cache key up to maxWait. Returns value+true if populated,
+// "" + false on timeout.
+func (s *Server) waitForCache(ctx context.Context, key string, maxWait time.Duration) (string, bool) {
+	if s.redis == nil {
+		return "", false
+	}
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+			return v, true
+		}
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return "", false
+}
+
+// cachedJSON serves a JSON response from Redis cache or computes and caches it.
+// Adds X-Cache: HIT|WAITED|MISS|BYPASS header for observability.
+//
+// On cache miss the caller acquires a single-flight lock. Other callers wait
+// up to waitMs for the cache to populate. If they time out, they compute
+// anyway (degraded mode — better than failing).
+func (s *Server) cachedJSON(
+	ctx context.Context,
+	w http.ResponseWriter,
+	key string,
+	ttl time.Duration,
+	waitOnMiss time.Duration,
+	compute func() (any, error),
+) {
+	// Try cache.
+	if s.redis != nil {
+		if cached, err := s.redis.Get(ctx, key).Result(); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			io.WriteString(w, cached)
+			return
+		}
+	}
+
+	// Single-flight.
+	gotLock := s.trySingleFlight(ctx, key, 20*time.Second)
+	if !gotLock {
+		if cached, ok := s.waitForCache(ctx, key, waitOnMiss); ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "WAITED")
+			io.WriteString(w, cached)
+			return
+		}
+		// Timed out waiting — fall through to compute (degraded).
+	}
+	defer s.releaseSingleFlight(context.Background(), key)
+
+	value, err := compute()
+	if err != nil {
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to compute response")
+		return
+	}
+
+	body, err := json.Marshal(value)
+	if err != nil {
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to marshal response")
+		return
+	}
+
+	if s.redis != nil {
+		_ = s.redis.Set(ctx, key, body, ttl).Err()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if gotLock {
+		w.Header().Set("X-Cache", "MISS")
+	} else {
+		w.Header().Set("X-Cache", "BYPASS")
+	}
+	w.Write(body)
+}
+
+// _ keeps sql import used even if a future refactor removes the only call site.
+var _ = sql.ErrNoRows
+```
+
+- [ ] **Step 4: Remove `buildCountCacheKey` + `resultsCountTTL` + `cachedFilteredCount` body from `v2_handlers_results.go`**
+
+In `/Users/sadewadee/Downloads/Plugin Pro/serp-scraper/internal/api/v2_handlers_results.go`:
+
+Delete lines 20-79 (the `resultsCountTTL` const, `cachedFilteredCount` method, and `buildCountCacheKey` function). Replace with:
+
+```go
+// resultsCountTTL is the cache TTL for filtered COUNT(*) on business_listings.
+const resultsCountTTL = 60 * time.Second
+
+// cachedFilteredCount is the existing call signature, now thin wrapper over cachedCount.
+func (s *Server) cachedFilteredCount(ctx context.Context, where string, args []any) (int, error) {
+	return s.cachedCount(ctx, "business_listings bl", where, args, resultsCountTTL, 12*time.Second)
+}
+```
+
+Note: `buildCountCacheKey` is now in `cache.go` and accessible within the same package.
+
+- [ ] **Step 5: Run cache tests + build**
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestBuildCountCacheKey -v
+go build -tags playwright,tls ./...
+```
+Expected: tests PASS, build clean (no output).
+
+- [ ] **Step 6: Write failing tests for `trySingleFlight` and `waitForCache` using miniredis**
+
+Append to `internal/api/cache_test.go`:
+
+```go
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func newTestServer(t *testing.T) (*Server, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	s := &Server{redis: rdb}
+	return s, mr
+}
+
+func TestTrySingleFlight_FirstCallerWins(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	if !s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("first caller must win the lock")
+	}
+	if s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("second caller must NOT get the lock while held")
+	}
+}
+
+func TestTrySingleFlight_AfterRelease(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	s.trySingleFlight(ctx, "test:key", 5*time.Second)
+	s.releaseSingleFlight(ctx, "test:key")
+	if !s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("lock must be acquirable after release")
+	}
+}
+
+func TestTrySingleFlight_NoRedis(t *testing.T) {
+	s := &Server{redis: nil}
+	if !s.trySingleFlight(context.Background(), "test:key", 5*time.Second) {
+		t.Fatal("nil redis must degrade to compute-anyway (true)")
+	}
+}
+
+func TestWaitForCache_Populated(t *testing.T) {
+	s, mr := newTestServer(t)
+	ctx := context.Background()
+
+	mr.Set("test:key", `{"hello":"world"}`)
+	v, ok := s.waitForCache(ctx, "test:key", 1*time.Second)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if v != `{"hello":"world"}` {
+		t.Fatalf("unexpected value: %q", v)
+	}
+}
+
+func TestWaitForCache_TimesOut(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	start := time.Now()
+	_, ok := s.waitForCache(ctx, "test:nonexistent", 200*time.Millisecond)
+	elapsed := time.Since(start)
+	if ok {
+		t.Fatal("expected timeout")
+	}
+	if elapsed < 200*time.Millisecond || elapsed > 400*time.Millisecond {
+		t.Fatalf("waitForCache elapsed %v outside expected 200-400ms window", elapsed)
+	}
+}
+```
+
+Note: imports merge into the existing import block — Go formatter handles ordering.
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestTrySingleFlight -v
+go test -tags playwright,tls ./internal/api/ -run TestWaitForCache -v
+```
+Expected: tests PASS (implementation already in `cache.go` from Step 3).
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add internal/api/cache.go internal/api/cache_test.go \
+        internal/api/v2_handlers_results.go go.mod go.sum
+git commit -m "Add shared cache helpers (cachedCount, single-flight, cachedJSON)
+
+- Move buildCountCacheKey + cachedFilteredCount logic into cache.go
+- Add trySingleFlight/releaseSingleFlight/waitForCache for thundering-herd
+- Add cachedJSON for full-response cache (X-Cache observability header)
+- Tests via miniredis (test-only dep)
+
+Existing cachedFilteredCount preserved as thin wrapper for back-compat.
+No production binary deps added."
+```
+
+---
+
+## Task 2: `/api/v2/queries` — statement_timeout + count cache
+
+**Why P0:** Currently the only one of the 3 endpoints with NO `statement_timeout`. An ILIKE-search on unindexed `text` column on a growing `queries` table will hang the manager's connection pool indefinitely.
+
+**Files:**
+- Modify: `internal/api/v2_handlers_queries.go:15-75` (`handleV2ListQueries`)
+
+- [ ] **Step 1: Read current handler shape**
+
+Re-read `internal/api/v2_handlers_queries.go:15-75` to understand the count + data query flow before editing. The bug to preserve: `total int` is captured but `Scan` error is silently dropped — keep that behavior to avoid scope creep (separate ticket for error logging).
+
+- [ ] **Step 2: Refactor `handleV2ListQueries`**
+
+Replace `internal/api/v2_handlers_queries.go` lines 15-75 with:
+
+```go
+// handleV2ListQueries returns paginated queries wrapped in V2 format.
+// COUNT is cached in Redis (60s TTL) and protected by a 10s statement_timeout.
+func (s *Server) handleV2ListQueries(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := v2RequestContext(r)
+	defer cancel()
+
+	q := r.URL.Query()
+	page := queryInt(q, "page", 1)
+	perPage := queryInt(q, "per_page", 50)
+	if perPage > 200 {
+		perPage = 200
+	}
+	offset := (page - 1) * perPage
+
+	where := "WHERE 1=1"
+	args := []any{}
+	argIdx := 1
+
+	if status := q.Get("status"); status != "" {
+		where += fmt.Sprintf(" AND status = $%d", argIdx)
+		args = append(args, status)
+		argIdx++
+	}
+	if search := q.Get("search"); search != "" {
+		where += fmt.Sprintf(" AND text ILIKE $%d", argIdx)
+		args = append(args, "%"+search+"%")
+		argIdx++
+	}
+
+	// Cached count with 10s statement_timeout. -1 sentinel on timeout.
+	total, err := s.cachedCount(ctx, "queries", where, args, 60*time.Second, 10*time.Second)
+	if err != nil {
+		slog.Warn("v2: queries count failed (serving with -1 sentinel)", "error", err)
+	}
+
+	dataQuery := fmt.Sprintf(`
+		SELECT id, text, status, result_count, COALESCE(error_msg,''), created_at
+		FROM queries %s
+		ORDER BY id DESC
+		LIMIT $%d OFFSET $%d
+	`, where, argIdx, argIdx+1)
+	args = append(args, perPage, offset)
+
+	rows, err := s.db.QueryContext(ctx, dataQuery, args...)
+	if err != nil {
+		slog.Error("v2: list queries error", "error", err)
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch queries")
+		return
+	}
+	defer rows.Close()
+
+	type queryRow struct {
+		ID          int64     `json:"id"`
+		Text        string    `json:"text"`
+		Status      string    `json:"status"`
+		ResultCount int       `json:"result_count"`
+		Error       string    `json:"error"`
+		CreatedAt   time.Time `json:"created_at"`
+	}
+
+	queries := []queryRow{}
+	for rows.Next() {
+		var qr queryRow
+		rows.Scan(&qr.ID, &qr.Text, &qr.Status, &qr.ResultCount, &qr.Error, &qr.CreatedAt)
+		queries = append(queries, qr)
+	}
+
+	writeV2Paginated(w, queries, total, page, perPage)
+}
+```
+
+Key changes from current code:
+- Replace direct `s.db.QueryRow("SELECT COUNT(*) ...")` with `s.cachedCount(...)`.
+- `cachedCount` internally wraps in tx + `SET LOCAL statement_timeout`.
+- `ctx, cancel := v2RequestContext(r)` added (was missing — other v2 handlers have it).
+- Use `QueryContext` instead of `Query` for the data query (uses request context).
+
+- [ ] **Step 3: Build + verify**
+
+Run:
+```bash
+go build -tags playwright,tls ./...
+go test -tags playwright,tls ./internal/api/ -v
+```
+Expected: build clean, tests PASS (Task 1 tests still pass — no regression).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/v2_handlers_queries.go
+git commit -m "Protect /api/v2/queries with statement_timeout + count cache
+
+Currently the only v2 list endpoint without statement_timeout — an
+ILIKE-search on unindexed queries.text can hang the manager's
+connection pool indefinitely as the table grows.
+
+- Wrap COUNT in cachedCount helper (10s timeout, 60s Redis TTL)
+- Use QueryContext for data query (request context cancellation)
+- On count timeout, serve page with total=-1 sentinel via writeV2Paginated
+  (consumers already handle count_known=false in PaginationMeta)"
+```
+
+---
+
+## Task 3: `/api/v2/stats` — full-response cache + single-flight
+
+**Files:**
+- Modify: `internal/api/v2_handlers_stats.go:9-146`
+
+- [ ] **Step 1: Extract `computeDashboardStats` from current handler**
+
+Replace `internal/api/v2_handlers_stats.go` content with:
+
+```go
+package api
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"time"
+)
+
+// dashboardStatsCacheTTL is the Redis cache window for /api/v2/stats.
+// Dashboard polling clients re-hit within this window for ~free.
+const dashboardStatsCacheTTL = 30 * time.Second
+
+// handleV2DashboardStats returns the full dashboard stats wrapped in V2 format.
+// Backed by a 30s Redis cache with single-flight to prevent thundering herd
+// when the cache TTL expires under polling load.
+func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := v2RequestContext(r)
+	defer cancel()
+
+	s.cachedJSON(ctx, w,
+		"v2:stats:dashboard", dashboardStatsCacheTTL, 5*time.Second,
+		func() (any, error) {
+			return s.computeDashboardStats(ctx)
+		},
+	)
+}
+
+// computeDashboardStats runs the 5 COUNT(*) queries against the live DB.
+// Wrapped in cachedJSON above. Statement timeout 15s.
+func (s *Server) computeDashboardStats(ctx context.Context) (map[string]any, error) {
+	// -- Queries (small table, no timeout needed) --
+	queries := map[string]int{}
+	qRows, _ := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM queries GROUP BY status`)
+	if qRows != nil {
+		for qRows.Next() {
+			var status string
+			var cnt int
+			qRows.Scan(&status, &cnt)
+			queries[status] = cnt
+		}
+		qRows.Close()
+	}
+	qTotal := 0
+	for _, c := range queries {
+		qTotal += c
+	}
+	queries["total"] = qTotal
+
+	// -- Big-table aggregates: serp_jobs + enrichment_jobs + emails --
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("v2: dashboard tx error", "error", err)
+		return nil, err
+	}
+	defer tx.Rollback()
+
+	// 15s — serp_jobs (5.7M rows) and emails (828K+) need headroom.
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '15000'"); err != nil {
+		slog.Error("v2: set timeout error", "error", err)
+		return nil, err
+	}
+
+	serp := map[string]any{}
+	var serpTotal, serpNew, serpProcessing, serpCompleted, serpFailed int
+	var serpURLsFound, serpPerHour, serpToday int
+	tx.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE status = 'new'),
+			COUNT(*) FILTER (WHERE status = 'processing'),
+			COUNT(*) FILTER (WHERE status = 'completed'),
+			COUNT(*) FILTER (WHERE status = 'failed'),
+			COALESCE(SUM(result_count) FILTER (WHERE status = 'completed'), 0),
+			COUNT(*) FILTER (WHERE status = 'completed' AND updated_at > NOW() - INTERVAL '1 hour'),
+			COUNT(*) FILTER (WHERE status = 'completed' AND updated_at > NOW() - INTERVAL '24 hours')
+		FROM serp_jobs
+	`).Scan(&serpTotal, &serpNew, &serpProcessing, &serpCompleted, &serpFailed, &serpURLsFound, &serpPerHour, &serpToday)
+	serp["total"] = serpTotal
+	serp["pending"] = serpNew
+	serp["processing"] = serpProcessing
+	serp["completed"] = serpCompleted
+	serp["failed"] = serpFailed
+	serp["urls_found"] = serpURLsFound
+	serp["rate_per_hour"] = serpPerHour
+	serp["today"] = serpToday
+
+	enrich := map[string]any{}
+	var enrichTotal, enrichPending, enrichProcessing, enrichCompleted, enrichFailed, enrichDead int
+	var enrichPerHour, enrichToday int
+	tx.QueryRowContext(ctx, `
+		SELECT
+			COUNT(*),
+			COUNT(*) FILTER (WHERE status = 'pending'),
+			COUNT(*) FILTER (WHERE status = 'processing'),
+			COUNT(*) FILTER (WHERE status = 'completed'),
+			COUNT(*) FILTER (WHERE status = 'failed'),
+			COUNT(*) FILTER (WHERE status = 'dead'),
+			COUNT(*) FILTER (WHERE status = 'completed' AND completed_at > NOW() - INTERVAL '1 hour'),
+			COUNT(*) FILTER (WHERE status = 'completed' AND completed_at > NOW() - INTERVAL '24 hours')
+		FROM enrichment_jobs
+	`).Scan(&enrichTotal, &enrichPending, &enrichProcessing, &enrichCompleted, &enrichFailed, &enrichDead, &enrichPerHour, &enrichToday)
+	enrich["total"] = enrichTotal
+	enrich["pending"] = enrichPending
+	enrich["processing"] = enrichProcessing
+	enrich["completed"] = enrichCompleted
+	enrich["failed"] = enrichFailed
+	enrich["dead"] = enrichDead
+	enrich["rate_per_hour"] = enrichPerHour
+	enrich["today"] = enrichToday
+
+	results := map[string]any{}
+	var totalEmails, emailsToday, emailsLastHour, uniqueDomains int
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails`).Scan(&totalEmails)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'`).Scan(&emailsToday)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'`).Scan(&emailsLastHour)
+	tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT domain) FROM business_listings`).Scan(&uniqueDomains)
+	results["total_emails"] = totalEmails
+	results["emails_today"] = emailsToday
+	results["emails_per_hour"] = emailsLastHour
+	results["unique_domains"] = uniqueDomains
+
+	providerRows, _ := tx.QueryContext(ctx, `
+		SELECT domain, COUNT(*) AS cnt
+		FROM emails
+		GROUP BY domain ORDER BY cnt DESC LIMIT 10
+	`)
+	providers := map[string]int{}
+	if providerRows != nil {
+		for providerRows.Next() {
+			var p string
+			var c int
+			providerRows.Scan(&p, &c)
+			providers[p] = c
+		}
+		providerRows.Close()
+	}
+	results["providers"] = providers
+
+	tx.Commit()
+
+	queueMap := map[string]int64{}
+	qd, _ := s.redis.ZCard(ctx, "serp:queue:queries").Result()
+	queueMap["serp:queue:queries"] = qd
+	sb, _ := s.redis.LLen(ctx, "serp:buffer").Result()
+	queueMap["serp:buffer"] = sb
+	eb, _ := s.redis.LLen(ctx, "enrich:buffer").Result()
+	queueMap["enrich:buffer"] = eb
+
+	// Wrap in V2 envelope manually since we're not going through writeV2Single.
+	// cachedJSON caches the entire envelope so subsequent hits return identical
+	// shape without re-wrapping.
+	return map[string]any{
+		"data": map[string]any{
+			"queries": queries,
+			"serp":    serp,
+			"enrich":  enrich,
+			"results": results,
+			"queues":  queueMap,
+		},
+	}, nil
+}
+```
+
+Notable changes from original:
+- Body of original `handleV2DashboardStats` becomes `computeDashboardStats`.
+- New `handleV2DashboardStats` is a thin wrapper that delegates to `cachedJSON`.
+- The V2 envelope `{"data": ...}` is constructed inline because `cachedJSON` caches raw JSON bytes (not the Go map). Going through `writeV2Single` inside the cached path would re-wrap on every cache miss.
+
+- [ ] **Step 2: Build + run all api tests**
+
+Run:
+```bash
+go build -tags playwright,tls ./...
+go test -tags playwright,tls ./internal/api/ -v
+```
+Expected: build clean, Task 1 tests still PASS.
+
+- [ ] **Step 3: Manual smoke (skip if no local PG/Redis)**
+
+If you have local PG+Redis (e.g. via `docker compose up db redis`), spin manager:
+```bash
+go run -tags playwright,tls . run -stage none
+```
+Then in another terminal:
+```bash
+curl -i -H "x-api-key: $API_KEY" http://localhost:8080/api/v2/stats | head -10
+curl -i -H "x-api-key: $API_KEY" http://localhost:8080/api/v2/stats | head -10
+```
+Expected: first response `X-Cache: MISS`, second response `X-Cache: HIT` within 30s.
+
+If no local env: skip — verified post-deploy.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/api/v2_handlers_stats.go
+git commit -m "Cache /api/v2/stats response with 30s TTL + single-flight
+
+Dashboard polls every 5-10s with 3-5 concurrent users. Without cache,
+each request runs 5 sequential COUNT(*) on serp_jobs (5.7M) +
+enrichment_jobs + emails (828K) + business_listings + emails group-by.
+At scale that's 30-60 stat req/min × ~15s each = pool exhaustion.
+
+- Wrap response in cachedJSON helper (30s TTL)
+- Single-flight via Redis NX EX prevents thundering herd at TTL expiry
+- Extract compute path as computeDashboardStats for testability
+- Response shape unchanged (cached body is the full V2 envelope)
+- X-Cache: HIT|WAITED|MISS|BYPASS for observability"
+```
+
+---
+
+## Task 4: `/api/v2/results` — cursor pagination
+
+**Files:**
+- Create: `internal/api/cursor.go`
+- Create: `internal/api/cursor_test.go`
+- Modify: `internal/api/v2_handlers_results.go` (add cursor branch to `handleV2ListResults`)
+- Modify: `docs/api-response.md`
+
+- [ ] **Step 1: Write failing tests for cursor codec**
+
+Create `internal/api/cursor_test.go`:
+
+```go
+package api
+
+import (
+	"testing"
+)
+
+func TestCursor_RoundTrip(t *testing.T) {
+	encoded := encodeCursor(12345)
+	if encoded == "" {
+		t.Fatal("expected non-empty cursor")
+	}
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != 12345 {
+		t.Fatalf("expected id=12345, got %d", id)
+	}
+}
+
+func TestCursor_EmptyDecode(t *testing.T) {
+	_, err := decodeCursor("")
+	if err == nil {
+		t.Fatal("empty cursor must error")
+	}
+}
+
+func TestCursor_MalformedDecode(t *testing.T) {
+	_, err := decodeCursor("not-base64!!!")
+	if err == nil {
+		t.Fatal("malformed cursor must error")
+	}
+}
+
+func TestCursor_MalformedJSON(t *testing.T) {
+	// Valid base64 but not JSON
+	_, err := decodeCursor("aGVsbG8=") // "hello"
+	if err == nil {
+		t.Fatal("non-JSON cursor body must error")
+	}
+}
+
+func TestCursor_NegativeID(t *testing.T) {
+	encoded := encodeCursor(-1)
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != -1 {
+		t.Fatalf("expected -1, got %d", id)
+	}
+}
+```
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestCursor -v
+```
+Expected: FAIL with `undefined: encodeCursor` / `undefined: decodeCursor`.
+
+- [ ] **Step 2: Implement cursor codec**
+
+Create `internal/api/cursor.go`:
+
+```go
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+)
+
+// cursorPayload is the wire format inside an opaque cursor.
+// Versioned via the struct shape so future fields stay backward-compatible.
+type cursorPayload struct {
+	ID int64 `json:"id"`
+}
+
+// encodeCursor builds an opaque base64url cursor from a row ID.
+// Used for pagination "next page" pointer.
+func encodeCursor(id int64) string {
+	payload, _ := json.Marshal(cursorPayload{ID: id})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+// decodeCursor unwraps a cursor back to its row ID.
+// Returns error for empty, non-base64, or non-JSON inputs.
+func decodeCursor(cursor string) (int64, error) {
+	if cursor == "" {
+		return 0, errors.New("cursor is empty")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, err
+	}
+	var p cursorPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return 0, err
+	}
+	return p.ID, nil
+}
+```
+
+Run:
+```bash
+go test -tags playwright,tls ./internal/api/ -run TestCursor -v
+```
+Expected: all PASS.
+
+- [ ] **Step 3: Add cursor branch to `handleV2ListResults`**
+
+Modify `internal/api/v2_handlers_results.go` `handleV2ListResults` (lines 122-261 in original). The change is in the WHERE-clause assembly + pagination logic; the email-fetch section (lines 203-254) is unchanged.
+
+Locate this block (around line 134):
+
+```go
+	where, args, argIdx := buildResultsFilter(q)
+
+	// Count total via Redis-cached helper. On timeout/error the helper returns -1
+	// so we serve the page with a sentinel instead of 500.
+	total, err := s.cachedFilteredCount(ctx, where, args)
+	if err != nil {
+		slog.Warn("v2: count failed (returning -1 sentinel)", "error", err)
+	}
+```
+
+Replace with:
+
+```go
+	where, args, argIdx := buildResultsFilter(q)
+
+	// Cursor mode: ?cursor=<base64> uses keyset pagination — O(log N) at deep pages.
+	// OFFSET mode (existing): ?page=N + ?per_page=M — capped at perPage=200.
+	cursorParam := q.Get("cursor")
+	useCursor := cursorParam != ""
+
+	var cursorID int64
+	if useCursor {
+		var err error
+		cursorID, err = decodeCursor(cursorParam)
+		if err != nil {
+			writeV2Error(w, http.StatusBadRequest, "invalid_cursor", "cursor is malformed")
+			return
+		}
+		dir := q.Get("cursor_dir")
+		if dir == "prev" {
+			where += fmt.Sprintf(" AND bl.id > $%d", argIdx)
+		} else {
+			where += fmt.Sprintf(" AND bl.id < $%d", argIdx)
+		}
+		args = append(args, cursorID)
+		argIdx++
+	}
+
+	// Count is only computed for offset mode. Cursor mode returns has_more flag.
+	var total int
+	if !useCursor {
+		var err error
+		total, err = s.cachedFilteredCount(ctx, where, args)
+		if err != nil {
+			slog.Warn("v2: count failed (returning -1 sentinel)", "error", err)
+		}
+	}
+```
+
+Then locate the existing query construction (around line 144):
+
+```go
+	// Query 1: Fetch paginated listings (all columns).
+	dataQuery := fmt.Sprintf(`
+		SELECT bl.id, COALESCE(bl.business_name,''), ...
+		FROM business_listings bl %s
+		ORDER BY bl.id DESC
+		LIMIT $%d OFFSET $%d
+	`, where, argIdx, argIdx+1)
+	args = append(args, perPage, offset)
+```
+
+Replace the `dataQuery` block + `args = append(args, perPage, offset)` with:
+
+```go
+	// Cursor mode: fetch perPage+1 to detect has_more without separate query.
+	// OFFSET mode: existing pagination.
+	limit := perPage
+	if useCursor {
+		limit = perPage + 1 // +1 sentinel for has_more detection
+	}
+
+	dataQuery := fmt.Sprintf(`
+		SELECT bl.id, COALESCE(bl.business_name,''), COALESCE(bl.category,''),
+		       COALESCE(bl.description,''), COALESCE(bl.website,''),
+		       bl.domain, bl.url, COALESCE(bl.social_links,'{}'),
+		       COALESCE(bl.address,''), COALESCE(bl.location,''),
+		       COALESCE(bl.city,''), COALESCE(bl.country,''), COALESCE(bl.contact_name,''),
+		       COALESCE(bl.opening_hours,''), COALESCE(bl.rating,''),
+		       COALESCE(bl.page_title,''), COALESCE(bl.phone,''), COALESCE(bl.phones,'{}'),
+		       COALESCE(bl.tiktok,''), COALESCE(bl.youtube,''), COALESCE(bl.telegram,''),
+		       bl.source_query_id, bl.created_at, bl.updated_at
+		FROM business_listings bl %s
+		ORDER BY bl.id DESC
+		LIMIT $%d`, where, argIdx)
+	args = append(args, limit)
+	argIdx++
+
+	if !useCursor {
+		dataQuery += fmt.Sprintf(" OFFSET $%d", argIdx)
+		args = append(args, offset)
+	}
+```
+
+Then at the END of the handler (currently `writeV2Paginated(w, listings, total, page, perPage)` around line 260), replace with:
+
+```go
+	if useCursor {
+		hasMore := len(listings) > perPage
+		if hasMore {
+			listings = listings[:perPage] // drop sentinel row
+		}
+		var nextCursor string
+		if hasMore && len(listings) > 0 {
+			nextCursor = encodeCursor(listings[len(listings)-1].ID)
+		}
+		writeV2Single(w, map[string]any{
+			"data":        listings,
+			"next_cursor": nextCursor,
+			"has_more":    hasMore,
+		})
+		return
+	}
+
+	writeV2Paginated(w, listings, total, page, perPage)
+```
+
+- [ ] **Step 4: Build + run all api tests**
+
+Run:
+```bash
+go build -tags playwright,tls ./...
+go test -tags playwright,tls ./internal/api/ -v
+```
+Expected: build clean, all tests PASS.
+
+- [ ] **Step 5: Update docs/api-response.md**
+
+Append to `docs/api-response.md` (after the existing `/api/v2/results` section):
+
+```markdown
+### Cursor pagination for `/api/v2/results` (v0.8.0+)
+
+Two pagination modes are supported on the same endpoint. Choose based on UX:
+
+| Mode | Use when | Trigger param |
+|---|---|---|
+| OFFSET (default) | Need total count, jumping to arbitrary page (page 5, 10, etc.) | `?page=N&per_page=M` |
+| Cursor | "Load more" UX, deep pagination, no total count needed | `?cursor=<base64>&per_page=M` |
+
+Cursor request:
+```
+GET /api/v2/results?cursor=eyJpZCI6MTIzNDV9&per_page=50
+```
+
+Cursor response (200):
+```json
+{
+  "data": [ /* business listings */ ],
+  "next_cursor": "eyJpZCI6MTIyOTV9",
+  "has_more": true
+}
+```
+
+Notes:
+- `next_cursor` is an opaque base64-encoded value — treat as a black box.
+- When `has_more=false`, `next_cursor` is empty — pagination is done.
+- Optional `?cursor_dir=prev` reverses the direction (rare; for back-navigation).
+- Cursor mode does NOT return `meta.total` — use `/api/v2/results/count` separately if needed.
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/api/cursor.go internal/api/cursor_test.go \
+        internal/api/v2_handlers_results.go docs/api-response.md
+git commit -m "Add cursor pagination to /api/v2/results (additive)
+
+OFFSET pagination degrades at deep pages — OFFSET 50,000 scans 50K rows
+just to skip them. For 'load more' UX at 700K+ business_listings scale,
+keyset (cursor) pagination is O(log N) via the existing PK index.
+
+- Add encodeCursor/decodeCursor (base64url + JSON payload, versioned shape)
+- handleV2ListResults branches on ?cursor=...:
+    OFFSET mode (existing): unchanged, ?page + ?per_page
+    cursor mode (new):      ?cursor + ?per_page, returns next_cursor + has_more
+- Fetch perPage+1 to detect has_more in single query
+- Optional ?cursor_dir=prev for back-navigation
+- Documented in docs/api-response.md
+
+No breaking change. Frontend opts in by passing cursor instead of page."
+```
+
+---
+
+## Task 5: Integration verification
+
+**Files:** none modified — pure verification.
+
+- [ ] **Step 1: Full build (production target)**
+
+Run:
+```bash
+CGO_ENABLED=0 go build -tags playwright,tls -ldflags="-w -s" -o /tmp/serp-scraper-build .
+ls -lh /tmp/serp-scraper-build
+rm /tmp/serp-scraper-build
+```
+Expected: binary ~30-35MB, no compile error.
+
+- [ ] **Step 2: Full test suite**
+
+Run:
+```bash
+go test -tags playwright,tls ./... 2>&1 | tail -30
+```
+Expected: all packages PASS, no failures. Verify especially:
+- `ok  github.com/sadewadee/serp-scraper/internal/api` with N+ tests.
+- No regression in `internal/stage/...`, `internal/scraper/...`.
+
+- [ ] **Step 3: Race detector on api package**
+
+Run:
+```bash
+go test -tags playwright,tls -race -count=1 ./internal/api/...
+```
+Expected: ok, no race conditions. Single-flight + waitForCache use goroutine coordination — race detector validates we got it right.
+
+- [ ] **Step 4: Vet**
+
+Run:
+```bash
+go vet -tags playwright,tls ./...
+```
+Expected: no output (clean).
+
+- [ ] **Step 5: Final summary (no commit)**
+
+Run:
+```bash
+git log --oneline -5
+git diff --stat origin/canary/v0.8.0-country-extraction..HEAD
+```
+Expected: 4 commits ahead of remote (one per Task 1-4), `~400-500` lines net delta.
+
+---
+
+## Rollout
+
+After all tasks land:
+
+1. Push branch: `git push origin canary/v0.8.0-country-extraction`
+2. Build canary image on kurama via `docker-compose.build.yaml` (existing infra).
+3. Push to GHCR `ghcr.io/sadewadee/foxhound-serp-scraper:canary-latest`.
+4. Redeploy via Dokploy.
+5. Verify post-deploy:
+   - `curl -i -H "x-api-key: $API_KEY" https://manager.../api/v2/stats` — confirm `X-Cache` header present.
+   - Repeat curl within 30s — `X-Cache: HIT`.
+   - Watch dashboard p95 latency for 1h via Prometheus on `:9090`.
+6. Rollback path: revert the 4 commits, redeploy previous tag.
+
+## Success criteria (post-deploy)
+
+- `/api/v2/stats` p95 latency: <100ms (was 5-15s).
+- `/api/v2/queries`: zero HTTP 500 from statement timeout under ILIKE search.
+- `/api/v2/results?cursor=...`: <500ms at any logical page depth.
+- Worker email throughput unchanged (sanity check: no write-path regression).

--- a/docs/superpowers/specs/2026-05-14-api-endpoint-caching-design.md
+++ b/docs/superpowers/specs/2026-05-14-api-endpoint-caching-design.md
@@ -1,0 +1,155 @@
+# API Endpoint Caching — Design
+
+**Date**: 2026-05-14
+**Branch**: `canary/v0.8.0-country-extraction`
+**Problem**: User-facing v2 endpoints time out at scale. `/api/v2/stats` runs 5 sequential COUNT(*) on multi-million-row tables per request, dashboard polls every 5-10s with 3-5 concurrent users. `/api/v2/queries` has no `statement_timeout` and can hang the connection pool indefinitely. `/api/v2/results` is partially cached but OFFSET pagination degrades at deep pages.
+
+**Non-goals**: counter table + trigger (write amplification), materialized view (staleness), read replica (ops overhead), trigram index for ILIKE (separate concern).
+
+## Scope
+
+Four targeted changes inside `internal/api/v2_handlers_*.go`. No schema migration. No worker changes. No API breaking change.
+
+| # | Endpoint | Change |
+|---|---|---|
+| 1 | `/api/v2/stats` | Redis cache the full response body, TTL 30s, single key |
+| 2 | `/api/v2/queries` (list) | Add `SET LOCAL statement_timeout = '10000'` + Redis-cache the COUNT (TTL 60s, key by filter hash) |
+| 3 | `/api/v2/results` (list) | Add cursor pagination as additive query param; existing OFFSET path unchanged |
+| 4 | (shared) | Single-flight lock around cache misses to prevent thundering herd at TTL expiry |
+
+## Design — Component 1: `/api/v2/stats` full-response cache
+
+**Cache key**: `v2:stats:dashboard` (single key — endpoint has no filters)
+
+**TTL**: 30s
+
+**Flow**:
+```
+handleV2DashboardStats:
+  if GET v2:stats:dashboard hits → return raw JSON
+  else:
+    acquire single-flight lock (key: v2:stats:dashboard:lock, NX EX 20s)
+    if lock acquired:
+      run the 5 COUNT queries inside existing tx (statement_timeout=15s)
+      build response JSON
+      SET v2:stats:dashboard {json} EX 30
+      DEL v2:stats:dashboard:lock
+      return JSON
+    else:
+      wait up to 5s polling cache (50ms intervals)
+      if cache populated → return it
+      else → return cached-stale-or-503
+```
+
+**Failure mode**: Redis down → fall through to current code path (no cache, direct DB query). Single-flight lock degrades to "every request hits DB" — same as today, no regression.
+
+**Stale-while-revalidate**: NOT in v1. Add later if cache-miss latency proves painful.
+
+## Design — Component 2: `/api/v2/queries` count cache + timeout
+
+**Cache key**: `v2:queries:count:<sha1(where|args)>` — same pattern as existing `buildCountCacheKey` in `v2_handlers_results.go:72`.
+
+**TTL**: 60s
+
+**Statement timeout**: 10s (wrapped in `tx` like results.go does for COUNT).
+
+**Flow**: identical to `cachedFilteredCount` in `v2_handlers_results.go:30` — extract into a shared helper `cachedCount(ctx, table, where, args, ttl)` that both endpoints use. Sentinel `-1` on timeout, caller serves page with `count_known=false`.
+
+**Why 60s vs 30s for stats**: queries list count changes less frequently (user manually creates queries, not auto-incrementing); stats counters tick with every job completion (~hundreds/sec at peak).
+
+## Design — Component 3: `/api/v2/results` cursor pagination
+
+**New query params** (additive, optional):
+- `cursor` — opaque base64-encoded `last_id` from previous page
+- `cursor_dir` — `next` (default) or `prev`
+
+**Cursor format**: `base64url(json{"id": 12345, "ts": "2026-05-14T..."})` — version stays inside JSON for forward-compat.
+
+**Flow**:
+```
+if ?cursor is present:
+  decode → last_id
+  WHERE bl.id < $last_id (next)  or  bl.id > $last_id (prev)
+  ORDER BY bl.id DESC LIMIT $perPage
+  → response includes next_cursor = base64(last_row.id), no total count
+elif ?page is present:
+  (existing OFFSET path unchanged)
+```
+
+**Response shape** (cursor mode): `{data: [...], next_cursor: "...", has_more: true}` — no `total` field. Documented in `docs/api-response.md` update.
+
+**Backward compat**: `?page` continues to work. Frontend can opt-in to cursor for "load more" UX. No client breaking change.
+
+## Design — Component 4: single-flight lock helper
+
+**Pattern**:
+```go
+// trySingleFlight attempts to acquire a Redis NX EX lock. Returns true if
+// caller should compute the value, false if another caller is already computing.
+func (s *Server) trySingleFlight(ctx context.Context, key string, ttl time.Duration) (bool, error) {
+    ok, err := s.redis.SetNX(ctx, key+":lock", "1", ttl).Result()
+    return ok, err
+}
+
+// waitForCache polls a cache key up to maxWait, returning value when present.
+func (s *Server) waitForCache(ctx context.Context, key string, maxWait time.Duration) (string, bool) {
+    deadline := time.Now().Add(maxWait)
+    for time.Now().Before(deadline) {
+        if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+            return v, true
+        }
+        time.Sleep(50 * time.Millisecond)
+    }
+    return "", false
+}
+```
+
+**Where used**: Component 1 only (stats endpoint). Component 2 reuses existing `cachedFilteredCount` semantics (cache miss = each caller computes; cheap enough since query is already `LIMIT`-bounded). Avoiding single-flight on Component 2 keeps surface small.
+
+## Failure modes & fallbacks
+
+| Failure | Behavior |
+|---|---|
+| Redis down (GET fails) | Fall through to DB path. Same as current. |
+| Redis down (SET fails) | Best-effort, log + serve response. |
+| Single-flight lock held but holder dies | Lock TTL (20s) frees it. Next caller retries. |
+| DB statement_timeout fires | Return `count_known=false` (count endpoint) or 500 (stats/queries) — current behavior. |
+| Stale cache served during DB outage | Acceptable for dashboard. Document. |
+
+## Testing
+
+| Test | What | Where |
+|---|---|---|
+| `TestV2StatsCache_HitMiss` | First call DB, second call cache, after TTL expire DB again | `internal/api/v2_handlers_stats_test.go` (new) |
+| `TestV2StatsCache_SingleFlight` | 10 concurrent requests at cache miss → exactly 1 DB call | same |
+| `TestV2QueriesCount_CacheKey` | Different filter combos produce different cache keys | `internal/api/v2_handlers_queries_test.go` (new) |
+| `TestV2QueriesCount_StatementTimeout` | Slow mock DB → returns sentinel within 10s + 500 buffer | same |
+| `TestV2ResultsCursor_Encode` | Cursor round-trip (encode → decode → query) | `internal/api/v2_handlers_results_test.go` (existing file or new) |
+| `TestV2ResultsCursor_NextPrev` | next/prev directions return non-overlapping result sets | same |
+
+Redis mock: use `miniredis` or `redis-mock` if already in `go.sum`; otherwise small interface around `redis.Cmdable` mocked manually.
+
+## Out of scope (deferred to separate work items)
+
+- Trigram/full-text index for ILIKE search (affects both `queries.text` and `business_listings.business_name`) — separate ticket
+- Read-replica routing for analytics queries — too much ops surface change
+- Counter-table + trigger for real-time stats — write amplification risk
+- Stale-while-revalidate cache pattern — add only if cache-miss latency complaints arise
+
+## Rollout
+
+- Behind no feature flag — straightforward additive change, low risk.
+- Deploy via canary stack (`docker-compose.build.yaml` → GHCR → Dokploy).
+- Validate via `docker logs manager 2>&1 | grep "v2:.*cache"` for hit/miss counter — add `slog.Debug` lines.
+- Rollback path: revert one commit, redeploy previous tag.
+
+## Success criteria
+
+- `/api/v2/stats` p95 latency drops from current ~5-15s to <100ms under 5 concurrent users.
+- `/api/v2/queries` no longer returns 500 when ILIKE search hits unindexed scan.
+- `/api/v2/results` page=500 (deep) returns in <500ms via cursor path; existing OFFSET path unchanged for back-compat.
+- Zero impact on worker write throughput (no schema changes, no triggers).
+
+## Effort
+
+~150-200 lines net across 3 handler files + 1 new shared cache helper + 6 tests. No migration. Single commit feasible.

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lib/pq v1.11.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
-	github.com/sadewadee/foxhound v0.0.19
+	github.com/sadewadee/foxhound v0.0.22
 	golang.org/x/net v0.52.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lib/pq v1.11.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
-	github.com/sadewadee/foxhound v0.0.24
+	github.com/sadewadee/foxhound v0.0.22
 	golang.org/x/net v0.52.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -7,7 +7,7 @@ require (
 	github.com/lib/pq v1.11.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
-	github.com/sadewadee/foxhound v0.0.22
+	github.com/sadewadee/foxhound v0.0.24
 	golang.org/x/net v0.52.0
 	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.mod
+++ b/go.mod
@@ -4,10 +4,11 @@ go 1.25.0
 
 require (
 	github.com/PuerkitoBio/goquery v1.12.0
+	github.com/alicebob/miniredis/v2 v2.38.0
 	github.com/lib/pq v1.11.2
 	github.com/prometheus/client_golang v1.23.2
 	github.com/redis/go-redis/v9 v9.18.0
-	github.com/sadewadee/foxhound v0.0.22
+	github.com/sadewadee/foxhound v0.0.27
 	golang.org/x/net v0.52.0
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -19,7 +20,6 @@ require (
 	github.com/Noooste/uquic-go v1.0.5 // indirect
 	github.com/Noooste/utls v1.3.20 // indirect
 	github.com/Noooste/websocket v1.0.3 // indirect
-	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/bdandy/go-errors v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,6 +19,7 @@ require (
 	github.com/Noooste/uquic-go v1.0.5 // indirect
 	github.com/Noooste/utls v1.3.20 // indirect
 	github.com/Noooste/websocket v1.0.3 // indirect
+	github.com/alicebob/miniredis/v2 v2.38.0 // indirect
 	github.com/andybalholm/brotli v1.2.0 // indirect
 	github.com/andybalholm/cascadia v1.3.3 // indirect
 	github.com/bdandy/go-errors v1.2.2 // indirect
@@ -47,6 +48,7 @@ require (
 	github.com/quic-go/qpack v0.6.0 // indirect
 	github.com/refraction-networking/utls v1.8.2 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
+	github.com/yuin/gopher-lua v1.1.1 // indirect
 	go.uber.org/atomic v1.11.0 // indirect
 	go.yaml.in/yaml/v2 v2.4.2 // indirect
 	golang.org/x/crypto v0.49.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-github.com/sadewadee/foxhound v0.0.19 h1:SWPHxYzDJkeZI0rUYATkO9JdSlC4GlU6Q8xujdoDJUg=
-github.com/sadewadee/foxhound v0.0.19/go.mod h1:ky0A3l+j0+XUg7hk0AsM1UYEADspMdIqgBJza+tGJ6Q=
+github.com/sadewadee/foxhound v0.0.22 h1:+XoCGBTQbCOTK5hOVq6l+yK4otGTnu3Emf/bI0Jlemw=
+github.com/sadewadee/foxhound v0.0.22/go.mod h1:ky0A3l+j0+XUg7hk0AsM1UYEADspMdIqgBJza+tGJ6Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-github.com/sadewadee/foxhound v0.0.24 h1:wEu+eKswO30NpuJkothAZGvhGh3kDj977m6+swb6CpA=
-github.com/sadewadee/foxhound v0.0.24/go.mod h1:URZr8IbWs+Tv+/e341ACL+0PInndN+n3dSlptoTxRc0=
+github.com/sadewadee/foxhound v0.0.22 h1:+XoCGBTQbCOTK5hOVq6l+yK4otGTnu3Emf/bI0Jlemw=
+github.com/sadewadee/foxhound v0.0.22/go.mod h1:ky0A3l+j0+XUg7hk0AsM1UYEADspMdIqgBJza+tGJ6Q=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/go.sum
+++ b/go.sum
@@ -14,6 +14,8 @@ github.com/Noooste/websocket v1.0.3 h1:drW7tvZ3YqzqI9wApnaH1Q0syFMXO7gbLlsBWjZvM
 github.com/Noooste/websocket v1.0.3/go.mod h1:Qhw0Rtuju/fPPbcb3R5XGq7poa51qPDL462jTltl9nQ=
 github.com/PuerkitoBio/goquery v1.12.0 h1:pAcL4g3WRXekcB9AU/y1mbKez2dbY2AajVhtkO8RIBo=
 github.com/PuerkitoBio/goquery v1.12.0/go.mod h1:802ej+gV2y7bbIhOIoPY5sT183ZW0YFofScC4q/hIpQ=
+github.com/alicebob/miniredis/v2 v2.38.0 h1:nZAzCR+Lj+Vxk4ZXzm2NuKq2O33RXj1XxJ2e2uP9jiw=
+github.com/alicebob/miniredis/v2 v2.38.0/go.mod h1:TcL7YfarKPGDAthEtl5NBeHZfeUQj6OXMm/+iu5cLMM=
 github.com/andybalholm/brotli v1.2.0 h1:ukwgCxwYrmACq68yiUqwIWnGY0cTPox/M94sVwToPjQ=
 github.com/andybalholm/brotli v1.2.0/go.mod h1:rzTDkvFWvIrjDXZHkuS16NPggd91W3kUSvPlQ1pLaKY=
 github.com/andybalholm/cascadia v1.3.3 h1:AG2YHrzJIm4BZ19iwJ/DAua6Btl3IwJX+VI4kktS1LM=
@@ -121,6 +123,8 @@ github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD
 github.com/xyproto/randomstring v1.0.5 h1:YtlWPoRdgMu3NZtP45drfy1GKoojuR7hmRcnhZqKjWU=
 github.com/xyproto/randomstring v1.0.5/go.mod h1:rgmS5DeNXLivK7YprL0pY+lTuhNQW3iGxZ18UQApw/E=
 github.com/yuin/goldmark v1.4.13/go.mod h1:6yULJ656Px+3vBD8DxQVa3kxgyrAnzto9xy5taEt/CY=
+github.com/yuin/gopher-lua v1.1.1 h1:kYKnWBjvbNP4XLT3+bPEwAXJx262OhaHDWDVOPjL46M=
+github.com/yuin/gopher-lua v1.1.1/go.mod h1:GBR0iDaNXjAgGg9zfCvksxSRnQx76gclCIb7kdAd1Pw=
 github.com/zeebo/xxh3 v1.0.2 h1:xZmwmqxHZA8AI603jOQ0tMqmBr9lPeFwGg6d+xy9DC0=
 github.com/zeebo/xxh3 v1.0.2/go.mod h1:5NWz9Sef7zIDm2JHfFlcQvNekmcEl9ekUZQQKCYaDcA=
 go.uber.org/atomic v1.11.0 h1:ZvwS0R+56ePWxUNi+Atn9dWONBPp/AUETXlHW0DxSjE=

--- a/go.sum
+++ b/go.sum
@@ -114,8 +114,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-github.com/sadewadee/foxhound v0.0.22 h1:+XoCGBTQbCOTK5hOVq6l+yK4otGTnu3Emf/bI0Jlemw=
-github.com/sadewadee/foxhound v0.0.22/go.mod h1:ky0A3l+j0+XUg7hk0AsM1UYEADspMdIqgBJza+tGJ6Q=
+github.com/sadewadee/foxhound v0.0.27 h1:ml/1op2IVDBfQHbGKTV2/7Sm2afnd0bDQ0s9BUbXREE=
+github.com/sadewadee/foxhound v0.0.27/go.mod h1:URZr8IbWs+Tv+/e341ACL+0PInndN+n3dSlptoTxRc0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/go.sum
+++ b/go.sum
@@ -112,8 +112,8 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 github.com/rogpeppe/go-internal v1.11.0 h1:cWPaGQEPrBb5/AsnsZesgZZ9yb1OQ+GOISoDNXVBh4M=
 github.com/rogpeppe/go-internal v1.11.0/go.mod h1:ddIwULY96R17DhadqLgMfk9H9tvdUzkipdSkR5nkCZA=
-github.com/sadewadee/foxhound v0.0.22 h1:+XoCGBTQbCOTK5hOVq6l+yK4otGTnu3Emf/bI0Jlemw=
-github.com/sadewadee/foxhound v0.0.22/go.mod h1:ky0A3l+j0+XUg7hk0AsM1UYEADspMdIqgBJza+tGJ6Q=
+github.com/sadewadee/foxhound v0.0.24 h1:wEu+eKswO30NpuJkothAZGvhGh3kDj977m6+swb6CpA=
+github.com/sadewadee/foxhound v0.0.24/go.mod h1:URZr8IbWs+Tv+/e341ACL+0PInndN+n3dSlptoTxRc0=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=

--- a/internal/api/cache.go
+++ b/internal/api/cache.go
@@ -1,0 +1,172 @@
+package api
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"strconv"
+	"time"
+)
+
+// buildCountCacheKey hashes WHERE + args into a stable Redis key.
+// %q separates adjacent string args so ["a","bc"] and ["ab","c"] don't collide.
+func buildCountCacheKey(where string, args []any) string {
+	h := sha1.New()
+	h.Write([]byte(where))
+	for _, a := range args {
+		fmt.Fprintf(h, "|%q|", a)
+	}
+	return "v2:count:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// cachedCount returns COUNT(*) for `SELECT COUNT(*) FROM <fromClause> <where>`.
+// Caches result in Redis with TTL. On query timeout or DB error returns (-1, err)
+// so callers can serve `count_known=false` instead of HTTP 500.
+//
+// fromClause includes any join alias, e.g. "business_listings bl".
+// where includes the leading "WHERE", e.g. "WHERE bl.domain = $1" or "WHERE 1=1".
+func (s *Server) cachedCount(ctx context.Context, fromClause, where string, args []any, ttl, timeout time.Duration) (int, error) {
+	key := buildCountCacheKey(fromClause+"|"+where, args)
+
+	if s.redis != nil {
+		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+			if n, perr := strconv.Atoi(v); perr == nil {
+				return n, nil
+			}
+		}
+	}
+
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		return -1, err
+	}
+	defer tx.Rollback()
+
+	timeoutMs := int(timeout.Milliseconds())
+	if _, err := tx.ExecContext(ctx, fmt.Sprintf("SET LOCAL statement_timeout = '%d'", timeoutMs)); err != nil {
+		return -1, err
+	}
+
+	var total int
+	q := fmt.Sprintf("SELECT COUNT(*) FROM %s %s", fromClause, where)
+	if err := tx.QueryRowContext(ctx, q, args...).Scan(&total); err != nil {
+		return -1, err
+	}
+	if err := tx.Commit(); err != nil {
+		return -1, err
+	}
+
+	if s.redis != nil {
+		_ = s.redis.Set(ctx, key, strconv.Itoa(total), ttl).Err()
+	}
+	return total, nil
+}
+
+// trySingleFlight acquires a Redis NX EX lock for the given key.
+// Returns true if caller should compute the value, false if another caller
+// is already computing. lockTTL bounds the maximum work duration.
+func (s *Server) trySingleFlight(ctx context.Context, key string, lockTTL time.Duration) bool {
+	if s.redis == nil {
+		return true // no Redis = no coordination = every caller computes
+	}
+	ok, err := s.redis.SetNX(ctx, key+":lock", "1", lockTTL).Result()
+	if err != nil {
+		slog.Debug("single-flight lock error", "key", key, "error", err)
+		return true // Redis errored — degrade to compute-anyway
+	}
+	return ok
+}
+
+// releaseSingleFlight removes the lock. Best-effort; lock TTL is the safety net.
+func (s *Server) releaseSingleFlight(ctx context.Context, key string) {
+	if s.redis == nil {
+		return
+	}
+	_ = s.redis.Del(ctx, key+":lock").Err()
+}
+
+// waitForCache polls a cache key up to maxWait. Returns value+true if populated,
+// "" + false on timeout.
+func (s *Server) waitForCache(ctx context.Context, key string, maxWait time.Duration) (string, bool) {
+	if s.redis == nil {
+		return "", false
+	}
+	deadline := time.Now().Add(maxWait)
+	for time.Now().Before(deadline) {
+		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
+			return v, true
+		}
+		select {
+		case <-ctx.Done():
+			return "", false
+		case <-time.After(50 * time.Millisecond):
+		}
+	}
+	return "", false
+}
+
+// cachedJSON serves a JSON response from Redis cache or computes and caches it.
+// Adds X-Cache: HIT|WAITED|MISS|BYPASS header for observability.
+//
+// On cache miss the caller acquires a single-flight lock. Other callers wait
+// up to waitOnMiss for the cache to populate. If they time out, they compute
+// anyway (degraded mode — better than failing).
+func (s *Server) cachedJSON(
+	ctx context.Context,
+	w http.ResponseWriter,
+	key string,
+	ttl time.Duration,
+	waitOnMiss time.Duration,
+	compute func() (any, error),
+) {
+	// Try cache.
+	if s.redis != nil {
+		if cached, err := s.redis.Get(ctx, key).Result(); err == nil {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "HIT")
+			io.WriteString(w, cached)
+			return
+		}
+	}
+
+	// Single-flight.
+	gotLock := s.trySingleFlight(ctx, key, 20*time.Second)
+	if !gotLock {
+		if cached, ok := s.waitForCache(ctx, key, waitOnMiss); ok {
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-Cache", "WAITED")
+			io.WriteString(w, cached)
+			return
+		}
+		// Timed out waiting — fall through to compute (degraded).
+	}
+	defer s.releaseSingleFlight(context.Background(), key)
+
+	value, err := compute()
+	if err != nil {
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to compute response")
+		return
+	}
+
+	body, err := json.Marshal(value)
+	if err != nil {
+		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to marshal response")
+		return
+	}
+
+	if s.redis != nil {
+		_ = s.redis.Set(ctx, key, body, ttl).Err()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	if gotLock {
+		w.Header().Set("X-Cache", "MISS")
+	} else {
+		w.Header().Set("X-Cache", "BYPASS")
+	}
+	w.Write(body)
+}

--- a/internal/api/cache.go
+++ b/internal/api/cache.go
@@ -30,8 +30,14 @@ func buildCountCacheKey(where string, args []any) string {
 //
 // fromClause includes any join alias, e.g. "business_listings bl".
 // where includes the leading "WHERE", e.g. "WHERE bl.domain = $1" or "WHERE 1=1".
+//
+// SECURITY: fromClause and where are interpolated directly into the SQL string.
+// Both MUST be compile-time constants. NEVER pass user input as either; pass
+// user values through args and reference them via $N placeholders in where.
 func (s *Server) cachedCount(ctx context.Context, fromClause, where string, args []any, ttl, timeout time.Duration) (int, error) {
-	key := buildCountCacheKey(fromClause+"|"+where, args)
+	// %q quotes both parts so concatenation is unambiguous: an unquoted "|"
+	// inside either string cannot collide with the separator.
+	key := buildCountCacheKey(fmt.Sprintf("%q|%q", fromClause, where), args)
 
 	if s.redis != nil {
 		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
@@ -145,7 +151,14 @@ func (s *Server) cachedJSON(
 		}
 		// Timed out waiting — fall through to compute (degraded).
 	}
-	defer s.releaseSingleFlight(context.Background(), key)
+	// Only release if WE acquired the lock. BYPASS callers (timed out waiting)
+	// must NOT delete a key they don't own — that would let other concurrent
+	// callers re-acquire and partially defeat thundering-herd protection.
+	// context.Background() (not ctx) so release fires even if request ctx is
+	// already cancelled by the time compute() returns.
+	if gotLock {
+		defer s.releaseSingleFlight(context.Background(), key)
+	}
 
 	value, err := compute()
 	if err != nil {

--- a/internal/api/cache_test.go
+++ b/internal/api/cache_test.go
@@ -1,0 +1,108 @@
+package api
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/alicebob/miniredis/v2"
+	"github.com/redis/go-redis/v9"
+)
+
+func TestBuildCountCacheKey_StableAcrossCalls(t *testing.T) {
+	where := "WHERE bl.domain = $1"
+	args := []any{"example.com"}
+	a := buildCountCacheKey(where, args)
+	b := buildCountCacheKey(where, args)
+	if a != b {
+		t.Fatalf("expected stable key, got %q vs %q", a, b)
+	}
+	if a == "" {
+		t.Fatal("expected non-empty key")
+	}
+}
+
+func TestBuildCountCacheKey_DifferentArgs(t *testing.T) {
+	where := "WHERE bl.domain = $1"
+	a := buildCountCacheKey(where, []any{"a.com"})
+	b := buildCountCacheKey(where, []any{"b.com"})
+	if a == b {
+		t.Fatalf("expected different keys for different args")
+	}
+}
+
+// Regression: %v formatting would collide ["a","bc"] with ["ab","c"].
+func TestBuildCountCacheKey_NoTransposeCollision(t *testing.T) {
+	a := buildCountCacheKey("WHERE x = $1 AND y = $2", []any{"a", "bc"})
+	b := buildCountCacheKey("WHERE x = $1 AND y = $2", []any{"ab", "c"})
+	if a == b {
+		t.Fatal("transpose collision: adjacent string args produced the same key")
+	}
+}
+
+func newTestServer(t *testing.T) (*Server, *miniredis.Miniredis) {
+	t.Helper()
+	mr := miniredis.RunT(t)
+	rdb := redis.NewClient(&redis.Options{Addr: mr.Addr()})
+	s := &Server{redis: rdb}
+	return s, mr
+}
+
+func TestTrySingleFlight_FirstCallerWins(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	if !s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("first caller must win the lock")
+	}
+	if s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("second caller must NOT get the lock while held")
+	}
+}
+
+func TestTrySingleFlight_AfterRelease(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	s.trySingleFlight(ctx, "test:key", 5*time.Second)
+	s.releaseSingleFlight(ctx, "test:key")
+	if !s.trySingleFlight(ctx, "test:key", 5*time.Second) {
+		t.Fatal("lock must be acquirable after release")
+	}
+}
+
+func TestTrySingleFlight_NoRedis(t *testing.T) {
+	s := &Server{redis: nil}
+	if !s.trySingleFlight(context.Background(), "test:key", 5*time.Second) {
+		t.Fatal("nil redis must degrade to compute-anyway (true)")
+	}
+}
+
+func TestWaitForCache_Populated(t *testing.T) {
+	s, mr := newTestServer(t)
+	ctx := context.Background()
+
+	mr.Set("test:key", `{"hello":"world"}`)
+	v, ok := s.waitForCache(ctx, "test:key", 1*time.Second)
+	if !ok {
+		t.Fatal("expected cache hit")
+	}
+	if v != `{"hello":"world"}` {
+		t.Fatalf("unexpected value: %q", v)
+	}
+}
+
+func TestWaitForCache_TimesOut(t *testing.T) {
+	s, _ := newTestServer(t)
+	ctx := context.Background()
+
+	start := time.Now()
+	_, ok := s.waitForCache(ctx, "test:nonexistent", 200*time.Millisecond)
+	elapsed := time.Since(start)
+	if ok {
+		t.Fatal("expected timeout")
+	}
+	if elapsed < 200*time.Millisecond || elapsed > 400*time.Millisecond {
+		t.Fatalf("waitForCache elapsed %v outside expected 200-400ms window", elapsed)
+	}
+}

--- a/internal/api/cursor.go
+++ b/internal/api/cursor.go
@@ -1,0 +1,37 @@
+package api
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+)
+
+// cursorPayload is the wire format inside an opaque cursor.
+// Versioned via the struct shape so future fields stay backward-compatible.
+type cursorPayload struct {
+	ID int64 `json:"id"`
+}
+
+// encodeCursor builds an opaque base64url cursor from a row ID.
+// Used for pagination "next page" pointer.
+func encodeCursor(id int64) string {
+	payload, _ := json.Marshal(cursorPayload{ID: id})
+	return base64.RawURLEncoding.EncodeToString(payload)
+}
+
+// decodeCursor unwraps a cursor back to its row ID.
+// Returns error for empty, non-base64, or non-JSON inputs.
+func decodeCursor(cursor string) (int64, error) {
+	if cursor == "" {
+		return 0, errors.New("cursor is empty")
+	}
+	raw, err := base64.RawURLEncoding.DecodeString(cursor)
+	if err != nil {
+		return 0, err
+	}
+	var p cursorPayload
+	if err := json.Unmarshal(raw, &p); err != nil {
+		return 0, err
+	}
+	return p.ID, nil
+}

--- a/internal/api/cursor_test.go
+++ b/internal/api/cursor_test.go
@@ -1,0 +1,64 @@
+package api
+
+import (
+	"testing"
+)
+
+func TestCursor_RoundTrip(t *testing.T) {
+	encoded := encodeCursor(12345)
+	if encoded == "" {
+		t.Fatal("expected non-empty cursor")
+	}
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != 12345 {
+		t.Fatalf("expected id=12345, got %d", id)
+	}
+}
+
+func TestCursor_EmptyDecode(t *testing.T) {
+	_, err := decodeCursor("")
+	if err == nil {
+		t.Fatal("empty cursor must error")
+	}
+}
+
+func TestCursor_MalformedDecode(t *testing.T) {
+	_, err := decodeCursor("not-base64!!!")
+	if err == nil {
+		t.Fatal("malformed cursor must error")
+	}
+}
+
+func TestCursor_MalformedJSON(t *testing.T) {
+	// Valid base64 ("hello") but not JSON.
+	_, err := decodeCursor("aGVsbG8")
+	if err == nil {
+		t.Fatal("non-JSON cursor body must error")
+	}
+}
+
+func TestCursor_NegativeID(t *testing.T) {
+	encoded := encodeCursor(-1)
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != -1 {
+		t.Fatalf("expected -1, got %d", id)
+	}
+}
+
+func TestCursor_LargeID(t *testing.T) {
+	const big int64 = 9_223_372_036_854_775_000 // near max int64
+	encoded := encodeCursor(big)
+	id, err := decodeCursor(encoded)
+	if err != nil {
+		t.Fatalf("decode failed: %v", err)
+	}
+	if id != big {
+		t.Fatalf("expected %d, got %d", big, id)
+	}
+}

--- a/internal/api/handlers_contacts.go
+++ b/internal/api/handlers_contacts.go
@@ -1,6 +1,7 @@
 package api
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
@@ -98,7 +99,7 @@ func (s *Server) handleListContacts(w http.ResponseWriter, r *http.Request) {
 		}
 
 		contacts = append(contacts, map[string]any{
-			"id": id,
+			"id":            id,
 			"business_name": businessName, "business_category": category,
 			"description": description, "website": website,
 			"emails": emails, "phones": phones, "domain": domain,
@@ -198,29 +199,62 @@ func (s *Server) handleExportContacts(w http.ResponseWriter, r *http.Request) {
 			"business_name": businessName, "business_category": category,
 			"website": website, "emails": emails, "domain": domain,
 			"social_links": json.RawMessage(socialLinksJSON),
-			"address": address, "location": location, "phone": phone,
+			"address":      address, "location": location, "phone": phone,
 		})
 	}
 	w.Write([]byte("]"))
 }
 
 func (s *Server) handleContactStats(w http.ResponseWriter, r *http.Request) {
+	// 10s budget — must exceed the 8s statement_timeout below.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
 	var totalBiz, withEmail, uniqueDomains, totalEmails, lastHour, last24h int
 	var validEmails, pendingEmails, invalidEmails int
 
-	s.db.QueryRow("SELECT COUNT(*) FROM business_listings").Scan(&totalBiz)
-	s.db.QueryRow("SELECT COUNT(DISTINCT bl.id) FROM business_listings bl JOIN business_emails be ON be.business_id = bl.id").Scan(&withEmail)
-	s.db.QueryRow("SELECT COUNT(DISTINCT domain) FROM business_listings").Scan(&uniqueDomains)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails").Scan(&totalEmails)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'").Scan(&lastHour)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'").Scan(&last24h)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE validation_status = 'valid'").Scan(&validEmails)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE validation_status = 'pending'").Scan(&pendingEmails)
-	s.db.QueryRow("SELECT COUNT(*) FROM emails WHERE validation_status = 'invalid'").Scan(&invalidEmails)
+	// 9 serial QueryRow on a 2-conn pool was the cascade root: 1 slow query
+	// held both pool conns ~40s and v2 endpoints saw 500 with context deadline.
+	// Fold into 3 queries (business, email, providers) inside one tx with
+	// statement_timeout to bound the damage on the pool.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("v1: contact-stats tx error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '8000'"); err != nil {
+		slog.Error("v1: contact-stats set timeout error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+
+	// Business listings: 2 aggregates in 1 pass.
+	tx.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COUNT(DISTINCT domain)
+		FROM business_listings
+	`).Scan(&totalBiz, &uniqueDomains)
+
+	// with_email needs a join; separate query (still inside tx).
+	tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT business_id) FROM business_emails`).Scan(&withEmail)
+
+	// Emails: 6 aggregates in 1 pass.
+	tx.QueryRowContext(ctx, `
+		SELECT COUNT(*),
+		       COUNT(*) FILTER (WHERE validation_status = 'valid'),
+		       COUNT(*) FILTER (WHERE validation_status = 'pending'),
+		       COUNT(*) FILTER (WHERE validation_status = 'invalid'),
+		       COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '1 hour'),
+		       COUNT(*) FILTER (WHERE created_at > NOW() - INTERVAL '24 hours')
+		FROM emails
+	`).Scan(&totalEmails, &validEmails, &pendingEmails, &invalidEmails, &lastHour, &last24h)
 
 	// Top email providers.
 	providers := map[string]int{}
-	providerRows, _ := s.db.Query(`
+	providerRows, _ := tx.QueryContext(ctx, `
 		SELECT domain, COUNT(*) AS cnt
 		FROM emails
 		GROUP BY domain
@@ -228,14 +262,16 @@ func (s *Server) handleContactStats(w http.ResponseWriter, r *http.Request) {
 		LIMIT 10
 	`)
 	if providerRows != nil {
-		defer providerRows.Close()
 		for providerRows.Next() {
 			var provider string
 			var cnt int
 			providerRows.Scan(&provider, &cnt)
 			providers[provider] = cnt
 		}
+		providerRows.Close()
 	}
+
+	tx.Commit()
 
 	writeJSON(w, http.StatusOK, map[string]any{
 		"total":          totalBiz,

--- a/internal/api/handlers_pipeline.go
+++ b/internal/api/handlers_pipeline.go
@@ -12,10 +12,32 @@ import (
 )
 
 func (s *Server) handlePipelineStats(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	// 10s budget — must exceed the 8s statement_timeout below so PG cancels
+	// the query first and we observe a clean error rather than a context-cancel.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Second)
+	defer cancel()
+
 	stats := map[string]any{}
 
-	// Table counts.
+	// Wrap big-table COUNT(*) in a single tx with statement_timeout so a slow
+	// query can't hold the manager's 2-conn pool open indefinitely (the cascade
+	// that was causing v2 endpoints to balas 500 with context deadline exceeded).
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("v1: pipeline-stats tx error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '8000'"); err != nil {
+		slog.Error("v1: pipeline-stats set timeout error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+
+	// Table counts. tables is compile-time only — no user input flows into the
+	// SQL string here, so fmt.Sprintf is safe.
 	tables := map[string]string{
 		"queries": "queries", "serp_jobs": "serp_jobs",
 		"enrichment_jobs": "enrichment_jobs", "emails": "emails",
@@ -23,9 +45,12 @@ func (s *Server) handlePipelineStats(w http.ResponseWriter, r *http.Request) {
 	}
 	for key, table := range tables {
 		var total int
-		s.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&total)
+		if err := tx.QueryRowContext(ctx, fmt.Sprintf("SELECT COUNT(*) FROM %s", table)).Scan(&total); err != nil {
+			slog.Warn("v1: pipeline-stats count failed", "table", table, "error", err)
+		}
 		stats[key+"_total"] = total
 	}
+	tx.Commit()
 
 	// Queue depths from Redis (buffers are LISTs, queries queue is sorted set).
 	queueStats := map[string]int64{}
@@ -41,11 +66,15 @@ func (s *Server) handlePipelineStats(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
+	// 18s — same budget as v2_response.v2RequestContext so the V1 dashboard
+	// won't outlive V2 requests. Statement timeout below is 15s; PG cancels first.
+	ctx, cancel := context.WithTimeout(r.Context(), 18*time.Second)
+	defer cancel()
 
-	// -- Queries --
+	// -- Queries (small table — runs outside the big tx since CSV-style status
+	// rollup is cheap and we want it to complete even if the tx hits timeout.) --
 	queries := map[string]int{}
-	qRows, _ := s.db.Query(`SELECT status, COUNT(*) FROM queries GROUP BY status`)
+	qRows, _ := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM queries GROUP BY status`)
 	if qRows != nil {
 		for qRows.Next() {
 			var status string
@@ -61,11 +90,28 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	queries["total"] = qTotal
 
+	// Big-table aggregates wrapped in a tx + statement_timeout to bound the
+	// time these can hold the manager's 2-conn pool. Without this V2 endpoints
+	// see 500 with context deadline exceeded when this handler runs slow.
+	tx, err := s.db.BeginTx(ctx, nil)
+	if err != nil {
+		slog.Error("v1: dashboard tx error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+	defer tx.Rollback()
+
+	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '15000'"); err != nil {
+		slog.Error("v1: dashboard set timeout error", "error", err)
+		writeJSON(w, http.StatusInternalServerError, map[string]string{"error": "internal server error"})
+		return
+	}
+
 	// -- SERP Jobs --
 	serp := map[string]any{}
 	var serpTotal, serpNew, serpProcessing, serpCompleted, serpFailed int
 	var serpURLsFound, serpPerHour, serpToday int
-	s.db.QueryRow(`
+	tx.QueryRowContext(ctx, `
 		SELECT
 			COUNT(*),
 			COUNT(*) FILTER (WHERE status = 'new'),
@@ -90,7 +136,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	enrich := map[string]any{}
 	var enrichTotal, enrichPending, enrichProcessing, enrichCompleted, enrichFailed, enrichDead int
 	var enrichPerHour, enrichToday int
-	s.db.QueryRow(`
+	tx.QueryRowContext(ctx, `
 		SELECT
 			COUNT(*),
 			COUNT(*) FILTER (WHERE status = 'pending'),
@@ -114,11 +160,11 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	// -- Contacts (from normalized tables) --
 	contacts := map[string]any{}
 	var totalEmails, uniqueEmails, emailsToday, emailsLastHour, uniqueDomains int
-	s.db.QueryRow(`SELECT COUNT(*) FROM emails`).Scan(&totalEmails)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails`).Scan(&totalEmails)
 	uniqueEmails = totalEmails // emails table has UNIQUE constraint, so total == unique
-	s.db.QueryRow(`SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'`).Scan(&emailsToday)
-	s.db.QueryRow(`SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'`).Scan(&emailsLastHour)
-	s.db.QueryRow(`SELECT COUNT(DISTINCT domain) FROM business_listings`).Scan(&uniqueDomains)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'`).Scan(&emailsToday)
+	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'`).Scan(&emailsLastHour)
+	tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT domain) FROM business_listings`).Scan(&uniqueDomains)
 
 	contacts["total_emails"] = totalEmails
 	contacts["unique_emails"] = uniqueEmails
@@ -126,7 +172,7 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	contacts["emails_per_hour"] = emailsLastHour
 
 	// Top email providers.
-	providerRows, _ := s.db.Query(`
+	providerRows, _ := tx.QueryContext(ctx, `
 		SELECT domain, COUNT(*) AS cnt
 		FROM emails
 		GROUP BY domain ORDER BY cnt DESC LIMIT 10
@@ -143,6 +189,8 @@ func (s *Server) handleDashboard(w http.ResponseWriter, r *http.Request) {
 	}
 	contacts["providers"] = providers
 	contacts["unique_domains"] = uniqueDomains
+
+	tx.Commit()
 
 	// -- Queues (Redis) --
 	queueMap := map[string]int64{}

--- a/internal/api/v2_filters_test.go
+++ b/internal/api/v2_filters_test.go
@@ -1,0 +1,115 @@
+package api
+
+import (
+	"net/url"
+	"strings"
+	"testing"
+)
+
+func TestBuildResultsFilter_NoParams(t *testing.T) {
+	q := url.Values{}
+	where, args, idx := buildResultsFilter(q)
+	if where != "WHERE 1=1" {
+		t.Fatalf("expected baseline WHERE 1=1, got %q", where)
+	}
+	if len(args) != 0 {
+		t.Fatalf("expected no args, got %d", len(args))
+	}
+	if idx != 1 {
+		t.Fatalf("expected argIdx=1, got %d", idx)
+	}
+}
+
+func TestBuildResultsFilter_Country(t *testing.T) {
+	q := url.Values{"country": {"id"}}
+	where, args, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "UPPER(bl.country) = UPPER($1)") {
+		t.Fatalf("country clause missing or wrong, got %q", where)
+	}
+	if len(args) != 1 || args[0] != "id" {
+		t.Fatalf("unexpected args: %v", args)
+	}
+}
+
+func TestBuildResultsFilter_City(t *testing.T) {
+	q := url.Values{"city": {"Berlin"}}
+	where, args, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "bl.city ILIKE $1") {
+		t.Fatalf("city clause missing, got %q", where)
+	}
+	if args[0] != "Berlin%" {
+		t.Fatalf("city must be prefix-wildcarded, got %v", args[0])
+	}
+}
+
+func TestBuildResultsFilter_HasPhone(t *testing.T) {
+	q := url.Values{"has_phone": {"true"}}
+	where, args, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "bl.phone IS NOT NULL AND bl.phone <> ''") {
+		t.Fatalf("has_phone clause missing, got %q", where)
+	}
+	if len(args) != 0 {
+		t.Fatalf("has_phone should not bind args, got %d", len(args))
+	}
+}
+
+func TestBuildResultsFilter_HasPhoneFalseIgnored(t *testing.T) {
+	q := url.Values{"has_phone": {"false"}}
+	where, _, _ := buildResultsFilter(q)
+	if strings.Contains(where, "phone") {
+		t.Fatalf("has_phone=false must not add a clause, got %q", where)
+	}
+}
+
+func TestBuildResultsFilter_HasSocial(t *testing.T) {
+	q := url.Values{"has_social": {"true"}}
+	where, _, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "bl.social_links IS NOT NULL") {
+		t.Fatalf("has_social clause missing, got %q", where)
+	}
+	if !strings.Contains(where, "NOT IN ('{}', '')") {
+		t.Fatalf("has_social must exclude empty jsonb objects, got %q", where)
+	}
+}
+
+func TestBuildResultsFilter_Combined(t *testing.T) {
+	q := url.Values{
+		"country":    {"DE"},
+		"city":       {"Berlin"},
+		"has_phone":  {"true"},
+		"has_social": {"true"},
+	}
+	where, args, idx := buildResultsFilter(q)
+	// 2 bound args (country + city); has_phone + has_social bind no args.
+	if len(args) != 2 {
+		t.Fatalf("expected 2 args (country + city), got %d: %v", len(args), args)
+	}
+	if idx != 3 {
+		t.Fatalf("expected argIdx=3 after 2 binds, got %d", idx)
+	}
+	for _, frag := range []string{"UPPER(bl.country)", "bl.city ILIKE", "bl.phone IS NOT NULL", "bl.social_links"} {
+		if !strings.Contains(where, frag) {
+			t.Fatalf("combined clause missing %q in %q", frag, where)
+		}
+	}
+}
+
+func TestResultsOrderBy_Whitelist(t *testing.T) {
+	cases := map[string]string{
+		"":              "ORDER BY bl.id DESC",
+		"id_desc":       "ORDER BY bl.id DESC",
+		"id_asc":        "ORDER BY bl.id ASC",
+		"updated_desc":  "ORDER BY bl.updated_at DESC, bl.id DESC",
+		"updated_asc":   "ORDER BY bl.updated_at ASC, bl.id ASC",
+		"created_desc":  "ORDER BY bl.created_at DESC, bl.id DESC",
+		"created_asc":   "ORDER BY bl.created_at ASC, bl.id ASC",
+		"DROP TABLE bl": "ORDER BY bl.id DESC", // unknown -> default
+		"random()":      "ORDER BY bl.id DESC",
+	}
+	for sort, want := range cases {
+		got := resultsOrderBy(sort)
+		if got != want {
+			t.Errorf("resultsOrderBy(%q) = %q, want %q", sort, got, want)
+		}
+	}
+}

--- a/internal/api/v2_filters_test.go
+++ b/internal/api/v2_filters_test.go
@@ -9,14 +9,51 @@ import (
 func TestBuildResultsFilter_NoParams(t *testing.T) {
 	q := url.Values{}
 	where, args, idx := buildResultsFilter(q)
-	if where != "WHERE 1=1" {
-		t.Fatalf("expected baseline WHERE 1=1, got %q", where)
+	// Default-safe: off_niche IS NOT TRUE is always applied unless
+	// include_off_niche=true. Without the safe default a consumer would see
+	// AutoDealer/Hotel/Dentist rows mixed in by default.
+	if !strings.Contains(where, "bl.off_niche IS NOT TRUE") {
+		t.Fatalf("default must include off_niche guard, got %q", where)
 	}
 	if len(args) != 0 {
-		t.Fatalf("expected no args, got %d", len(args))
+		t.Fatalf("expected no args for params-less call, got %d", len(args))
 	}
 	if idx != 1 {
 		t.Fatalf("expected argIdx=1, got %d", idx)
+	}
+}
+
+func TestBuildResultsFilter_IncludeOffNiche(t *testing.T) {
+	q := url.Values{"include_off_niche": {"true"}}
+	where, _, _ := buildResultsFilter(q)
+	if strings.Contains(where, "off_niche") {
+		t.Fatalf("include_off_niche=true must drop the off_niche clause, got %q", where)
+	}
+}
+
+func TestBuildResultsFilter_IncludeOffNicheOnlyTrue(t *testing.T) {
+	// Anything other than literal "true" preserves the default safe filter.
+	for _, v := range []string{"1", "yes", "on", "TRUE", ""} {
+		q := url.Values{"include_off_niche": {v}}
+		where, _, _ := buildResultsFilter(q)
+		if !strings.Contains(where, "off_niche IS NOT TRUE") {
+			t.Errorf("include_off_niche=%q should NOT disable off_niche filter (only 'true' opts in), got %q", v, where)
+		}
+	}
+}
+
+func TestBuildResultsFilter_Niche(t *testing.T) {
+	q := url.Values{"niche": {"yoga"}}
+	where, args, _ := buildResultsFilter(q)
+	if !strings.Contains(where, "bl.niche_category = $1") {
+		t.Fatalf("niche clause missing, got %q", where)
+	}
+	if len(args) != 1 || args[0] != "yoga" {
+		t.Fatalf("unexpected args: %v", args)
+	}
+	// And the off_niche default still applies — niche filter doesn't disable it.
+	if !strings.Contains(where, "off_niche IS NOT TRUE") {
+		t.Fatalf("niche filter must still respect off_niche default, got %q", where)
 	}
 }
 

--- a/internal/api/v2_handlers_queries.go
+++ b/internal/api/v2_handlers_queries.go
@@ -11,8 +11,19 @@ import (
 	"github.com/sadewadee/serp-scraper/internal/query"
 )
 
+// queriesCountTTL is the cache TTL for filtered COUNT(*) on queries.
+// 60s — list mutates only on manual create/retry, not in the hot path.
+const queriesCountTTL = 60 * time.Second
+
 // handleV2ListQueries returns paginated queries wrapped in V2 format.
+// COUNT is Redis-cached (60s TTL) and protected by a 10s statement_timeout.
+// On count timeout the handler still serves data with total=-1 sentinel — the
+// envelope's TotalKnown=false signals to consumers that pagination math is
+// unreliable, avoiding a cascade 500 on an ILIKE search hitting an unindexed scan.
 func (s *Server) handleV2ListQueries(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := v2RequestContext(r)
+	defer cancel()
+
 	q := r.URL.Query()
 	page := queryInt(q, "page", 1)
 	perPage := queryInt(q, "per_page", 50)
@@ -36,8 +47,10 @@ func (s *Server) handleV2ListQueries(w http.ResponseWriter, r *http.Request) {
 		argIdx++
 	}
 
-	var total int
-	s.db.QueryRow(fmt.Sprintf("SELECT COUNT(*) FROM queries %s", where), args...).Scan(&total)
+	total, err := s.cachedCount(ctx, "queries", where, args, queriesCountTTL, 10*time.Second)
+	if err != nil {
+		slog.Warn("v2: queries count failed (serving with -1 sentinel)", "error", err)
+	}
 
 	dataQuery := fmt.Sprintf(`
 		SELECT id, text, status, result_count, COALESCE(error_msg,''), created_at
@@ -47,7 +60,7 @@ func (s *Server) handleV2ListQueries(w http.ResponseWriter, r *http.Request) {
 	`, where, argIdx, argIdx+1)
 	args = append(args, perPage, offset)
 
-	rows, err := s.db.Query(dataQuery, args...)
+	rows, err := s.db.QueryContext(ctx, dataQuery, args...)
 	if err != nil {
 		slog.Error("v2: list queries error", "error", err)
 		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch queries")

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -537,7 +537,7 @@ func (s *Server) handleV2Download(w http.ResponseWriter, r *http.Request) {
 	if format == "csv" {
 		w.Header().Set("Content-Type", "text/csv")
 		w.Header().Set("Content-Disposition", "attachment; filename=results.csv")
-		fmt.Fprintln(w, "id,business_name,category,domain,website,address,location,phone,emails,email_count,valid_email_count,created_at")
+		fmt.Fprintln(w, "id,business_name,category,niche_category,off_niche,domain,website,address,location,phone,emails,email_count,valid_email_count,created_at")
 	} else {
 		w.Header().Set("Content-Type", "application/json")
 		w.Header().Set("Content-Disposition", "attachment; filename=results.json")
@@ -658,9 +658,10 @@ func (s *Server) handleV2Download(w http.ResponseWriter, r *http.Request) {
 		// Write batch to output.
 		for _, l := range batch {
 			if format == "csv" {
-				fmt.Fprintf(w, "%d,%s,%s,%s,%s,%s,%s,%s,%s,%d,%d,%s\n",
+				fmt.Fprintf(w, "%d,%s,%s,%s,%t,%s,%s,%s,%s,%s,%s,%d,%d,%s\n",
 					l.ID,
 					csvEscape(l.BusinessName), csvEscape(l.Category),
+					csvEscape(l.NicheCategory), l.OffNiche,
 					csvEscape(l.Domain), csvEscape(l.Website),
 					csvEscape(l.Address), csvEscape(l.Location),
 					csvEscape(l.Phone),

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -2,80 +2,24 @@ package api
 
 import (
 	"context"
-	"crypto/sha1"
 	"database/sql"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
 	"net/http"
 	"net/url"
-	"strconv"
 	"strings"
 	"time"
 
 	pq "github.com/lib/pq"
 )
 
-// resultsCountTTL is the Redis cache window for filtered COUNT(*) results.
-// Polling clients re-hit the same filter combo within this window for free.
+// resultsCountTTL is the cache TTL for filtered COUNT(*) on business_listings.
 const resultsCountTTL = 60 * time.Second
 
-// cachedFilteredCount returns COUNT(*) for the given WHERE+args, served from
-// Redis when fresh. On query timeout/error, returns (-1, err) so the caller can
-// still serve the page with a "many" sentinel instead of HTTP 500.
-//
-// Cache key shape: "v2:count:<sha1(where|args)>" — args serialized via fmt to
-// keep numbers/strings/timestamps stable across calls.
+// cachedFilteredCount is the existing call signature, now thin wrapper over cachedCount.
 func (s *Server) cachedFilteredCount(ctx context.Context, where string, args []any) (int, error) {
-	key := buildCountCacheKey(where, args)
-
-	if s.redis != nil {
-		if v, err := s.redis.Get(ctx, key).Result(); err == nil {
-			if n, perr := strconv.Atoi(v); perr == nil {
-				return n, nil
-			}
-		}
-	}
-
-	tx, err := s.db.BeginTx(ctx, nil)
-	if err != nil {
-		return -1, err
-	}
-	defer tx.Rollback()
-
-	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '12000'"); err != nil {
-		return -1, err
-	}
-
-	var total int
-	q := fmt.Sprintf("SELECT COUNT(*) FROM business_listings bl %s", where)
-	if err := tx.QueryRowContext(ctx, q, args...).Scan(&total); err != nil {
-		return -1, err
-	}
-	if err := tx.Commit(); err != nil {
-		// Commit failure means the COUNT result may be from a tx that did not
-		// fully reconcile — never cache it and signal the caller to skip.
-		return -1, err
-	}
-
-	if s.redis != nil {
-		// Best-effort SETEX; cache miss isn't worth failing the request over.
-		_ = s.redis.Set(ctx, key, strconv.Itoa(total), resultsCountTTL).Err()
-	}
-	return total, nil
-}
-
-// buildCountCacheKey hashes WHERE + args into a stable Redis key. Args are
-// formatted with %q so adjacent string values cannot transpose into the same
-// byte stream (e.g. ["a","bc"] and ["ab","c"] used to collide under %v).
-func buildCountCacheKey(where string, args []any) string {
-	h := sha1.New()
-	h.Write([]byte(where))
-	for _, a := range args {
-		fmt.Fprintf(h, "|%q|", a)
-	}
-	return "v2:count:" + hex.EncodeToString(h.Sum(nil))
+	return s.cachedCount(ctx, "business_listings bl", where, args, resultsCountTTL, 12*time.Second)
 }
 
 // buildResultsFilter builds a WHERE clause + args from query parameters.

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -57,8 +57,48 @@ func buildResultsFilter(q url.Values) (string, []any, int) {
 		args = append(args, "%"+search+"%")
 		argIdx++
 	}
+	if country := q.Get("country"); country != "" {
+		// Stored values are ISO alpha-2 ("ID", "DE", ...) — accept any case
+		// from the caller and normalize via UPPER on both sides.
+		where += fmt.Sprintf(" AND UPPER(bl.country) = UPPER($%d)", argIdx)
+		args = append(args, country)
+		argIdx++
+	}
+	if city := q.Get("city"); city != "" {
+		// Prefix ILIKE so "?city=Berlin" matches "Berlin", "Berlin-Mitte", etc.
+		// Cheaper than substring %x% and friendlier to a btree(city) index.
+		where += fmt.Sprintf(" AND bl.city ILIKE $%d", argIdx)
+		args = append(args, city+"%")
+		argIdx++
+	}
+	if hasPhone := q.Get("has_phone"); hasPhone == "true" {
+		where += " AND bl.phone IS NOT NULL AND bl.phone <> ''"
+	}
+	if hasSocial := q.Get("has_social"); hasSocial == "true" {
+		where += " AND bl.social_links IS NOT NULL AND bl.social_links::text NOT IN ('{}', '')"
+	}
 
 	return where, args, argIdx
+}
+
+// resultsOrderBy returns a safe ORDER BY clause for the results endpoint.
+// Whitelist-only to prevent SQL injection — q.Get("sort") is user input.
+// Defaults to id_desc for compat with the original hardcoded ordering.
+func resultsOrderBy(sort string) string {
+	switch sort {
+	case "id_asc":
+		return "ORDER BY bl.id ASC"
+	case "updated_desc":
+		return "ORDER BY bl.updated_at DESC, bl.id DESC"
+	case "updated_asc":
+		return "ORDER BY bl.updated_at ASC, bl.id ASC"
+	case "created_desc":
+		return "ORDER BY bl.created_at DESC, bl.id DESC"
+	case "created_asc":
+		return "ORDER BY bl.created_at ASC, bl.id ASC"
+	default:
+		return "ORDER BY bl.id DESC"
+	}
 }
 
 // handleV2ListResults returns paginated business listings with full email info.
@@ -118,6 +158,14 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		limit = perPage + 1
 	}
 
+	// Cursor mode is keyed on bl.id, so ?sort= only takes effect in OFFSET mode.
+	// Forcing id-order in cursor mode keeps the keyset boundary consistent —
+	// mixing sort keys with a cursor would skip or duplicate rows.
+	orderBy := "ORDER BY bl.id DESC"
+	if !useCursor {
+		orderBy = resultsOrderBy(q.Get("sort"))
+	}
+
 	// Query 1: Fetch paginated listings (all columns).
 	dataQuery := fmt.Sprintf(`
 		SELECT bl.id, COALESCE(bl.business_name,''), COALESCE(bl.category,''),
@@ -130,8 +178,8 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		       COALESCE(bl.tiktok,''), COALESCE(bl.youtube,''), COALESCE(bl.telegram,''),
 		       bl.source_query_id, bl.created_at, bl.updated_at
 		FROM business_listings bl %s
-		ORDER BY bl.id DESC
-		LIMIT $%d`, where, argIdx)
+		%s
+		LIMIT $%d`, where, orderBy, argIdx)
 	args = append(args, limit)
 	argIdx++
 

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -77,11 +77,45 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 
 	where, args, argIdx := buildResultsFilter(q)
 
-	// Count total via Redis-cached helper. On timeout/error the helper returns -1
+	// Cursor mode (?cursor=base64): keyset pagination — O(log N) at any depth
+	// via the existing bl.id PK index. Skips COUNT entirely and returns
+	// {next_cursor, has_more} instead of a total. Detected by presence of the
+	// cursor param; if absent we fall through to the existing OFFSET path so
+	// existing consumers keep working unchanged.
+	cursorParam := q.Get("cursor")
+	useCursor := cursorParam != ""
+
+	if useCursor {
+		cursorID, derr := decodeCursor(cursorParam)
+		if derr != nil {
+			writeV2Error(w, http.StatusBadRequest, "invalid_cursor", "cursor is malformed")
+			return
+		}
+		dir := q.Get("cursor_dir")
+		if dir == "prev" {
+			where += fmt.Sprintf(" AND bl.id > $%d", argIdx)
+		} else {
+			where += fmt.Sprintf(" AND bl.id < $%d", argIdx)
+		}
+		args = append(args, cursorID)
+		argIdx++
+	}
+
+	// Count only applies in OFFSET mode. On timeout/error the helper returns -1
 	// so we serve the page with a sentinel instead of 500.
-	total, err := s.cachedFilteredCount(ctx, where, args)
-	if err != nil {
-		slog.Warn("v2: count failed (returning -1 sentinel)", "error", err)
+	var total int
+	if !useCursor {
+		var err error
+		total, err = s.cachedFilteredCount(ctx, where, args)
+		if err != nil {
+			slog.Warn("v2: count failed (returning -1 sentinel)", "error", err)
+		}
+	}
+
+	// Cursor mode fetches perPage+1 to detect has_more without a second query.
+	limit := perPage
+	if useCursor {
+		limit = perPage + 1
 	}
 
 	// Query 1: Fetch paginated listings (all columns).
@@ -97,9 +131,14 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		       bl.source_query_id, bl.created_at, bl.updated_at
 		FROM business_listings bl %s
 		ORDER BY bl.id DESC
-		LIMIT $%d OFFSET $%d
-	`, where, argIdx, argIdx+1)
-	args = append(args, perPage, offset)
+		LIMIT $%d`, where, argIdx)
+	args = append(args, limit)
+	argIdx++
+
+	if !useCursor {
+		dataQuery += fmt.Sprintf(" OFFSET $%d", argIdx)
+		args = append(args, offset)
+	}
 
 	rows, err := s.db.QueryContext(ctx, dataQuery, args...)
 	if err != nil {
@@ -142,6 +181,15 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		l.Phone = phone
 		listings = append(listings, l)
 		listingIDs = append(listingIDs, l.ID)
+	}
+
+	// Cursor mode: detect has_more via the sentinel row, then trim it BEFORE
+	// the email batch fetch so we don't waste a query on a row we're dropping.
+	hasMore := false
+	if useCursor && len(listings) > perPage {
+		hasMore = true
+		listings = listings[:perPage]
+		listingIDs = listingIDs[:perPage]
 	}
 
 	// Query 2: Batch-fetch ALL email columns for those listing IDs.
@@ -199,6 +247,23 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 
 	if listings == nil {
 		listings = []V2BusinessListing{}
+	}
+
+	if useCursor {
+		// Cursor envelope: explicit fields instead of pagination meta. Skip
+		// writeV2Single because that wraps in "data" and we also need
+		// next_cursor + has_more at the same level as the JSON-RPC-ish v2 style.
+		var nextCursor string
+		if hasMore && len(listings) > 0 {
+			nextCursor = encodeCursor(listings[len(listings)-1].ID)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"data":        listings,
+			"next_cursor": nextCursor,
+			"has_more":    hasMore,
+		})
+		return
 	}
 
 	writeV2Paginated(w, listings, total, page, perPage)

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -77,6 +77,18 @@ func buildResultsFilter(q url.Values) (string, []any, int) {
 	if hasSocial := q.Get("has_social"); hasSocial == "true" {
 		where += " AND bl.social_links IS NOT NULL AND bl.social_links::text NOT IN ('{}', '')"
 	}
+	// off_niche default-filtered out so consumer doesn't see polluted rows
+	// (Hotel, AutoDealer, Dentist, ...) unless they explicitly opt in.
+	// `include_off_niche=true` opts in for full view; anything else preserves
+	// the default safe path.
+	if q.Get("include_off_niche") != "true" {
+		where += " AND bl.off_niche IS NOT TRUE"
+	}
+	if niche := q.Get("niche"); niche != "" {
+		where += fmt.Sprintf(" AND bl.niche_category = $%d", argIdx)
+		args = append(args, niche)
+		argIdx++
+	}
 
 	return where, args, argIdx
 }
@@ -169,6 +181,7 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 	// Query 1: Fetch paginated listings (all columns).
 	dataQuery := fmt.Sprintf(`
 		SELECT bl.id, COALESCE(bl.business_name,''), COALESCE(bl.category,''),
+		       COALESCE(bl.niche_category,''), COALESCE(bl.off_niche, FALSE),
 		       COALESCE(bl.description,''), COALESCE(bl.website,''),
 		       bl.domain, bl.url, COALESCE(bl.social_links,'{}'),
 		       COALESCE(bl.address,''), COALESCE(bl.location,''),
@@ -203,7 +216,9 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		var socialLinksJSON []byte
 		var phone string
 		var phones pq.StringArray
-		err := rows.Scan(&l.ID, &l.BusinessName, &l.Category, &l.Description, &l.Website,
+		err := rows.Scan(&l.ID, &l.BusinessName, &l.Category,
+			&l.NicheCategory, &l.OffNiche,
+			&l.Description, &l.Website,
 			&l.Domain, &l.URL, &socialLinksJSON,
 			&l.Address, &l.Location, &l.City, &l.Country, &l.ContactName,
 			&l.OpeningHours, &l.Rating,
@@ -539,6 +554,7 @@ func (s *Server) handleV2Download(w http.ResponseWriter, r *http.Request) {
 
 		batchQuery := fmt.Sprintf(`
 			SELECT bl.id, COALESCE(bl.business_name,''), COALESCE(bl.category,''),
+			       COALESCE(bl.niche_category,''), COALESCE(bl.off_niche, FALSE),
 			       COALESCE(bl.description,''), COALESCE(bl.website,''),
 			       bl.domain, bl.url, COALESCE(bl.social_links,'{}'),
 			       COALESCE(bl.address,''), COALESCE(bl.location,''),
@@ -565,7 +581,9 @@ func (s *Server) handleV2Download(w http.ResponseWriter, r *http.Request) {
 			var socialLinksJSON []byte
 			var phone string
 			var phones pq.StringArray
-			if err := rows.Scan(&l.ID, &l.BusinessName, &l.Category, &l.Description, &l.Website,
+			if err := rows.Scan(&l.ID, &l.BusinessName, &l.Category,
+				&l.NicheCategory, &l.OffNiche,
+				&l.Description, &l.Website,
 				&l.Domain, &l.URL, &socialLinksJSON,
 				&l.Address, &l.Location, &l.City, &l.Country, &l.ContactName,
 				&l.OpeningHours, &l.Rating,

--- a/internal/api/v2_handlers_stats.go
+++ b/internal/api/v2_handlers_stats.go
@@ -1,16 +1,37 @@
 package api
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
+	"time"
 )
 
+// dashboardStatsCacheTTL is the Redis cache window for /api/v2/stats.
+// Dashboard polling clients re-hit within this window for ~free.
+const dashboardStatsCacheTTL = 30 * time.Second
+
 // handleV2DashboardStats returns the full dashboard stats wrapped in V2 format.
+// Backed by a 30s Redis cache with single-flight to prevent thundering herd
+// when the cache TTL expires under polling load.
 func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) {
 	ctx, cancel := v2RequestContext(r)
 	defer cancel()
 
-	// -- Queries --
+	s.cachedJSON(ctx, w,
+		"v2:stats:dashboard", dashboardStatsCacheTTL, 5*time.Second,
+		func() (any, error) {
+			return s.computeDashboardStats(ctx)
+		},
+	)
+}
+
+// computeDashboardStats runs the dashboard COUNT(*) queries against the live DB.
+// Wrapped by cachedJSON above. The V2 envelope {"data": ...} is constructed
+// inline because cachedJSON caches raw JSON bytes; going through writeV2Single
+// inside the cached path would re-wrap on every cache miss.
+func (s *Server) computeDashboardStats(ctx context.Context) (map[string]any, error) {
+	// -- Queries (small table, no timeout needed) --
 	queries := map[string]int{}
 	qRows, _ := s.db.QueryContext(ctx, `SELECT status, COUNT(*) FROM queries GROUP BY status`)
 	if qRows != nil {
@@ -28,26 +49,23 @@ func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) 
 	}
 	queries["total"] = qTotal
 
-	// -- SERP Jobs (with statement timeout) --
-	serp := map[string]any{}
-	var serpTotal, serpNew, serpProcessing, serpCompleted, serpFailed int
-	var serpURLsFound, serpPerHour, serpToday int
-
+	// -- Big-table aggregates: serp_jobs + enrichment_jobs + emails --
 	tx, err := s.db.BeginTx(ctx, nil)
 	if err != nil {
 		slog.Error("v2: dashboard tx error", "error", err)
-		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch dashboard stats")
-		return
+		return nil, err
 	}
 	defer tx.Rollback()
 
-	// 15s — serp_jobs (5.7M rows) and emails (828K+) need more headroom.
+	// 15s — serp_jobs (5.7M rows) and emails (828K+) need headroom.
 	if _, err := tx.ExecContext(ctx, "SET LOCAL statement_timeout = '15000'"); err != nil {
 		slog.Error("v2: set timeout error", "error", err)
-		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to set timeout")
-		return
+		return nil, err
 	}
 
+	serp := map[string]any{}
+	var serpTotal, serpNew, serpProcessing, serpCompleted, serpFailed int
+	var serpURLsFound, serpPerHour, serpToday int
 	tx.QueryRowContext(ctx, `
 		SELECT
 			COUNT(*),
@@ -69,7 +87,6 @@ func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) 
 	serp["rate_per_hour"] = serpPerHour
 	serp["today"] = serpToday
 
-	// -- Enrich Jobs --
 	enrich := map[string]any{}
 	var enrichTotal, enrichPending, enrichProcessing, enrichCompleted, enrichFailed, enrichDead int
 	var enrichPerHour, enrichToday int
@@ -94,20 +111,17 @@ func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) 
 	enrich["rate_per_hour"] = enrichPerHour
 	enrich["today"] = enrichToday
 
-	// -- Results --
 	results := map[string]any{}
 	var totalEmails, emailsToday, emailsLastHour, uniqueDomains int
 	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails`).Scan(&totalEmails)
 	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '24 hours'`).Scan(&emailsToday)
 	tx.QueryRowContext(ctx, `SELECT COUNT(*) FROM emails WHERE created_at > NOW() - INTERVAL '1 hour'`).Scan(&emailsLastHour)
 	tx.QueryRowContext(ctx, `SELECT COUNT(DISTINCT domain) FROM business_listings`).Scan(&uniqueDomains)
-
 	results["total_emails"] = totalEmails
 	results["emails_today"] = emailsToday
 	results["emails_per_hour"] = emailsLastHour
 	results["unique_domains"] = uniqueDomains
 
-	// Top email providers.
 	providerRows, _ := tx.QueryContext(ctx, `
 		SELECT domain, COUNT(*) AS cnt
 		FROM emails
@@ -127,20 +141,25 @@ func (s *Server) handleV2DashboardStats(w http.ResponseWriter, r *http.Request) 
 
 	tx.Commit()
 
-	// -- Queues (Redis) --
 	queueMap := map[string]int64{}
-	qd, _ := s.redis.ZCard(ctx, "serp:queue:queries").Result()
-	queueMap["serp:queue:queries"] = qd
-	sb, _ := s.redis.LLen(ctx, "serp:buffer").Result()
-	queueMap["serp:buffer"] = sb
-	eb, _ := s.redis.LLen(ctx, "enrich:buffer").Result()
-	queueMap["enrich:buffer"] = eb
+	if s.redis != nil {
+		qd, _ := s.redis.ZCard(ctx, "serp:queue:queries").Result()
+		queueMap["serp:queue:queries"] = qd
+		sb, _ := s.redis.LLen(ctx, "serp:buffer").Result()
+		queueMap["serp:buffer"] = sb
+		eb, _ := s.redis.LLen(ctx, "enrich:buffer").Result()
+		queueMap["enrich:buffer"] = eb
+	}
 
-	writeV2Single(w, map[string]any{
-		"queries": queries,
-		"serp":    serp,
-		"enrich":  enrich,
-		"results": results,
-		"queues":  queueMap,
-	})
+	// Wrap in V2 envelope manually since cachedJSON caches the raw bytes —
+	// returning the inner object alone would force callers to re-wrap on hit.
+	return map[string]any{
+		"data": map[string]any{
+			"queries": queries,
+			"serp":    serp,
+			"enrich":  enrich,
+			"results": results,
+			"queues":  queueMap,
+		},
+	}, nil
 }

--- a/internal/api/v2_types.go
+++ b/internal/api/v2_types.go
@@ -12,6 +12,8 @@ type V2BusinessListing struct {
 	URL             string          `json:"url"`
 	BusinessName    string          `json:"business_name"`
 	Category        string          `json:"category"`
+	NicheCategory   string          `json:"niche_category"`
+	OffNiche        bool            `json:"off_niche"`
 	Description     string          `json:"description"`
 	Address         string          `json:"address"`
 	Location        string          `json:"location"`

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -251,6 +251,25 @@ func runMigrations(db *sql.DB) error {
 		`ALTER TABLE enrichment_jobs ADD COLUMN IF NOT EXISTS raw_telegram TEXT`,
 		`CREATE INDEX IF NOT EXISTS idx_bl_country ON business_listings(country) WHERE country IS NOT NULL`,
 		`CREATE INDEX IF NOT EXISTS idx_bl_city ON business_listings(city) WHERE city IS NOT NULL`,
+		// Niche infrastructure (2026-05-22). The category column is contaminated:
+		// ~6K rows are explicit off-niche schema.org types (Hotel, AutoDealer,
+		// Dentist, Restaurant, ...) and ~41K are meta-keyword soup (>100 chars).
+		// off_niche flag lets the API default-filter to wellness/yoga/fitness
+		// results without DELETing data (memory feedback_never_drop_data.md).
+		// niche_category is the trigger-classified bucket (yoga, pilates,
+		// fitness, wellness, healing, ayurveda, spa, meditation) for the
+		// upcoming ?niche= filter. Both columns also wired into the upsert
+		// trigger below so new rows get tagged at insert time.
+		`ALTER TABLE business_listings ADD COLUMN IF NOT EXISTS off_niche BOOLEAN DEFAULT FALSE`,
+		`ALTER TABLE business_listings ADD COLUMN IF NOT EXISTS niche_category TEXT`,
+		// Partial index serves the default API path (?include_off_niche=false +
+		// optional ?niche=X). Skipping NULL keeps the index small on the long
+		// tail of rows whose category text didn't match any niche regex.
+		`CREATE INDEX IF NOT EXISTS idx_bl_niche_active ON business_listings(niche_category) WHERE off_niche IS NOT TRUE AND niche_category IS NOT NULL`,
+		// Separate index for the default-listing path (no niche filter, just
+		// off_niche=false). business_listings(id) PK already covers the
+		// ORDER BY, but the planner can use this partial idx for the WHERE.
+		`CREATE INDEX IF NOT EXISTS idx_bl_off_niche_false ON business_listings(id) WHERE off_niche IS NOT TRUE`,
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("db: schema fix 2026-04-27: %w (stmt: %s)", err, stmt)
@@ -297,15 +316,70 @@ func runMigrations(db *sql.DB) error {
 		    --    description and location were hardcoded NULL here, and
 		    --    country/city/contact_name/opening_hours/rating/multi-phone
 		    --    had no path at all — extracted then dropped on the floor.
+		    --
+		    -- Niche classifier inlined here (no Go code, per design):
+		    --   • off_niche = TRUE for known off-niche schema.org @type values
+		    --     (AutoDealer, Hotel, Restaurant, Dentist, ...) OR meta-keyword
+		    --     soup (raw_category length > 100). These are the patterns
+		    --     observed polluting business_listings.category — see plan.
+		    --   • niche_category bucketed from the union of raw_business_name +
+		    --     raw_page_title + raw_description against the same niche keyword
+		    --     whitelist used to generate queries in internal/query/wellness.go.
+		    --     \m...\M = word boundaries; LOWER() makes the match case-insensitive.
 		    INSERT INTO business_listings (domain, url, business_name, category, description,
 		        address, location, country, city, contact_name,
 		        phone, phones, website, page_title, social_links,
-		        opening_hours, rating, tiktok, youtube, telegram, source_query_id)
+		        opening_hours, rating, tiktok, youtube, telegram, source_query_id,
+		        off_niche, niche_category)
 		    VALUES (NEW.domain, NEW.url, NEW.raw_business_name, NEW.raw_category, NEW.raw_description,
 		        NEW.raw_address, NEW.raw_location, NEW.raw_country, NEW.raw_city, NEW.raw_contact_name,
 		        NEW.raw_phones[1], COALESCE(NEW.raw_phones, '{}'), NEW.url, NEW.raw_page_title, NEW.raw_social,
 		        NEW.raw_opening_hours, NEW.raw_rating, NEW.raw_tiktok, NEW.raw_youtube, NEW.raw_telegram,
-		        NEW.parent_query_id)
+		        NEW.parent_query_id,
+		        -- off_niche
+		        CASE
+		          WHEN NEW.raw_category IS NOT NULL AND LENGTH(NEW.raw_category) > 100 THEN TRUE
+		          WHEN NEW.raw_category IN (
+		            'AutoDealer','Hotel','Restaurant','Dentist','Physician',
+		            'RealEstateAgent','LegalService','HairSalon','BeautySalon',
+		            'TravelAgency','LodgingBusiness','GeneralContractor',
+		            'RoofingContractor','HomeAndConstructionBusiness',
+		            'MedicalClinic','MedicalBusiness'
+		          ) THEN TRUE
+		          ELSE FALSE
+		        END,
+		        -- niche_category
+		        CASE
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\myoga|asana|vinyasa|ashtanga|kundalini|iyengar|hatha|bikram|jivamukti\M' THEN 'yoga'
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\mpilates|reformer\M' THEN 'pilates'
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\mcrossfit|bootcamp|hiit|barre|spin\M' THEN 'fitness'
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\m(gym|fitness)\M' THEN 'fitness'
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\mmeditation|mindfulness|breathwork\M' THEN 'meditation'
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\mreiki|sound healing|energy healing|healing\M' THEN 'healing'
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\mayurved\M' THEN 'ayurveda'
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\m(spa|massage|thermal)\M' THEN 'spa'
+		          WHEN LOWER(COALESCE(NEW.raw_business_name,'') || ' ' ||
+		                     COALESCE(NEW.raw_page_title,'') || ' ' ||
+		                     COALESCE(NEW.raw_description,'')) ~ '\m(wellness|holistic)\M' THEN 'wellness'
+		          ELSE NULL
+		        END
+		    )
 		    ON CONFLICT (domain) DO UPDATE SET
 		        business_name = COALESCE(EXCLUDED.business_name, business_listings.business_name),
 		        category      = COALESCE(EXCLUDED.category, business_listings.category),
@@ -329,6 +403,12 @@ func runMigrations(db *sql.DB) error {
 		        tiktok        = COALESCE(EXCLUDED.tiktok, business_listings.tiktok),
 		        youtube       = COALESCE(EXCLUDED.youtube, business_listings.youtube),
 		        telegram      = COALESCE(EXCLUDED.telegram, business_listings.telegram),
+		        -- Niche fields: only promote a TRUE off_niche so a re-enrichment
+		        -- of a previously-tagged off-niche row never silently flips back
+		        -- to in-niche. niche_category COALESCEs in case re-enrich misses
+		        -- the keyword on a shorter page_title.
+		        off_niche      = (business_listings.off_niche OR EXCLUDED.off_niche),
+		        niche_category = COALESCE(business_listings.niche_category, EXCLUDED.niche_category),
 		        updated_at    = NOW();
 		    -- 2-step biz_id resolution. RETURNING id INTO biz_id was unreliable
 		    -- on the DO UPDATE path when all incoming values were NULL — the
@@ -1054,6 +1134,209 @@ func runMigrations(db *sql.DB) error {
 			"backup garbage country rows, convert country names to ISO, purge remaining garbage",
 		); err != nil {
 			slog.Warn("db: country garbage purge version record failed", "error", err)
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// One-shot migration 2026-05-22: Off-niche backfill cleanup.
+	//
+	// The trigger above started tagging NEW rows with off_niche + niche_category
+	// at insert time. Existing 779K rows in business_listings still carry the
+	// pollution from before the trigger landed: ~6K rows with explicit off-niche
+	// schema.org @type values (Hotel=1838, MedicalBusiness=787, MedicalClinic=730,
+	// Restaurant=666, Store=489, AutoDealer=332, Physician=321, BeautySalon=310,
+	// LegalService=269, TravelAgency=240, HairSalon=239, LodgingBusiness=236,
+	// Dentist=193, RealEstateAgent=174, HomeAndConstructionBusiness=118,
+	// GeneralContractor=26, RoofingContractor=12, HealthAndBeautyBusiness=804)
+	// plus ~41K rows where category is >100 chars (meta-keyword soup from
+	// <meta name="keywords"> instead of schema.org @type).
+	//
+	// Steps mirror the country garbage purge (versioned, gated, backup-first):
+	//   A. BACKUP — copy id+category+off_niche of all rows about to mutate.
+	//   B. FLAG — UPDATE off_niche=TRUE for rows matching either rule.
+	//   C. CLASSIFY — forward-fill niche_category for off_niche=FALSE rows
+	//                 whose category text matches the niche regex used by the
+	//                 trigger. No mutation for rows the regex doesn't match.
+	//   D. VERIFY — log post-cleanup counts.
+	//
+	// Dry-run gate: OFFNICHE_CLEANUP_DRY_RUN=true → count only, no mutation,
+	// version NOT recorded so the dry-run re-runs next deploy. Default OFF
+	// (cleanup runs). Per memory feedback_gated_flag_for_risky_changes.md.
+	// -------------------------------------------------------------------------
+	const offNicheCleanupVersion = "2026_05_22_off_niche_backfill"
+	var offNicheCleanupDone bool
+	if err := db.QueryRow(
+		`SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = $1)`, offNicheCleanupVersion,
+	).Scan(&offNicheCleanupDone); err != nil {
+		return fmt.Errorf("db: off-niche cleanup version check: %w", err)
+	}
+	if !offNicheCleanupDone {
+		// Off-niche schema.org @type list — kept in sync with the trigger above.
+		const offNicheTypes = `'AutoDealer','Hotel','Restaurant','Dentist','Physician',
+		'RealEstateAgent','LegalService','HairSalon','BeautySalon',
+		'TravelAgency','LodgingBusiness','GeneralContractor',
+		'RoofingContractor','HomeAndConstructionBusiness',
+		'MedicalClinic','MedicalBusiness','HealthAndBeautyBusiness'`
+
+		dryRun := os.Getenv("OFFNICHE_CLEANUP_DRY_RUN") == "true"
+		if dryRun {
+			slog.Info("db: off-niche cleanup DRY-RUN mode — counting only, no mutation")
+			var explicitOff, metaSoup int
+			_ = db.QueryRow(
+				`SELECT COUNT(*) FROM business_listings WHERE category IN (` + offNicheTypes + `) AND off_niche IS NOT TRUE`,
+			).Scan(&explicitOff)
+			_ = db.QueryRow(
+				`SELECT COUNT(*) FROM business_listings WHERE LENGTH(category) > 100 AND off_niche IS NOT TRUE`,
+			).Scan(&metaSoup)
+			slog.Info("db: off-niche cleanup dry-run counts",
+				"explicit_off_niche_to_flag", explicitOff,
+				"meta_keyword_soup_to_flag", metaSoup,
+				"total_affected", explicitOff+metaSoup,
+			)
+			// Do NOT record version — dry-run should re-run on next deploy.
+			return nil
+		}
+
+		// STEP A — BACKUP: capture pre-mutation state for everything we're
+		// about to flag. Append-safe via IF NOT EXISTS. Following the country
+		// purge integrity gate pattern: count live rows, create backup, verify
+		// backup count matches within 10% before mutating.
+		var liveAffected int
+		if err := db.QueryRow(`
+			SELECT COUNT(*) FROM business_listings
+			WHERE off_niche IS NOT TRUE
+			  AND (category IN (` + offNicheTypes + `) OR LENGTH(category) > 100)
+		`).Scan(&liveAffected); err != nil {
+			slog.Warn("db: off-niche cleanup pre-backup count failed — aborting", "error", err)
+			return nil
+		}
+		slog.Info("db: off-niche cleanup pre-backup count", "live_rows_to_flag", liveAffected)
+
+		if _, err := db.Exec(`
+			CREATE TABLE IF NOT EXISTS business_listings_offniche_backup_20260522 AS
+			SELECT id, category, off_niche, niche_category, updated_at
+			FROM business_listings
+			WHERE off_niche IS NOT TRUE
+			  AND (category IN (` + offNicheTypes + `) OR LENGTH(category) > 100)
+		`); err != nil {
+			slog.Warn("db: off-niche cleanup backup failed — aborting for safety", "error", err)
+			return nil
+		}
+		var backupCount int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings_offniche_backup_20260522`).Scan(&backupCount)
+		slog.Info("db: off-niche cleanup backup created", "backup_rows", backupCount, "expected_rows", liveAffected)
+
+		if backupCount == 0 && liveAffected > 0 {
+			slog.Warn("db: off-niche cleanup backup integrity FAILED — backup empty, aborting")
+			return nil
+		}
+		if liveAffected > 0 {
+			divergePct := float64(liveAffected-backupCount) / float64(liveAffected) * 100
+			if divergePct < 0 {
+				divergePct = -divergePct
+			}
+			if divergePct > 10 {
+				slog.Warn("db: off-niche cleanup backup integrity FAILED — count diverges, aborting",
+					"live_rows", liveAffected, "backup_rows", backupCount, "diverge_pct", divergePct)
+				return nil
+			}
+		}
+		slog.Info("db: off-niche cleanup backup integrity verified — proceeding with FLAG + CLASSIFY")
+
+		// STEP B — FLAG: set off_niche=TRUE for the two patterns. Wrapped in
+		// tx with statement_timeout (30s — partial idx_bl_niche_active helps,
+		// but the UPDATE touches both indexed and unindexed rows).
+		var flaggedRows int64
+		if txB, txErr := db.Begin(); txErr != nil {
+			slog.Warn("db: off-niche cleanup FLAG tx begin failed", "error", txErr)
+		} else {
+			txB.Exec(`SET LOCAL statement_timeout = '30000'`) //nolint:errcheck — advisory
+			res, flagErr := txB.Exec(`
+				UPDATE business_listings
+				SET off_niche = TRUE, updated_at = NOW()
+				WHERE off_niche IS NOT TRUE
+				  AND (category IN (` + offNicheTypes + `) OR LENGTH(category) > 100)
+			`)
+			if flagErr != nil {
+				slog.Warn("db: off-niche cleanup FLAG UPDATE failed — rolling back", "error", flagErr)
+				txB.Rollback() //nolint:errcheck
+			} else {
+				txB.Commit() //nolint:errcheck
+				flaggedRows, _ = res.RowsAffected()
+				slog.Info("db: off-niche cleanup FLAG applied", "rows_flagged", flaggedRows)
+			}
+		}
+
+		// STEP C — CLASSIFY: forward-fill niche_category for rows that survived
+		// the FLAG step (off_niche=FALSE). Mirrors the trigger CASE so old rows
+		// get the same classification as new rows. Single-pass UPDATE keyed by
+		// the same regex; rows that match no niche stay NULL.
+		var classifiedRows int64
+		if txC, txErr := db.Begin(); txErr != nil {
+			slog.Warn("db: off-niche cleanup CLASSIFY tx begin failed", "error", txErr)
+		} else {
+			txC.Exec(`SET LOCAL statement_timeout = '60000'`) //nolint:errcheck — advisory
+			res, classErr := txC.Exec(`
+				UPDATE business_listings SET niche_category = CASE
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\myoga|asana|vinyasa|ashtanga|kundalini|iyengar|hatha|bikram|jivamukti\M' THEN 'yoga'
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\mpilates|reformer\M' THEN 'pilates'
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\mcrossfit|bootcamp|hiit|barre|spin\M' THEN 'fitness'
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\m(gym|fitness)\M' THEN 'fitness'
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\mmeditation|mindfulness|breathwork\M' THEN 'meditation'
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\mreiki|sound healing|energy healing|healing\M' THEN 'healing'
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\mayurved\M' THEN 'ayurveda'
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\m(spa|massage|thermal)\M' THEN 'spa'
+				  WHEN LOWER(COALESCE(business_name,'') || ' ' ||
+				             COALESCE(page_title,'') || ' ' ||
+				             COALESCE(description,'')) ~ '\m(wellness|holistic)\M' THEN 'wellness'
+				  ELSE niche_category
+				END
+				WHERE off_niche IS NOT TRUE
+				  AND niche_category IS NULL
+			`)
+			if classErr != nil {
+				slog.Warn("db: off-niche cleanup CLASSIFY UPDATE failed — rolling back", "error", classErr)
+				txC.Rollback() //nolint:errcheck
+			} else {
+				txC.Commit() //nolint:errcheck
+				classifiedRows, _ = res.RowsAffected()
+				slog.Info("db: off-niche cleanup CLASSIFY applied", "rows_classified", classifiedRows)
+			}
+		}
+
+		// STEP D — VERIFY.
+		var finalOffNiche, finalClassified, finalUnclassified int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS TRUE`).Scan(&finalOffNiche)
+		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS NOT TRUE AND niche_category IS NOT NULL`).Scan(&finalClassified)
+		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS NOT TRUE AND niche_category IS NULL`).Scan(&finalUnclassified)
+		slog.Info("db: off-niche cleanup VERIFY",
+			"total_off_niche", finalOffNiche,
+			"total_in_niche_classified", finalClassified,
+			"total_in_niche_unclassified", finalUnclassified,
+		)
+
+		if _, err := db.Exec(
+			`INSERT INTO schema_migrations (version, notes) VALUES ($1, $2) ON CONFLICT (version) DO NOTHING`,
+			offNicheCleanupVersion,
+			"flag off_niche from category blacklist + meta-keyword-soup, then classify niche_category from name/title/description",
+		); err != nil {
+			slog.Warn("db: off-niche cleanup version record failed", "error", err)
 		}
 	}
 

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1,10 +1,14 @@
 package db
 
 import (
+	"context"
 	"database/sql"
 	"fmt"
 	"log/slog"
 	"os"
+	"regexp"
+	"strings"
+	"time"
 )
 
 const schema = `
@@ -162,10 +166,96 @@ CREATE TABLE IF NOT EXISTS workers (
 `
 
 // runMigrations applies incremental schema changes that are safe to re-run.
+// addColumnRe matches `ALTER TABLE <t> ADD COLUMN IF NOT EXISTS <c> ...` so we can
+// skip the statement when <c> already exists on <t>.
+var addColumnRe = regexp.MustCompile(`(?i)^\s*ALTER\s+TABLE\s+(\w+)\s+ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+(\w+)`)
+
+// existingColumns returns the set of "table.column" (lowercased) present in the
+// public schema. Used to skip ADD COLUMN IF NOT EXISTS migrations that would
+// otherwise take an ACCESS EXCLUSIVE lock on hot tables (enrichment_jobs/serp_jobs)
+// even as a no-op. Incident 2026-05-29: a reenrich boot ran the idempotent
+// ALTER batch, its no-op ALTER on enrichment_jobs queued for ACCESS EXCLUSIVE
+// behind the enrich hot path, and once queued it blocked all 21 enrich workers
+// behind it — boot exceeded the 120s healthcheck window, autoheal killed the
+// container, and it restart-looped, never finishing migrations. On a fully
+// migrated DB (production) every ADD COLUMN is a no-op, so skipping them means
+// boot takes ZERO hot-table DDL locks.
+func existingColumns(db *sql.DB) (map[string]bool, error) {
+	rows, err := db.Query(`SELECT table_name, column_name FROM information_schema.columns WHERE table_schema = 'public'`)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	set := make(map[string]bool)
+	for rows.Next() {
+		var t, c string
+		if err := rows.Scan(&t, &c); err != nil {
+			return nil, err
+		}
+		set[strings.ToLower(t)+"."+strings.ToLower(c)] = true
+	}
+	return set, rows.Err()
+}
+
+// execMigrationBatch runs a mixed DDL batch (ALTER ... ADD COLUMN + CREATE INDEX),
+// skipping ADD COLUMN statements whose column already exists (cols) so production
+// boots take no lock on hot tables. Surviving statements run on a dedicated
+// connection with a bounded lock_timeout: a genuinely-new column on a busy table
+// fails fast and is retried with backoff rather than wedging the hot path (and
+// cascading into an autoheal restart loop, incident 2026-05-29). errCtx labels
+// failures for the original call site.
+func execMigrationBatch(db *sql.DB, cols map[string]bool, errCtx string, stmts []string) error {
+	ctx := context.Background()
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return fmt.Errorf("db: %s: acquire conn: %w", errCtx, err)
+	}
+	defer conn.Close()
+	// Bound DDL lock waits. A no-op is instant; a real ALTER on a busy table must
+	// not block enrich/serp indefinitely. lock_timeout only bounds the lock
+	// acquisition, not the (metadata-only) ALTER itself.
+	if _, err := conn.ExecContext(ctx, `SET lock_timeout = '5s'`); err != nil {
+		return fmt.Errorf("db: %s: set lock_timeout: %w", errCtx, err)
+	}
+	for _, stmt := range stmts {
+		if m := addColumnRe.FindStringSubmatch(stmt); m != nil {
+			if cols[strings.ToLower(m[1])+"."+strings.ToLower(m[2])] {
+				continue // column present — skip the lock-taking no-op ALTER
+			}
+		}
+		var lastErr error
+		for attempt := 0; attempt < 6; attempt++ {
+			if _, lastErr = conn.ExecContext(ctx, stmt); lastErr == nil {
+				break
+			}
+			// 55P03 = lock_not_available (lock_timeout fired). Back off and retry;
+			// the hot path will eventually yield a lock window.
+			if !strings.Contains(lastErr.Error(), "lock_not_available") && !strings.Contains(lastErr.Error(), "55P03") {
+				break // not a lock timeout — real error, stop retrying
+			}
+			slog.Warn("db: migration DDL waiting on lock, retrying", "ctx", errCtx, "attempt", attempt+1, "stmt", stmt)
+			time.Sleep(time.Duration(attempt+1) * 2 * time.Second)
+		}
+		if lastErr != nil {
+			return fmt.Errorf("db: %s: %w (stmt: %s)", errCtx, lastErr, stmt)
+		}
+	}
+	return nil
+}
+
 func runMigrations(db *sql.DB) error {
 	// Enable pgcrypto for SHA-256 hashing in triggers.
 	if _, err := db.Exec(`CREATE EXTENSION IF NOT EXISTS pgcrypto`); err != nil {
 		return fmt.Errorf("db: create extension pgcrypto: %w", err)
+	}
+
+	// Snapshot existing columns so we skip idempotent ADD COLUMN no-ops that would
+	// otherwise take an ACCESS EXCLUSIVE lock on hot tables during worker boot
+	// (incident 2026-05-29 — see existingColumns doc). On a fresh DB this is empty
+	// and every ALTER runs; on a migrated DB it skips them all → zero-lock boot.
+	cols, err := existingColumns(db)
+	if err != nil {
+		return fmt.Errorf("db: snapshot existing columns: %w", err)
 	}
 
 	// GUARDRAIL: Legacy tables renamed to _backup, NEVER dropped.
@@ -173,9 +263,13 @@ func runMigrations(db *sql.DB) error {
 	db.Exec(`ALTER TABLE IF EXISTS enrich_jobs RENAME TO enrich_jobs_backup`)
 	db.Exec(`ALTER TABLE IF EXISTS websites RENAME TO websites_backup`)
 
-	// Add picked_at column to serp_jobs if missing (from redesign).
-	if _, err := db.Exec(`ALTER TABLE serp_jobs ADD COLUMN IF NOT EXISTS picked_at TIMESTAMPTZ`); err != nil {
-		return fmt.Errorf("db: add picked_at column: %w", err)
+	// Add picked_at column to serp_jobs if missing (from redesign). Routed through
+	// execMigrationBatch so a no-op skips the ACCESS EXCLUSIVE lock on the hot
+	// serp_jobs table (incident 2026-05-29).
+	if err := execMigrationBatch(db, cols, "add picked_at column", []string{
+		`ALTER TABLE serp_jobs ADD COLUMN IF NOT EXISTS picked_at TIMESTAMPTZ`,
+	}); err != nil {
+		return err
 	}
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_serp_feed ON serp_jobs(created_at) WHERE status = 'new' AND picked_at IS NULL`); err != nil {
 		return fmt.Errorf("db: create idx_serp_feed: %w", err)
@@ -213,16 +307,14 @@ func runMigrations(db *sql.DB) error {
 	}
 
 	// Add delta tracking columns to workers for per-heartbeat rate calculation.
-	for _, stmt := range []string{
+	if err := execMigrationBatch(db, cols, "worker delta columns", []string{
 		`ALTER TABLE workers ADD COLUMN IF NOT EXISTS pages_prev BIGINT DEFAULT 0`,
 		`ALTER TABLE workers ADD COLUMN IF NOT EXISTS emails_prev BIGINT DEFAULT 0`,
 		`ALTER TABLE workers ADD COLUMN IF NOT EXISTS pages_delta INT DEFAULT 0`,
 		`ALTER TABLE workers ADD COLUMN IF NOT EXISTS emails_delta INT DEFAULT 0`,
 		`ALTER TABLE workers ADD COLUMN IF NOT EXISTS delta_at TIMESTAMPTZ`,
-	} {
-		if _, err := db.Exec(stmt); err != nil {
-			return fmt.Errorf("db: worker delta columns: %w", err)
-		}
+	}); err != nil {
+		return err
 	}
 
 	// Schema fix 2026-04-27: extraction layer captured fields that the trigger
@@ -231,7 +323,7 @@ func runMigrations(db *sql.DB) error {
 	// Add missing columns + raw_* counterparts; the trigger update later in
 	// this file forwards them. opening_hours/rating remain optional — they
 	// stay null when extraction misses them.
-	for _, stmt := range []string{
+	if err := execMigrationBatch(db, cols, "schema fix 2026-04-27", []string{
 		`ALTER TABLE business_listings ADD COLUMN IF NOT EXISTS country TEXT`,
 		`ALTER TABLE business_listings ADD COLUMN IF NOT EXISTS city TEXT`,
 		`ALTER TABLE business_listings ADD COLUMN IF NOT EXISTS contact_name TEXT`,
@@ -269,10 +361,8 @@ func runMigrations(db *sql.DB) error {
 		// the pool. CONCURRENTLY uses ShareUpdateExclusiveLock instead, which
 		// doesn't block concurrent writes. Cannot live inside this batch since
 		// CONCURRENTLY is illegal inside a transaction block.
-	} {
-		if _, err := db.Exec(stmt); err != nil {
-			return fmt.Errorf("db: schema fix 2026-04-27: %w (stmt: %s)", err, stmt)
-		}
+	}); err != nil {
+		return err
 	}
 
 	// Niche indexes — created CONCURRENTLY outside any tx (CLAUDE.md /

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -861,11 +861,15 @@ func runMigrations(db *sql.DB) error {
 		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings_country_backup_20260512`).Scan(&backupCount)
 		slog.Info("db: country garbage purge backup created", "backup_rows", backupCount)
 
-		// STEP B — CONVERT: salvage rows where country is a full country name
-		// (e.g. "Portugal" → 'PT', "Ireland" → 'IE'). These are real data
-		// missed by tier1 normalize. Only rows not already in ISO alpha-2.
+		// STEP B — CONVERT: salvage all recognizable country names and common
+		// aliases not in the ISO alpha-2 set. Covers:
+		//   • Spelled-out names (>4 chars): Portugal, Ireland, Croatia, etc.
+		//   • Short country names (3-4 chars): Peru, Cuba, Oman, Laos
+		//   • Common aliases (2 chars): UK → GB
+		// The CASE uses ELSE country (not NULL) so unrecognized values pass
+		// through unchanged — they are caught by STEP C.
 		// Uses an explicit transaction so SET LOCAL statement_timeout applies
-		// only to this UPDATE (max 2,624 rows, index scan on country).
+		// only to this UPDATE (~2,812 rows after adding UK+Peru).
 		if txB, txErr := db.Begin(); txErr != nil {
 			slog.Warn("db: country garbage purge convert tx begin failed", "error", txErr)
 		} else {
@@ -873,6 +877,21 @@ func runMigrations(db *sql.DB) error {
 			_, convErr := txB.Exec(`
 				UPDATE business_listings SET
 				  country = CASE LOWER(TRIM(country))
+				    -- 2-char aliases not in ISO alpha-2
+				    WHEN 'uk'              THEN 'GB'
+				    -- Short country names (3-4 chars)
+				    WHEN 'peru'            THEN 'PE'
+				    WHEN 'cuba'            THEN 'CU'
+				    WHEN 'iran'            THEN 'IR'
+				    WHEN 'iraq'            THEN 'IQ'
+				    WHEN 'oman'            THEN 'OM'
+				    WHEN 'laos'            THEN 'LA'
+				    WHEN 'fiji'            THEN 'FJ'
+				    WHEN 'mali'            THEN 'ML'
+				    WHEN 'chad'            THEN 'TD'
+				    WHEN 'togo'            THEN 'TG'
+				    WHEN 'guam'            THEN 'GU'
+				    -- Spelled-out country names (>4 chars)
 				    WHEN 'portugal'        THEN 'PT'
 				    WHEN 'ireland'         THEN 'IE'
 				    WHEN 'croatia'         THEN 'HR'
@@ -898,11 +917,45 @@ func runMigrations(db *sql.DB) error {
 				    WHEN 'sri lanka'       THEN 'LK'
 				    WHEN 'cambodia'        THEN 'KH'
 				    WHEN 'hong kong'       THEN 'HK'
+				    WHEN 'switzerland'     THEN 'CH'
+				    WHEN 'south africa'    THEN 'ZA'
+				    WHEN 'united arab emirates' THEN 'AE'
+				    WHEN 'saudi arabia'    THEN 'SA'
+				    WHEN 'united states'   THEN 'US'
+				    WHEN 'united kingdom'  THEN 'GB'
+				    WHEN 'indonesia'       THEN 'ID'
+				    WHEN 'australia'       THEN 'AU'
+				    WHEN 'canada'          THEN 'CA'
+				    WHEN 'germany'         THEN 'DE'
+				    WHEN 'france'          THEN 'FR'
+				    WHEN 'singapore'       THEN 'SG'
+				    WHEN 'malaysia'        THEN 'MY'
+				    WHEN 'thailand'        THEN 'TH'
+				    WHEN 'brazil'          THEN 'BR'
+				    WHEN 'mexico'          THEN 'MX'
+				    WHEN 'spain'           THEN 'ES'
+				    WHEN 'italy'           THEN 'IT'
+				    WHEN 'netherlands'     THEN 'NL'
+				    WHEN 'belgium'         THEN 'BE'
+				    WHEN 'sweden'          THEN 'SE'
+				    WHEN 'norway'          THEN 'NO'
+				    WHEN 'denmark'         THEN 'DK'
+				    WHEN 'finland'         THEN 'FI'
+				    WHEN 'poland'          THEN 'PL'
+				    WHEN 'turkey'          THEN 'TR'
+				    WHEN 'india'           THEN 'IN'
+				    WHEN 'china'           THEN 'CN'
+				    WHEN 'korea'           THEN 'KR'
+				    WHEN 'south korea'     THEN 'KR'
+				    WHEN 'vietnam'         THEN 'VN'
+				    WHEN 'philippines'     THEN 'PH'
+				    WHEN 'new zealand'     THEN 'NZ'
+				    WHEN 'japan'           THEN 'JP'
 				    ELSE country
 				  END,
 				  updated_at = NOW()
 				WHERE country IS NOT NULL
-				  AND length(country) > 4
+				  AND country != ''
 				  AND country NOT IN (` + plausibleAlpha2 + `)`)
 			if convErr != nil {
 				txB.Rollback() //nolint:errcheck

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -3,12 +3,15 @@ package db
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
 	"regexp"
 	"strings"
 	"time"
+
+	"github.com/lib/pq"
 )
 
 const schema = `
@@ -217,6 +220,12 @@ func execMigrationBatch(db *sql.DB, cols map[string]bool, errCtx string, stmts [
 	if _, err := conn.ExecContext(ctx, `SET lock_timeout = '5s'`); err != nil {
 		return fmt.Errorf("db: %s: set lock_timeout: %w", errCtx, err)
 	}
+	// Reset before the pinned connection returns to the pool. lib/pq does NOT
+	// issue RESET on pool return, so a session-level lock_timeout would leak onto
+	// pooled connections for the container's lifetime and make reconciler/persist
+	// queries that legitimately wait >5s fail with 55P03. defer runs LIFO, so this
+	// fires before conn.Close().
+	defer conn.ExecContext(ctx, `SET lock_timeout = DEFAULT`)
 	for _, stmt := range stmts {
 		if m := addColumnRe.FindStringSubmatch(stmt); m != nil {
 			if cols[strings.ToLower(m[1])+"."+strings.ToLower(m[2])] {
@@ -229,9 +238,11 @@ func execMigrationBatch(db *sql.DB, cols map[string]bool, errCtx string, stmts [
 				break
 			}
 			// 55P03 = lock_not_available (lock_timeout fired). Back off and retry;
-			// the hot path will eventually yield a lock window.
-			if !strings.Contains(lastErr.Error(), "lock_not_available") && !strings.Contains(lastErr.Error(), "55P03") {
-				break // not a lock timeout — real error, stop retrying
+			// the hot path will eventually yield a lock window. Any other error is
+			// real — stop and surface it so boot fails loudly.
+			var pqErr *pq.Error
+			if !errors.As(lastErr, &pqErr) || pqErr.Code != "55P03" {
+				break
 			}
 			slog.Warn("db: migration DDL waiting on lock, retrying", "ctx", errCtx, "attempt", attempt+1, "stmt", stmt)
 			time.Sleep(time.Duration(attempt+1) * 2 * time.Second)

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -262,17 +262,42 @@ func runMigrations(db *sql.DB) error {
 		// trigger below so new rows get tagged at insert time.
 		`ALTER TABLE business_listings ADD COLUMN IF NOT EXISTS off_niche BOOLEAN DEFAULT FALSE`,
 		`ALTER TABLE business_listings ADD COLUMN IF NOT EXISTS niche_category TEXT`,
-		// Partial index serves the default API path (?include_off_niche=false +
-		// optional ?niche=X). Skipping NULL keeps the index small on the long
-		// tail of rows whose category text didn't match any niche regex.
-		`CREATE INDEX IF NOT EXISTS idx_bl_niche_active ON business_listings(niche_category) WHERE off_niche IS NOT TRUE AND niche_category IS NOT NULL`,
-		// Separate index for the default-listing path (no niche filter, just
-		// off_niche=false). business_listings(id) PK already covers the
-		// ORDER BY, but the planner can use this partial idx for the WHERE.
-		`CREATE INDEX IF NOT EXISTS idx_bl_off_niche_false ON business_listings(id) WHERE off_niche IS NOT TRUE`,
+		// idx_bl_niche_active + idx_bl_off_niche_false are created BELOW with
+		// CONCURRENTLY (auditor P1 fix): plain CREATE INDEX takes ShareLock on
+		// business_listings (779K rows), and with 7 deploy containers racing
+		// db.Migrate() against PG_MAX_OPEN_CONNS=2 the lock contention saturates
+		// the pool. CONCURRENTLY uses ShareUpdateExclusiveLock instead, which
+		// doesn't block concurrent writes. Cannot live inside this batch since
+		// CONCURRENTLY is illegal inside a transaction block.
 	} {
 		if _, err := db.Exec(stmt); err != nil {
 			return fmt.Errorf("db: schema fix 2026-04-27: %w (stmt: %s)", err, stmt)
+		}
+	}
+
+	// Niche indexes — created CONCURRENTLY outside any tx (CLAUDE.md /
+	// CONCURRENTLY is illegal inside a tx block).
+	//
+	//   idx_bl_niche_active   — serves ?include_off_niche=false + ?niche=X.
+	//                            Skips NULL niche_category to keep idx small
+	//                            on the long tail of unclassified rows.
+	//   idx_bl_off_niche_false — serves the default-listing path (no niche
+	//                            filter, just off_niche=false). PK already
+	//                            covers ORDER BY bl.id, this partial idx
+	//                            backs the WHERE predicate.
+	//
+	// Failure handling: CONCURRENTLY can race with parallel deploys; one of
+	// the 7 containers will succeed, the rest will see IF NOT EXISTS and skip.
+	// We log+continue on error rather than failing the entire migration, since
+	// the partial idx is an optimization, not a correctness requirement (the
+	// planner falls back to PK scan + filter, slower but correct).
+	for _, stmt := range []string{
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bl_niche_active ON business_listings(niche_category) WHERE off_niche IS NOT TRUE AND niche_category IS NOT NULL`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bl_off_niche_false ON business_listings(id) WHERE off_niche IS NOT TRUE`,
+	} {
+		if _, err := db.Exec(stmt); err != nil {
+			slog.Warn("db: niche index CREATE CONCURRENTLY failed — continuing without it (planner will fall back to PK scan)",
+				"stmt", stmt, "error", err)
 		}
 	}
 

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -344,7 +344,7 @@ func runMigrations(db *sql.DB) error {
 		            'RealEstateAgent','LegalService','HairSalon','BeautySalon',
 		            'TravelAgency','LodgingBusiness','GeneralContractor',
 		            'RoofingContractor','HomeAndConstructionBusiness',
-		            'MedicalClinic','MedicalBusiness'
+		            'MedicalClinic','MedicalBusiness','HealthAndBeautyBusiness'
 		          ) THEN TRUE
 		          ELSE FALSE
 		        END,
@@ -1193,13 +1193,22 @@ func runMigrations(db *sql.DB) error {
 		// log how many rows the migration is about to flag, broken down by
 		// reason. No mutation yet — if the numbers look wrong, the operator
 		// can stop the container before STEPS B-D run.
+		// Wrapped in tx + statement_timeout per CLAUDE.md Invariant #2 —
+		// business_listings is 779K rows; a slow COUNT during deploy-restart
+		// autovacuum can stall both pool conns and starve the API.
 		var explicitOff, metaSoup int
-		_ = db.QueryRow(
-			`SELECT COUNT(*) FROM business_listings WHERE category IN (` + offNicheTypes + `) AND off_niche IS NOT TRUE`,
-		).Scan(&explicitOff)
-		_ = db.QueryRow(
-			`SELECT COUNT(*) FROM business_listings WHERE LENGTH(category) > 100 AND off_niche IS NOT TRUE`,
-		).Scan(&metaSoup)
+		if preTx, ptxErr := db.Begin(); ptxErr != nil {
+			slog.Warn("db: off-niche cleanup PRE-COUNT tx begin failed", "error", ptxErr)
+		} else {
+			preTx.Exec(`SET LOCAL statement_timeout = '5000'`) //nolint:errcheck — advisory
+			_ = preTx.QueryRow(
+				`SELECT COUNT(*) FROM business_listings WHERE category IN (` + offNicheTypes + `) AND off_niche IS NOT TRUE`,
+			).Scan(&explicitOff)
+			_ = preTx.QueryRow(
+				`SELECT COUNT(*) FROM business_listings WHERE LENGTH(category) > 100 AND off_niche IS NOT TRUE`,
+			).Scan(&metaSoup)
+			preTx.Rollback() //nolint:errcheck — read-only, nothing to commit
+		}
 		slog.Info("db: off-niche cleanup pre-count",
 			"explicit_off_niche_to_flag", explicitOff,
 			"meta_keyword_soup_to_flag", metaSoup,
@@ -1329,11 +1338,22 @@ func runMigrations(db *sql.DB) error {
 			}
 		}
 
-		// STEP E — VERIFY.
+		// STEP E — VERIFY. Wrapped in tx + statement_timeout per CLAUDE.md
+		// Invariant #2 (same reason as PRE-COUNT above). The partial indexes
+		// idx_bl_niche_active + idx_bl_off_niche_false back these COUNTs so
+		// the planner should pick index-only scans, but the timeout is the
+		// safety net for cases where the planner picks a seqscan instead
+		// (e.g. statistics not yet refreshed after the bulk UPDATEs above).
 		var finalOffNiche, finalClassified, finalUnclassified int
-		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS TRUE`).Scan(&finalOffNiche)
-		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS NOT TRUE AND niche_category IS NOT NULL`).Scan(&finalClassified)
-		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS NOT TRUE AND niche_category IS NULL`).Scan(&finalUnclassified)
+		if vTx, vtxErr := db.Begin(); vtxErr != nil {
+			slog.Warn("db: off-niche cleanup VERIFY tx begin failed", "error", vtxErr)
+		} else {
+			vTx.Exec(`SET LOCAL statement_timeout = '5000'`) //nolint:errcheck — advisory
+			_ = vTx.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS TRUE`).Scan(&finalOffNiche)
+			_ = vTx.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS NOT TRUE AND niche_category IS NOT NULL`).Scan(&finalClassified)
+			_ = vTx.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS NOT TRUE AND niche_category IS NULL`).Scan(&finalUnclassified)
+			vTx.Rollback() //nolint:errcheck — read-only, nothing to commit
+		}
 		slog.Info("db: off-niche cleanup VERIFY",
 			"total_off_niche", finalOffNiche,
 			"total_in_niche_classified", finalClassified,

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -846,6 +846,22 @@ func runMigrations(db *sql.DB) error {
 		// STEP A — BACKUP: capture all non-plausible country values before
 		// any mutation. Backup table is append-safe; IF NOT EXISTS prevents
 		// failure on re-run if backup already exists from a prior attempt.
+		//
+		// Integrity gate: count live garbage rows BEFORE creating the backup,
+		// then verify backup row count matches. If backup is empty or the count
+		// diverges by more than 10%, abort STEPS B and C to prevent data loss
+		// on a silent CREATE failure (e.g. table already existed with old data).
+		var liveGarbageCount int
+		if err := db.QueryRow(`
+			SELECT COUNT(*) FROM business_listings
+			WHERE country IS NOT NULL
+			  AND country != ''
+			  AND country NOT IN (` + plausibleAlpha2 + `)`).Scan(&liveGarbageCount); err != nil {
+			slog.Warn("db: country garbage purge pre-backup count failed — aborting", "error", err)
+			return nil
+		}
+		slog.Info("db: country garbage purge pre-backup count", "live_garbage_rows", liveGarbageCount)
+
 		_, err := db.Exec(`
 			CREATE TABLE IF NOT EXISTS business_listings_country_backup_20260512 AS
 			SELECT id, country, updated_at
@@ -859,7 +875,31 @@ func runMigrations(db *sql.DB) error {
 		}
 		var backupCount int
 		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings_country_backup_20260512`).Scan(&backupCount)
-		slog.Info("db: country garbage purge backup created", "backup_rows", backupCount)
+		slog.Info("db: country garbage purge backup created", "backup_rows", backupCount, "expected_rows", liveGarbageCount)
+
+		// Integrity gate: abort if backup is empty (total failure) or count
+		// diverges more than 10% from live count (partial failure / stale table).
+		// A 10% tolerance covers rows legitimately converted between the pre-count
+		// query and the CREATE TABLE AS SELECT (concurrent pipeline activity).
+		if backupCount == 0 && liveGarbageCount > 0 {
+			slog.Warn("db: country garbage purge backup integrity FAILED — backup is empty, aborting purge",
+				"live_garbage_rows", liveGarbageCount)
+			return nil
+		}
+		if liveGarbageCount > 0 {
+			divergePct := float64(liveGarbageCount-backupCount) / float64(liveGarbageCount) * 100
+			if divergePct < 0 {
+				divergePct = -divergePct
+			}
+			if divergePct > 10 {
+				slog.Warn("db: country garbage purge backup integrity FAILED — count diverges, aborting purge",
+					"live_garbage_rows", liveGarbageCount,
+					"backup_rows", backupCount,
+					"diverge_pct", divergePct)
+				return nil
+			}
+		}
+		slog.Info("db: country garbage purge backup integrity verified — proceeding with STEPS B and C")
 
 		// STEP B — CONVERT: salvage all recognizable country names and common
 		// aliases not in the ISO alpha-2 set. Covers:

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -4,6 +4,7 @@ import (
 	"database/sql"
 	"fmt"
 	"log/slog"
+	"os"
 )
 
 const schema = `
@@ -608,6 +609,358 @@ func runMigrations(db *sql.DB) error {
 			db.Exec(`INSERT INTO schema_migrations (version, notes) VALUES ($1, $2) ON CONFLICT (version) DO NOTHING`,
 				reenrichLockVersion, "add re_enrich_locked_at for multi-worker FOR UPDATE SKIP LOCKED claim")
 			slog.Info("db: reenrich lock migration applied")
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// 2026-05-12: Country regex hardening (Deliverable 1).
+	//
+	// Background: the original phase2Version recover_country step used
+	// `[A-Z]{2,3}` as the first alternative in the regex, which captured the
+	// last 2-3 uppercase characters of ANY string (e.g. "LS7 1AB" → "AB",
+	// "Den Haag" → "AAG", "Schönebach" → "ACH"). The stateCodeBlocklist only
+	// filtered US/AU/CA/BR state codes, so random suffixes like "AAG", "ACH",
+	// "ADO", "ADS" passed through.
+	//
+	// Fix: remove [A-Z]{2,3} entirely. Match only known full country names
+	// (same whitelist as before), then map them to ISO alpha-2 via CASE.
+	// The WHERE guard `(bl.country IS NULL OR bl.country = '')` is retained so
+	// this step only fills blanks — it will not overwrite any existing value.
+	//
+	// This step is intentionally idempotent: running it again on rows that
+	// already have a correct country is a no-op due to the WHERE guard.
+	// -------------------------------------------------------------------------
+	const countryRegexHardenVersion = "2026_05_12_country_regex_hardening"
+	var countryRegexHardenDone bool
+	if err := db.QueryRow(
+		`SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = $1)`, countryRegexHardenVersion,
+	).Scan(&countryRegexHardenDone); err != nil {
+		return fmt.Errorf("db: country regex harden version check: %w", err)
+	}
+	if !countryRegexHardenDone {
+		// Match only spelled-out country names at end of address string.
+		// [A-Z]{2,3} removed entirely — it was too greedy and caused 8,177
+		// garbage rows (COM, AND, ACH, AAG, etc.) in production.
+		// The CASE below maps each matched name to its ISO 3166-1 alpha-2 code.
+		countryRegexHardenSQL := `
+		WITH parsed AS (
+		  SELECT ej.domain,
+		         (regexp_match(ej.raw_address,
+		           '(?i)(United States|United Kingdom|Indonesia|Australia|Canada|Germany|France|Singapore|Malaysia|Thailand|Japan|Brazil|Mexico|Spain|Italy|Netherlands|Belgium|Sweden|Norway|Denmark|Finland|Poland|Turkey|India|China|Korea|Vietnam|Philippines|New Zealand|Portugal|Ireland|Croatia|Austria|Chile|Colombia|Hungary|Romania|Greece|Taiwan|Morocco|Argentina|Egypt|Myanmar|Costa Rica|Panama|Kenya|Bahrain|Qatar|Nepal|Nigeria|Sri Lanka|Cambodia|Switzerland|South Africa|United Arab Emirates|Saudi Arabia|South Korea|New Zealand|Czech Republic|Hong Kong)\s*$'))[1]
+		         AS matched_name
+		  FROM enrichment_jobs ej
+		  WHERE ej.status = 'completed' AND ej.raw_address IS NOT NULL
+		)
+		UPDATE business_listings bl
+		SET country = CASE LOWER(parsed.matched_name)
+		  WHEN 'united states'           THEN 'US'
+		  WHEN 'united kingdom'          THEN 'GB'
+		  WHEN 'indonesia'               THEN 'ID'
+		  WHEN 'australia'               THEN 'AU'
+		  WHEN 'canada'                  THEN 'CA'
+		  WHEN 'germany'                 THEN 'DE'
+		  WHEN 'france'                  THEN 'FR'
+		  WHEN 'singapore'               THEN 'SG'
+		  WHEN 'malaysia'                THEN 'MY'
+		  WHEN 'thailand'                THEN 'TH'
+		  WHEN 'japan'                   THEN 'JP'
+		  WHEN 'brazil'                  THEN 'BR'
+		  WHEN 'mexico'                  THEN 'MX'
+		  WHEN 'spain'                   THEN 'ES'
+		  WHEN 'italy'                   THEN 'IT'
+		  WHEN 'netherlands'             THEN 'NL'
+		  WHEN 'belgium'                 THEN 'BE'
+		  WHEN 'sweden'                  THEN 'SE'
+		  WHEN 'norway'                  THEN 'NO'
+		  WHEN 'denmark'                 THEN 'DK'
+		  WHEN 'finland'                 THEN 'FI'
+		  WHEN 'poland'                  THEN 'PL'
+		  WHEN 'turkey'                  THEN 'TR'
+		  WHEN 'india'                   THEN 'IN'
+		  WHEN 'china'                   THEN 'CN'
+		  WHEN 'korea'                   THEN 'KR'
+		  WHEN 'south korea'             THEN 'KR'
+		  WHEN 'vietnam'                 THEN 'VN'
+		  WHEN 'philippines'             THEN 'PH'
+		  WHEN 'new zealand'             THEN 'NZ'
+		  WHEN 'portugal'                THEN 'PT'
+		  WHEN 'ireland'                 THEN 'IE'
+		  WHEN 'croatia'                 THEN 'HR'
+		  WHEN 'austria'                 THEN 'AT'
+		  WHEN 'chile'                   THEN 'CL'
+		  WHEN 'colombia'                THEN 'CO'
+		  WHEN 'hungary'                 THEN 'HU'
+		  WHEN 'romania'                 THEN 'RO'
+		  WHEN 'greece'                  THEN 'GR'
+		  WHEN 'taiwan'                  THEN 'TW'
+		  WHEN 'morocco'                 THEN 'MA'
+		  WHEN 'argentina'               THEN 'AR'
+		  WHEN 'egypt'                   THEN 'EG'
+		  WHEN 'myanmar'                 THEN 'MM'
+		  WHEN 'costa rica'              THEN 'CR'
+		  WHEN 'panama'                  THEN 'PA'
+		  WHEN 'kenya'                   THEN 'KE'
+		  WHEN 'bahrain'                 THEN 'BH'
+		  WHEN 'qatar'                   THEN 'QA'
+		  WHEN 'nepal'                   THEN 'NP'
+		  WHEN 'nigeria'                 THEN 'NG'
+		  WHEN 'sri lanka'               THEN 'LK'
+		  WHEN 'cambodia'                THEN 'KH'
+		  WHEN 'switzerland'             THEN 'CH'
+		  WHEN 'south africa'            THEN 'ZA'
+		  WHEN 'united arab emirates'    THEN 'AE'
+		  WHEN 'saudi arabia'            THEN 'SA'
+		  WHEN 'czech republic'          THEN 'CZ'
+		  WHEN 'hong kong'               THEN 'HK'
+		  ELSE NULL
+		END
+		FROM parsed
+		WHERE parsed.domain = bl.domain
+		  AND parsed.matched_name IS NOT NULL
+		  AND (bl.country IS NULL OR bl.country = '')`
+
+		res, err := db.Exec(countryRegexHardenSQL)
+		if err != nil {
+			slog.Warn("db: country regex hardening failed", "error", err)
+		} else {
+			n, _ := res.RowsAffected()
+			slog.Info("db: country regex hardening applied", "rows_updated", n)
+		}
+
+		if _, err := db.Exec(
+			`INSERT INTO schema_migrations (version, notes) VALUES ($1, $2) ON CONFLICT (version) DO NOTHING`,
+			countryRegexHardenVersion,
+			"fix recover_country regex: remove [A-Z]{2,3} greedy alternative, match known country names only",
+		); err != nil {
+			slog.Warn("db: country regex harden version record failed", "error", err)
+		}
+	}
+
+	// -------------------------------------------------------------------------
+	// 2026-05-12: Country garbage purge (Deliverable 2).
+	//
+	// Pre-condition: ~8,177 rows in business_listings have garbage country
+	// values (COM, AND, ACH, AAG, ONS, etc.) from the buggy [A-Z]{2,3}
+	// regex in the original phase2Version recover_country step.
+	// Additionally ~2,624 rows have spelled-out country names (Portugal,
+	// Ireland, etc.) that the tier1 normalize step missed.
+	//
+	// Steps:
+	//   A. BACKUP: CREATE TABLE ... AS SELECT — persists garbage values
+	//              before any mutation. Rollback: UPDATE bl SET country =
+	//              b.country FROM backup b WHERE bl.id = b.id.
+	//   B. CONVERT: salvage the spelled-out country names (Portugal → 'PT',
+	//               Ireland → 'IE', etc.) — these are real data, not garbage.
+	//   C. PURGE:   set country = NULL for remaining non-ISO-alpha2 values
+	//               (the 3-4 char uppercase garbage: COM, AND, ACH, etc.).
+	//   D. VERIFY:  log post-cleanup counts.
+	//
+	// Dry-run gate: set COUNTRY_CLEANUP_DRY_RUN=true to log affected counts
+	// without applying any UPDATE/CREATE. Default is OFF (cleanup runs).
+	// Per memory rule feedback_gated_flag_for_risky_changes.md — gate risky
+	// changes behind an off-by-default flag for first production run.
+	//
+	// Statement timeout: 30s per batch. The UPDATE touches at most ~8,177
+	// rows on a 483K-row table; with an index on country this is fast, but
+	// we cap it to avoid unexpected lock escalation.
+	// -------------------------------------------------------------------------
+	const countryGarbagePurgeVersion = "2026_05_12_country_garbage_purge"
+	var countryGarbagePurgeDone bool
+	if err := db.QueryRow(
+		`SELECT EXISTS(SELECT 1 FROM schema_migrations WHERE version = $1)`, countryGarbagePurgeVersion,
+	).Scan(&countryGarbagePurgeDone); err != nil {
+		return fmt.Errorf("db: country garbage purge version check: %w", err)
+	}
+	if !countryGarbagePurgeDone {
+		// plausibleAlpha2 is the inline SQL literal of the canonical ISO
+		// 3166-1 alpha-2 set. Kept as a SQL constant here because the
+		// iso3166Alpha2 Go map lives in internal/scraper (different package)
+		// and cannot be imported from internal/db without a circular dep.
+		// Generated from internal/scraper/contact.go:iso3166Alpha2.
+		// Rollback SQL (documented for ops):
+		//   UPDATE business_listings bl
+		//   SET country = b.country, updated_at = b.updated_at
+		//   FROM business_listings_country_backup_20260512 b
+		//   WHERE bl.id = b.id;
+		const plausibleAlpha2 = `'AD','AE','AF','AG','AI','AL','AM','AO',
+		'AQ','AR','AS','AT','AU','AW','AX','AZ',
+		'BA','BB','BD','BE','BF','BG','BH','BI',
+		'BJ','BL','BM','BN','BO','BQ','BR','BS',
+		'BT','BV','BW','BY','BZ','CA','CC','CD',
+		'CF','CG','CH','CI','CK','CL','CM','CN',
+		'CO','CR','CU','CV','CW','CX','CY','CZ',
+		'DE','DJ','DK','DM','DO','DZ','EC','EE',
+		'EG','EH','ER','ES','ET','FI','FJ','FK',
+		'FM','FO','FR','GA','GB','GD','GE','GF',
+		'GG','GH','GI','GL','GM','GN','GP','GQ',
+		'GR','GS','GT','GU','GW','GY','HK','HM',
+		'HN','HR','HT','HU','ID','IE','IL','IM',
+		'IN','IO','IQ','IR','IS','IT','JE','JM',
+		'JO','JP','KE','KG','KH','KI','KM','KN',
+		'KP','KR','KW','KY','KZ','LA','LB','LC',
+		'LI','LK','LR','LS','LT','LU','LV','LY',
+		'MA','MC','MD','ME','MF','MG','MH','MK',
+		'ML','MM','MN','MO','MP','MQ','MR','MS',
+		'MT','MU','MV','MW','MX','MY','MZ','NA',
+		'NC','NE','NF','NG','NI','NL','NO','NP',
+		'NR','NU','NZ','OM','PA','PE','PF','PG',
+		'PH','PK','PL','PM','PN','PR','PS','PT',
+		'PW','PY','QA','RE','RO','RS','RU','RW',
+		'SA','SB','SC','SD','SE','SG','SH','SI',
+		'SJ','SK','SL','SM','SN','SO','SR','SS',
+		'ST','SV','SX','SY','SZ','TC','TD','TF',
+		'TG','TH','TJ','TK','TL','TM','TN','TO',
+		'TR','TT','TV','TW','TZ','UA','UG','UM',
+		'US','UY','UZ','VA','VC','VE','VG','VI',
+		'VN','VU','WF','WS','YE','YT','ZA','ZM',
+		'ZW'`
+
+		dryRun := os.Getenv("COUNTRY_CLEANUP_DRY_RUN") == "true"
+		if dryRun {
+			slog.Info("db: country garbage purge DRY-RUN mode — counting affected rows, no mutation applied")
+
+			var garbageCount int
+			_ = db.QueryRow(`
+				SELECT COUNT(*) FROM business_listings
+				WHERE country IS NOT NULL
+				  AND country != ''
+				  AND country NOT IN (` + plausibleAlpha2 + `)`,
+			).Scan(&garbageCount)
+
+			var nameCount int
+			_ = db.QueryRow(`
+				SELECT COUNT(*) FROM business_listings
+				WHERE country IS NOT NULL AND length(country) > 4`,
+			).Scan(&nameCount)
+
+			slog.Info("db: country garbage purge dry-run counts",
+				"garbage_to_null", garbageCount-nameCount,
+				"names_to_convert", nameCount,
+				"total_affected", garbageCount,
+			)
+			// Do NOT record version — dry-run should re-run on next deploy
+			// when operator removes COUNTRY_CLEANUP_DRY_RUN=true.
+			return nil
+		}
+
+		// STEP A — BACKUP: capture all non-plausible country values before
+		// any mutation. Backup table is append-safe; IF NOT EXISTS prevents
+		// failure on re-run if backup already exists from a prior attempt.
+		_, err := db.Exec(`
+			CREATE TABLE IF NOT EXISTS business_listings_country_backup_20260512 AS
+			SELECT id, country, updated_at
+			FROM business_listings
+			WHERE country IS NOT NULL
+			  AND country != ''
+			  AND country NOT IN (` + plausibleAlpha2 + `)`)
+		if err != nil {
+			slog.Warn("db: country garbage purge backup failed — aborting purge for safety", "error", err)
+			return nil // abort this step; do not purge without backup
+		}
+		var backupCount int
+		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings_country_backup_20260512`).Scan(&backupCount)
+		slog.Info("db: country garbage purge backup created", "backup_rows", backupCount)
+
+		// STEP B — CONVERT: salvage rows where country is a full country name
+		// (e.g. "Portugal" → 'PT', "Ireland" → 'IE'). These are real data
+		// missed by tier1 normalize. Only rows not already in ISO alpha-2.
+		// Uses an explicit transaction so SET LOCAL statement_timeout applies
+		// only to this UPDATE (max 2,624 rows, index scan on country).
+		if txB, txErr := db.Begin(); txErr != nil {
+			slog.Warn("db: country garbage purge convert tx begin failed", "error", txErr)
+		} else {
+			txB.Exec(`SET LOCAL statement_timeout = '30000'`) //nolint:errcheck — advisory
+			_, convErr := txB.Exec(`
+				UPDATE business_listings SET
+				  country = CASE LOWER(TRIM(country))
+				    WHEN 'portugal'        THEN 'PT'
+				    WHEN 'ireland'         THEN 'IE'
+				    WHEN 'croatia'         THEN 'HR'
+				    WHEN 'austria'         THEN 'AT'
+				    WHEN 'chile'           THEN 'CL'
+				    WHEN 'colombia'        THEN 'CO'
+				    WHEN 'hungary'         THEN 'HU'
+				    WHEN 'romania'         THEN 'RO'
+				    WHEN 'greece'          THEN 'GR'
+				    WHEN 'taiwan'          THEN 'TW'
+				    WHEN 'morocco'         THEN 'MA'
+				    WHEN 'argentina'       THEN 'AR'
+				    WHEN 'egypt'           THEN 'EG'
+				    WHEN 'czech republic'  THEN 'CZ'
+				    WHEN 'myanmar'         THEN 'MM'
+				    WHEN 'costa rica'      THEN 'CR'
+				    WHEN 'panama'          THEN 'PA'
+				    WHEN 'kenya'           THEN 'KE'
+				    WHEN 'bahrain'         THEN 'BH'
+				    WHEN 'qatar'           THEN 'QA'
+				    WHEN 'nepal'           THEN 'NP'
+				    WHEN 'nigeria'         THEN 'NG'
+				    WHEN 'sri lanka'       THEN 'LK'
+				    WHEN 'cambodia'        THEN 'KH'
+				    WHEN 'hong kong'       THEN 'HK'
+				    ELSE country
+				  END,
+				  updated_at = NOW()
+				WHERE country IS NOT NULL
+				  AND length(country) > 4
+				  AND country NOT IN (` + plausibleAlpha2 + `)`)
+			if convErr != nil {
+				txB.Rollback() //nolint:errcheck
+				slog.Warn("db: country garbage purge convert step failed", "error", convErr)
+				// Non-fatal: purge step C still handles remaining garbage.
+			} else {
+				txB.Commit() //nolint:errcheck
+				slog.Info("db: country garbage purge convert step applied (names → ISO codes)")
+			}
+		}
+
+		// STEP C — PURGE: set country = NULL for all remaining non-ISO-alpha2
+		// values (garbage: COM, AND, ACH, AAG, ONS, etc.).
+		// Uses explicit transaction so SET LOCAL statement_timeout is scoped.
+		// Lock class: ROW EXCLUSIVE — not ACCESS EXCLUSIVE; concurrent SELECTs
+		// are unaffected. At most ~5,553 rows (3-4 char uppercase garbage).
+		var purgedRows int64
+		if txC, txErr := db.Begin(); txErr != nil {
+			slog.Warn("db: country garbage purge step C tx begin failed", "error", txErr)
+		} else {
+			txC.Exec(`SET LOCAL statement_timeout = '30000'`) //nolint:errcheck — advisory
+			res, purgeErr := txC.Exec(`
+				UPDATE business_listings
+				SET country = NULL, updated_at = NOW()
+				WHERE country IS NOT NULL
+				  AND country != ''
+				  AND country NOT IN (` + plausibleAlpha2 + `)`)
+			if purgeErr != nil {
+				txC.Rollback() //nolint:errcheck
+				slog.Warn("db: country garbage purge step C failed", "error", purgeErr)
+			} else {
+				txC.Commit() //nolint:errcheck
+				purgedRows, _ = res.RowsAffected()
+				slog.Info("db: country garbage purge applied", "rows_nulled", purgedRows)
+			}
+		}
+
+		// STEP D — VERIFY: post-cleanup count of remaining garbage.
+		var remainingGarbage int
+		_ = db.QueryRow(`
+			SELECT COUNT(*) FROM business_listings
+			WHERE country IS NOT NULL
+			  AND country != ''
+			  AND country NOT IN (` + plausibleAlpha2 + `)`,
+		).Scan(&remainingGarbage)
+		if remainingGarbage > 0 {
+			slog.Warn("db: country garbage purge: residual garbage detected after purge",
+				"remaining_garbage_rows", remainingGarbage)
+		} else {
+			slog.Info("db: country garbage purge: verified clean — zero garbage rows remain")
+		}
+
+		if _, err := db.Exec(
+			`INSERT INTO schema_migrations (version, notes) VALUES ($1, $2) ON CONFLICT (version) DO NOTHING`,
+			countryGarbagePurgeVersion,
+			"backup garbage country rows, convert country names to ISO, purge remaining garbage",
+		); err != nil {
+			slog.Warn("db: country garbage purge version record failed", "error", err)
 		}
 	}
 

--- a/internal/db/migrate.go
+++ b/internal/db/migrate.go
@@ -1151,17 +1151,28 @@ func runMigrations(db *sql.DB) error {
 	// plus ~41K rows where category is >100 chars (meta-keyword soup from
 	// <meta name="keywords"> instead of schema.org @type).
 	//
-	// Steps mirror the country garbage purge (versioned, gated, backup-first):
-	//   A. BACKUP — copy id+category+off_niche of all rows about to mutate.
-	//   B. FLAG — UPDATE off_niche=TRUE for rows matching either rule.
-	//   C. CLASSIFY — forward-fill niche_category for off_niche=FALSE rows
+	// Steps mirror the country garbage purge (versioned, backup-first), but
+	// without an env-var dry-run flag — the backup + integrity gate below
+	// (count-divergence check + abort-on-empty-backup) provides equivalent
+	// safety without operational toggles. Counts are logged BEFORE mutation
+	// so the operator can verify in the deploy log without code changes.
+	//   A. PRE-COUNT — log live affected row count (visible in deploy log).
+	//   B. BACKUP — copy id+category+off_niche of all rows about to mutate.
+	//      Integrity gate: backup must be non-empty AND within 10% of live count.
+	//   C. FLAG — UPDATE off_niche=TRUE for rows matching either rule.
+	//   D. CLASSIFY — forward-fill niche_category for off_niche=FALSE rows
 	//                 whose category text matches the niche regex used by the
 	//                 trigger. No mutation for rows the regex doesn't match.
-	//   D. VERIFY — log post-cleanup counts.
+	//   E. VERIFY — log post-cleanup counts.
 	//
-	// Dry-run gate: OFFNICHE_CLEANUP_DRY_RUN=true → count only, no mutation,
-	// version NOT recorded so the dry-run re-runs next deploy. Default OFF
-	// (cleanup runs). Per memory feedback_gated_flag_for_risky_changes.md.
+	// Rollback (documented for ops):
+	//   UPDATE business_listings bl
+	//   SET off_niche = b.off_niche,
+	//       niche_category = b.niche_category,
+	//       updated_at = b.updated_at
+	//   FROM business_listings_offniche_backup_20260522 b
+	//   WHERE bl.id = b.id;
+	//   DELETE FROM schema_migrations WHERE version = '2026_05_22_off_niche_backfill';
 	// -------------------------------------------------------------------------
 	const offNicheCleanupVersion = "2026_05_22_off_niche_backfill"
 	var offNicheCleanupDone bool
@@ -1178,26 +1189,24 @@ func runMigrations(db *sql.DB) error {
 		'RoofingContractor','HomeAndConstructionBusiness',
 		'MedicalClinic','MedicalBusiness','HealthAndBeautyBusiness'`
 
-		dryRun := os.Getenv("OFFNICHE_CLEANUP_DRY_RUN") == "true"
-		if dryRun {
-			slog.Info("db: off-niche cleanup DRY-RUN mode — counting only, no mutation")
-			var explicitOff, metaSoup int
-			_ = db.QueryRow(
-				`SELECT COUNT(*) FROM business_listings WHERE category IN (` + offNicheTypes + `) AND off_niche IS NOT TRUE`,
-			).Scan(&explicitOff)
-			_ = db.QueryRow(
-				`SELECT COUNT(*) FROM business_listings WHERE LENGTH(category) > 100 AND off_niche IS NOT TRUE`,
-			).Scan(&metaSoup)
-			slog.Info("db: off-niche cleanup dry-run counts",
-				"explicit_off_niche_to_flag", explicitOff,
-				"meta_keyword_soup_to_flag", metaSoup,
-				"total_affected", explicitOff+metaSoup,
-			)
-			// Do NOT record version — dry-run should re-run on next deploy.
-			return nil
-		}
+		// STEP A — PRE-COUNT: log counts so the operator sees in the deploy
+		// log how many rows the migration is about to flag, broken down by
+		// reason. No mutation yet — if the numbers look wrong, the operator
+		// can stop the container before STEPS B-D run.
+		var explicitOff, metaSoup int
+		_ = db.QueryRow(
+			`SELECT COUNT(*) FROM business_listings WHERE category IN (` + offNicheTypes + `) AND off_niche IS NOT TRUE`,
+		).Scan(&explicitOff)
+		_ = db.QueryRow(
+			`SELECT COUNT(*) FROM business_listings WHERE LENGTH(category) > 100 AND off_niche IS NOT TRUE`,
+		).Scan(&metaSoup)
+		slog.Info("db: off-niche cleanup pre-count",
+			"explicit_off_niche_to_flag", explicitOff,
+			"meta_keyword_soup_to_flag", metaSoup,
+			"total_affected", explicitOff+metaSoup,
+		)
 
-		// STEP A — BACKUP: capture pre-mutation state for everything we're
+		// STEP B — BACKUP: capture pre-mutation state for everything we're
 		// about to flag. Append-safe via IF NOT EXISTS. Following the country
 		// purge integrity gate pattern: count live rows, create backup, verify
 		// backup count matches within 10% before mutating.
@@ -1243,7 +1252,7 @@ func runMigrations(db *sql.DB) error {
 		}
 		slog.Info("db: off-niche cleanup backup integrity verified — proceeding with FLAG + CLASSIFY")
 
-		// STEP B — FLAG: set off_niche=TRUE for the two patterns. Wrapped in
+		// STEP C — FLAG: set off_niche=TRUE for the two patterns. Wrapped in
 		// tx with statement_timeout (30s — partial idx_bl_niche_active helps,
 		// but the UPDATE touches both indexed and unindexed rows).
 		var flaggedRows int64
@@ -1267,7 +1276,7 @@ func runMigrations(db *sql.DB) error {
 			}
 		}
 
-		// STEP C — CLASSIFY: forward-fill niche_category for rows that survived
+		// STEP D — CLASSIFY: forward-fill niche_category for rows that survived
 		// the FLAG step (off_niche=FALSE). Mirrors the trigger CASE so old rows
 		// get the same classification as new rows. Single-pass UPDATE keyed by
 		// the same regex; rows that match no niche stay NULL.
@@ -1320,7 +1329,7 @@ func runMigrations(db *sql.DB) error {
 			}
 		}
 
-		// STEP D — VERIFY.
+		// STEP E — VERIFY.
 		var finalOffNiche, finalClassified, finalUnclassified int
 		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS TRUE`).Scan(&finalOffNiche)
 		_ = db.QueryRow(`SELECT COUNT(*) FROM business_listings WHERE off_niche IS NOT TRUE AND niche_category IS NOT NULL`).Scan(&finalClassified)

--- a/internal/db/migrate_country_test.go
+++ b/internal/db/migrate_country_test.go
@@ -1,0 +1,299 @@
+package db
+
+// Tests for the country migration logic introduced in:
+//   - 2026_05_12_country_regex_hardening
+//   - 2026_05_12_country_garbage_purge
+//
+// These tests validate two properties WITHOUT a live DB:
+//
+//  1. The hardened regex does NOT capture [A-Z]{2,3} suffixes from arbitrary
+//     address strings (the original bug that created 8,177 garbage rows).
+//
+//  2. The CASE mapping table in both the regex-hardening SQL and the
+//     garbage-purge convert SQL maps every known country name to the correct
+//     ISO 3166-1 alpha-2 code (no typos, no missing entries, no mismatches).
+//
+// The regex under test mirrors the SQL regex used in countryRegexHardenSQL.
+// If the SQL regex is edited, the Go constant below must be updated to match.
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// hardenedRegex mirrors the regex alternative list used in
+// countryRegexHardenVersion SQL. The `(?i)` flag + `\s*$` anchor are retained.
+// [A-Z]{2,3} is intentionally ABSENT.
+const hardenedRegexPattern = `(?i)(United States|United Kingdom|Indonesia|Australia|Canada|Germany|France|Singapore|Malaysia|Thailand|Japan|Brazil|Mexico|Spain|Italy|Netherlands|Belgium|Sweden|Norway|Denmark|Finland|Poland|Turkey|India|China|Korea|Vietnam|Philippines|New Zealand|Portugal|Ireland|Croatia|Austria|Chile|Colombia|Hungary|Romania|Greece|Taiwan|Morocco|Argentina|Egypt|Myanmar|Costa Rica|Panama|Kenya|Bahrain|Qatar|Nepal|Nigeria|Sri Lanka|Cambodia|Switzerland|South Africa|United Arab Emirates|Saudi Arabia|South Korea|New Zealand|Czech Republic|Hong Kong)\s*$`
+
+// countryNameToISO mirrors the CASE blocks in both the regex-hardening SQL
+// and the garbage-purge convert SQL. Any name present in the SQL CASE must
+// appear here with the correct ISO code.
+var countryNameToISOTest = map[string]string{
+	"united states":        "US",
+	"united kingdom":       "GB",
+	"indonesia":            "ID",
+	"australia":            "AU",
+	"canada":               "CA",
+	"germany":              "DE",
+	"france":               "FR",
+	"singapore":            "SG",
+	"malaysia":             "MY",
+	"thailand":             "TH",
+	"japan":                "JP",
+	"brazil":               "BR",
+	"mexico":               "MX",
+	"spain":                "ES",
+	"italy":                "IT",
+	"netherlands":          "NL",
+	"belgium":              "BE",
+	"sweden":               "SE",
+	"norway":               "NO",
+	"denmark":              "DK",
+	"finland":              "FI",
+	"poland":               "PL",
+	"turkey":               "TR",
+	"india":                "IN",
+	"china":                "CN",
+	"korea":                "KR",
+	"south korea":          "KR",
+	"vietnam":              "VN",
+	"philippines":          "PH",
+	"new zealand":          "NZ",
+	"portugal":             "PT",
+	"ireland":              "IE",
+	"croatia":              "HR",
+	"austria":              "AT",
+	"chile":                "CL",
+	"colombia":             "CO",
+	"hungary":              "HU",
+	"romania":              "RO",
+	"greece":               "GR",
+	"taiwan":               "TW",
+	"morocco":              "MA",
+	"argentina":            "AR",
+	"egypt":                "EG",
+	"myanmar":              "MM",
+	"costa rica":           "CR",
+	"panama":               "PA",
+	"kenya":                "KE",
+	"bahrain":              "BH",
+	"qatar":                "QA",
+	"nepal":                "NP",
+	"nigeria":              "NG",
+	"sri lanka":            "LK",
+	"cambodia":             "KH",
+	"switzerland":          "CH",
+	"south africa":         "ZA",
+	"united arab emirates": "AE",
+	"saudi arabia":         "SA",
+	"czech republic":       "CZ",
+	"hong kong":            "HK",
+}
+
+// TestHardenedRegex_NoGarbageCapture verifies that the hardened regex does NOT
+// match address strings that produced garbage in the original buggy migration.
+// Each case was observed in production or is a representative edge case.
+func TestHardenedRegex_NoGarbageCapture(t *testing.T) {
+	re := regexp.MustCompile(hardenedRegexPattern)
+
+	noMatchCases := []struct {
+		name    string
+		address string
+	}{
+		{"uk postcode AB", "123 Main Street, Leeds, LS7 1AB"},
+		{"dutch city AAG", "Hofweg 1, Den Haag"},
+		{"german city ACH", "Bachstraße 5, Schönebach"},
+		{"spanish city ADO", "Calle Mayor 3, Maldonado"},
+		{"generic ads suffix ADS", "Texarkana escort ads"},
+		{"3-letter suffix COM", "42 Business Park, Telecom"},
+		{"3-letter suffix ONS", "1 Customer Relations"},
+		{"3-letter suffix ESS", "Fitness Progress"},
+		{"3-letter suffix MAP", "Roadmap Avenue"},
+		{"3-letter suffix ICA", "Botanica Street"},
+		{"3-letter suffix ORG", "123 Org blvd"},
+		{"3-letter suffix ION", "Application Center"},
+		{"3-letter suffix EET", "1 Meet Street"},
+		{"3-letter suffix ODE", "Zip Code Lane"},
+		{"3-letter suffix ICO", "El Economico"},
+		{"3-letter suffix RIS", "Chris Close"},
+		{"3-letter suffix OAD", "44 Broad Road"},
+		{"3-letter suffix TER", "1 Manchester Center"},
+		{"3-letter suffix NIA", "California"},
+		{"3-letter suffix URG", "Hamburg"},
+		{"plain 2-letter AB", "AB"},
+		{"plain 2-letter CD", "CD"},
+	}
+
+	for _, tc := range noMatchCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := re.FindStringSubmatch(tc.address)
+			if m != nil {
+				t.Errorf("hardened regex incorrectly matched %q in address %q; got capture=%q",
+					tc.address, tc.address, m[1])
+			}
+		})
+	}
+}
+
+// TestHardenedRegex_LegitimateCountriesMatch verifies that the hardened regex
+// DOES match known country names at the end of address strings.
+func TestHardenedRegex_LegitimateCountriesMatch(t *testing.T) {
+	re := regexp.MustCompile(hardenedRegexPattern)
+
+	matchCases := []struct {
+		name      string
+		address   string
+		wantLower string // expected match (lowercased for case-insensitive comparison)
+	}{
+		{"US full name", "123 Main St, New York, United States", "united states"},
+		{"GB full name", "10 Downing St, London, United Kingdom", "united kingdom"},
+		{"AU full name", "42 Sydney Rd, Sydney, Australia", "australia"},
+		{"DE full name", "Bahnhofstr. 1, Berlin, Germany", "germany"},
+		{"PT full name", "Rua da Liberdade 1, Lisbon, Portugal", "portugal"},
+		{"IE full name", "O'Connell St, Dublin, Ireland", "ireland"},
+		{"HR full name", "Ilica 1, Zagreb, Croatia", "croatia"},
+		{"NZ full name", "Queen St, Auckland, New Zealand", "new zealand"},
+		{"LK full name", "Main Rd, Colombo, Sri Lanka", "sri lanka"},
+		{"KH full name", "Monivong Blvd, Phnom Penh, Cambodia", "cambodia"},
+		{"case insensitive lower", "123 st, PORTUGAL", "portugal"},
+		{"trailing space", "Lisbon, Portugal  ", "portugal"},
+	}
+
+	for _, tc := range matchCases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := re.FindStringSubmatch(tc.address)
+			if m == nil {
+				t.Errorf("hardened regex failed to match legitimate country in %q", tc.address)
+				return
+			}
+			got := strings.ToLower(strings.TrimSpace(m[1]))
+			if got != tc.wantLower {
+				t.Errorf("got %q, want %q for address %q", got, tc.wantLower, tc.address)
+			}
+		})
+	}
+}
+
+// TestCountryNameToISO_Mapping validates that every entry in the CASE mapping
+// used by both SQL blocks has the correct ISO 3166-1 alpha-2 output.
+// Caught typos or wrong codes will fail here before reaching production.
+func TestCountryNameToISO_Mapping(t *testing.T) {
+	// canonical spot-checks: name → expected ISO (independently verified)
+	wantISO := map[string]string{
+		"portugal":             "PT",
+		"ireland":              "IE",
+		"croatia":              "HR",
+		"austria":              "AT",
+		"chile":                "CL",
+		"colombia":             "CO",
+		"hungary":              "HU",
+		"romania":              "RO",
+		"greece":               "GR",
+		"taiwan":               "TW",
+		"morocco":              "MA",
+		"argentina":            "AR",
+		"egypt":                "EG",
+		"myanmar":              "MM",
+		"costa rica":           "CR",
+		"panama":               "PA",
+		"kenya":                "KE",
+		"bahrain":              "BH",
+		"qatar":                "QA",
+		"nepal":                "NP",
+		"nigeria":              "NG",
+		"sri lanka":            "LK",
+		"cambodia":             "KH",
+		"switzerland":          "CH",
+		"south africa":         "ZA",
+		"united arab emirates": "AE",
+		"saudi arabia":         "SA",
+		"czech republic":       "CZ",
+		"hong kong":            "HK",
+		"united states":        "US",
+		"united kingdom":       "GB",
+		"indonesia":            "ID",
+		"australia":            "AU",
+		"canada":               "CA",
+		"germany":              "DE",
+		"france":               "FR",
+		"singapore":            "SG",
+		"malaysia":             "MY",
+		"thailand":             "TH",
+		"japan":                "JP",
+		"brazil":               "BR",
+		"mexico":               "MX",
+		"spain":                "ES",
+		"italy":                "IT",
+		"netherlands":          "NL",
+		"belgium":              "BE",
+		"sweden":               "SE",
+		"norway":               "NO",
+		"denmark":              "DK",
+		"finland":              "FI",
+		"poland":               "PL",
+		"turkey":               "TR",
+		"india":                "IN",
+		"china":                "CN",
+		"korea":                "KR",
+		"vietnam":              "VN",
+		"philippines":          "PH",
+		"new zealand":          "NZ",
+	}
+
+	for name, expectedISO := range wantISO {
+		t.Run(name, func(t *testing.T) {
+			got, ok := countryNameToISOTest[name]
+			if !ok {
+				t.Errorf("country name %q missing from mapping table", name)
+				return
+			}
+			if got != expectedISO {
+				t.Errorf("country name %q: got ISO %q, want %q", name, got, expectedISO)
+			}
+		})
+	}
+}
+
+// TestGarbagePattern_UppercaseGreedy demonstrates the original bug.
+// The original regex had [A-Z]{2,3} as the FIRST alternative, which caused it
+// to greedily capture the last uppercase chars of any address.
+// This test documents the bug (original regex WOULD match these) and confirms
+// the hardened regex does NOT.
+func TestGarbagePattern_UppercaseGreedy(t *testing.T) {
+	// Original buggy regex (for documentation of what the bug looked like)
+	buggyRe := regexp.MustCompile(`(?i)([A-Z]{2,3}|United States|United Kingdom|Indonesia|Australia|Canada|Germany|France|Singapore|Malaysia|Thailand|Japan|Brazil|Mexico|Spain|Italy|Netherlands|Belgium|Sweden|Norway|Denmark|Finland|Poland|Turkey|India|China|Korea|Vietnam|Philippines|New Zealand)\s*$`)
+	hardenedRe := regexp.MustCompile(hardenedRegexPattern)
+
+	garbageCases := []struct {
+		address       string
+		buggyCaptures string // what the buggy regex captured
+	}{
+		{"123 Main Street, Leeds, LS7 1AB", "AB"},
+		{"Hofweg 1, Den Haag", "AAG"},
+		{"Bachstraße 5, Schönebach", "ACH"},
+		{"Calle Mayor 3, Maldonado", "ADO"},
+		{"Texarkana escort ads", "ADS"},
+	}
+
+	for _, tc := range garbageCases {
+		t.Run(tc.buggyCaptures, func(t *testing.T) {
+			// Confirm the buggy regex DOES capture garbage (bug documentation)
+			buggyMatch := buggyRe.FindStringSubmatch(tc.address)
+			if buggyMatch == nil {
+				t.Logf("note: buggy regex didn't match %q (address may have changed)", tc.address)
+			} else if strings.ToUpper(buggyMatch[1]) != tc.buggyCaptures {
+				t.Logf("note: buggy regex captured %q not %q for %q",
+					buggyMatch[1], tc.buggyCaptures, tc.address)
+			}
+
+			// The hardened regex must NOT capture anything for these addresses
+			hardenedMatch := hardenedRe.FindStringSubmatch(tc.address)
+			if hardenedMatch != nil {
+				t.Errorf("hardened regex incorrectly matched %q in %q; capture=%q",
+					hardenedMatch[1], tc.address, hardenedMatch[1])
+			}
+		})
+	}
+}

--- a/internal/db/migrate_country_test.go
+++ b/internal/db/migrate_country_test.go
@@ -28,9 +28,24 @@ import (
 const hardenedRegexPattern = `(?i)(United States|United Kingdom|Indonesia|Australia|Canada|Germany|France|Singapore|Malaysia|Thailand|Japan|Brazil|Mexico|Spain|Italy|Netherlands|Belgium|Sweden|Norway|Denmark|Finland|Poland|Turkey|India|China|Korea|Vietnam|Philippines|New Zealand|Portugal|Ireland|Croatia|Austria|Chile|Colombia|Hungary|Romania|Greece|Taiwan|Morocco|Argentina|Egypt|Myanmar|Costa Rica|Panama|Kenya|Bahrain|Qatar|Nepal|Nigeria|Sri Lanka|Cambodia|Switzerland|South Africa|United Arab Emirates|Saudi Arabia|South Korea|New Zealand|Czech Republic|Hong Kong)\s*$`
 
 // countryNameToISO mirrors the CASE blocks in both the regex-hardening SQL
-// and the garbage-purge convert SQL. Any name present in the SQL CASE must
-// appear here with the correct ISO code.
+// and the garbage-purge STEP B convert SQL. Any name present in the SQL CASE
+// must appear here with the correct ISO code.
 var countryNameToISOTest = map[string]string{
+	// 2-char aliases (not in ISO alpha-2 set itself)
+	"uk": "GB",
+	// Short country names (3-4 chars), verified by auditor scan
+	"peru": "PE",
+	"cuba": "CU",
+	"iran": "IR",
+	"iraq": "IQ",
+	"oman": "OM",
+	"laos": "LA",
+	"fiji": "FJ",
+	"mali": "ML",
+	"chad": "TD",
+	"togo": "TG",
+	"guam": "GU",
+	// Spelled-out country names (>4 chars)
 	"united states":        "US",
 	"united kingdom":       "GB",
 	"indonesia":            "ID",
@@ -240,6 +255,19 @@ func TestCountryNameToISO_Mapping(t *testing.T) {
 		"vietnam":              "VN",
 		"philippines":          "PH",
 		"new zealand":          "NZ",
+		// Short names and aliases added by auditor P1 fix
+		"uk":   "GB",
+		"peru": "PE",
+		"cuba": "CU",
+		"iran": "IR",
+		"iraq": "IQ",
+		"oman": "OM",
+		"laos": "LA",
+		"fiji": "FJ",
+		"mali": "ML",
+		"chad": "TD",
+		"togo": "TG",
+		"guam": "GU",
 	}
 
 	for name, expectedISO := range wantISO {

--- a/internal/db/migrate_lockfix_test.go
+++ b/internal/db/migrate_lockfix_test.go
@@ -1,0 +1,41 @@
+package db
+
+import "testing"
+
+// Guards the boot-migration lock-stall fix (incident 2026-05-29): addColumnRe must
+// reliably pull <table> and <column> out of an "ALTER TABLE ... ADD COLUMN IF NOT
+// EXISTS ..." statement so execMigrationBatch can skip the no-op (and its
+// ACCESS EXCLUSIVE lock on hot tables) when the column already exists. It must NOT
+// match other DDL (CREATE INDEX, plain ALTER) — those always run.
+func TestAddColumnRe(t *testing.T) {
+	matches := map[string][2]string{
+		`ALTER TABLE serp_jobs ADD COLUMN IF NOT EXISTS picked_at TIMESTAMPTZ`:              {"serp_jobs", "picked_at"},
+		`ALTER TABLE enrichment_jobs ADD COLUMN IF NOT EXISTS raw_country TEXT`:             {"enrichment_jobs", "raw_country"},
+		`ALTER TABLE business_listings ADD COLUMN IF NOT EXISTS phones TEXT[] DEFAULT '{}'`: {"business_listings", "phones"},
+		"\t\tALTER TABLE workers ADD COLUMN IF NOT EXISTS pages_prev BIGINT DEFAULT 0":      {"workers", "pages_prev"},
+		`alter table foo add column if not exists bar int`:                                  {"foo", "bar"}, // case-insensitive
+	}
+	for stmt, want := range matches {
+		m := addColumnRe.FindStringSubmatch(stmt)
+		if m == nil {
+			t.Errorf("expected match for %q, got none", stmt)
+			continue
+		}
+		if m[1] != want[0] || m[2] != want[1] {
+			t.Errorf("for %q: got table=%q col=%q, want table=%q col=%q", stmt, m[1], m[2], want[0], want[1])
+		}
+	}
+
+	nonMatches := []string{
+		`CREATE INDEX IF NOT EXISTS idx_bl_country ON business_listings(country) WHERE country IS NOT NULL`,
+		`CREATE INDEX CONCURRENTLY IF NOT EXISTS idx_bl_niche_active ON business_listings(niche_category)`,
+		`ALTER TABLE serp_jobs ADD COLUMN picked_at TIMESTAMPTZ`, // no IF NOT EXISTS -> not our skip case
+		`ALTER TABLE IF EXISTS enrich_jobs RENAME TO enrich_jobs_backup`,
+		`UPDATE emails SET domain = split_part(email, '@', 2)`,
+	}
+	for _, stmt := range nonMatches {
+		if m := addColumnRe.FindStringSubmatch(stmt); m != nil {
+			t.Errorf("expected NO match for %q, got table=%q col=%q", stmt, m[1], m[2])
+		}
+	}
+}

--- a/internal/db/migrate_niche_test.go
+++ b/internal/db/migrate_niche_test.go
@@ -1,0 +1,187 @@
+package db
+
+// Tests for the niche classifier introduced in:
+//   - 2026_05_22_off_niche_backfill (one-shot cleanup migration)
+//   - trg_normalize_enrichment (per-row trigger CASE)
+//
+// Validates two properties WITHOUT a live DB:
+//
+//  1. The off-niche blacklist regex catches every category we said we'd flag
+//     (Hotel, AutoDealer, HealthAndBeautyBusiness, ...) — guards against the
+//     reviewer-caught HealthAndBeautyBusiness drift between the cleanup list
+//     and the trigger list.
+//
+//  2. The niche keyword regex bucks rows into the expected niche_category
+//     when the business name / page title / description matches a niche
+//     keyword, and stays NULL otherwise. Mirrors the SQL CASE.
+//
+// If the SQL CASE expressions in migrate.go change, the Go constants below
+// must be updated to match.
+
+import (
+	"regexp"
+	"strings"
+	"testing"
+)
+
+// offNicheBlacklist mirrors the IN (...) list in BOTH the trigger CASE
+// (migrate.go:342-348) AND the cleanup constant offNicheTypes (migrate.go:
+// 1175-1179). Both lists must stay in sync — if a category is added to one
+// it MUST be added to the other.
+var offNicheBlacklist = []string{
+	"AutoDealer", "Hotel", "Restaurant", "Dentist", "Physician",
+	"RealEstateAgent", "LegalService", "HairSalon", "BeautySalon",
+	"TravelAgency", "LodgingBusiness", "GeneralContractor",
+	"RoofingContractor", "HomeAndConstructionBusiness",
+	"MedicalClinic", "MedicalBusiness", "HealthAndBeautyBusiness",
+}
+
+// nicheKeywordRegex mirrors the per-niche regex alternatives in the SQL CASE
+// (both trigger AND cleanup STEP D). \m and \M are PostgreSQL word boundary
+// markers; Go regexp uses \b instead.
+var nicheKeywordRegex = map[string]string{
+	"yoga":       `(?i)\b(yoga|asana|vinyasa|ashtanga|kundalini|iyengar|hatha|bikram|jivamukti)\b`,
+	"pilates":    `(?i)\b(pilates|reformer)\b`,
+	"fitness":    `(?i)\b(crossfit|bootcamp|hiit|barre|spin|gym|fitness)\b`,
+	"meditation": `(?i)\b(meditation|mindfulness|breathwork)\b`,
+	"healing":    `(?i)\b(reiki|sound healing|energy healing|healing)\b`,
+	"ayurveda":   `(?i)\bayurved`,
+	"spa":        `(?i)\b(spa|massage|thermal)\b`,
+	"wellness":   `(?i)\b(wellness|holistic)\b`,
+}
+
+func TestOffNiche_BlacklistCoversReviewerExamples(t *testing.T) {
+	// The reviewer specifically called out HealthAndBeautyBusiness as missing
+	// from the trigger CASE. Both lists must include the high-volume categories
+	// observed polluting production data.
+	mustInclude := []string{
+		"AutoDealer",              // 332 rows
+		"Hotel",                   // 1838 rows
+		"Restaurant",              // 666 rows
+		"Dentist",                 // 193 rows
+		"HealthAndBeautyBusiness", // 804 rows — the reviewer-caught omission
+		"BeautySalon",             // 310 rows
+		"MedicalClinic",           // 730 rows
+		"MedicalBusiness",         // 787 rows
+	}
+	have := make(map[string]bool, len(offNicheBlacklist))
+	for _, c := range offNicheBlacklist {
+		have[c] = true
+	}
+	for _, c := range mustInclude {
+		if !have[c] {
+			t.Errorf("offNicheBlacklist missing %q — production has hundreds of rows of this @type", c)
+		}
+	}
+}
+
+func TestNicheClassifier_YogaKeywords(t *testing.T) {
+	yogaCases := []string{
+		"Sunrise Yoga Studio",
+		"Vinyasa Flow Center",
+		"ashtanga yoga teacher training",
+		"kundalini yoga and meditation",
+		"Bikram Yoga Bali",
+		"Hatha yoga for beginners",
+		"Jivamukti yoga school New York",
+	}
+	r := regexp.MustCompile(nicheKeywordRegex["yoga"])
+	for _, s := range yogaCases {
+		if !r.MatchString(s) {
+			t.Errorf("expected %q to match yoga regex but it did not", s)
+		}
+	}
+}
+
+func TestNicheClassifier_FitnessKeywords(t *testing.T) {
+	fitnessCases := []string{
+		"CrossFit Box Singapore",
+		"24 Hour Fitness",
+		"Bootcamp on the Beach",
+		"HIIT Class Manhattan",
+		"Barre Studio Brooklyn",
+		"Premier Gym Membership",
+	}
+	r := regexp.MustCompile(nicheKeywordRegex["fitness"])
+	for _, s := range fitnessCases {
+		if !r.MatchString(s) {
+			t.Errorf("expected %q to match fitness regex but it did not", s)
+		}
+	}
+}
+
+func TestNicheClassifier_WellnessKeywords(t *testing.T) {
+	wellnessCases := []string{
+		"Holistic Wellness Center",
+		"Sound Healing & Wellness",
+		"Holistic medicine clinic",
+	}
+	r := regexp.MustCompile(nicheKeywordRegex["wellness"])
+	for _, s := range wellnessCases {
+		if !r.MatchString(s) {
+			t.Errorf("expected %q to match wellness regex but it did not", s)
+		}
+	}
+}
+
+func TestNicheClassifier_AyurvedaPrefix(t *testing.T) {
+	// Ayurveda uses prefix match (ayurved) to cover "ayurveda" + "ayurvedic".
+	r := regexp.MustCompile(nicheKeywordRegex["ayurveda"])
+	for _, s := range []string{"Ayurveda Wellness", "Ayurvedic practitioner", "AYURVEDIC center"} {
+		if !r.MatchString(s) {
+			t.Errorf("expected %q to match ayurveda prefix regex", s)
+		}
+	}
+}
+
+func TestNicheClassifier_NoFalsePositiveOffNiche(t *testing.T) {
+	// The reviewer-flagged risk: HealthAndBeautyBusiness pages often have
+	// "spa" or "salon" in the title. Those keywords would tag them as 'spa'
+	// niche_category. But off_niche=TRUE takes precedence in the API filter
+	// (default include_off_niche=false), so a HealthAndBeautyBusiness row
+	// with niche_category='spa' is still excluded from consumer results.
+	// This test documents that contract: a category in the blacklist MUST
+	// result in off_niche=TRUE regardless of what niche_category turns out
+	// to be. (The off_niche flag is set first, in the same INSERT.)
+	have := make(map[string]bool, len(offNicheBlacklist))
+	for _, c := range offNicheBlacklist {
+		have[c] = true
+	}
+	if !have["HealthAndBeautyBusiness"] {
+		t.Fatal("HealthAndBeautyBusiness must be in blacklist (security: don't surface beauty/medical in wellness API)")
+	}
+}
+
+func TestNicheClassifier_StopwordsDontMisclassify(t *testing.T) {
+	// Pages mentioning niche keywords incidentally (in unrelated context)
+	// will still bucket — that's accepted false-positive surface for the
+	// regex-only classifier. This test documents that and acts as a
+	// canary: if someone tightens the regex, these cases should keep
+	// matching (current behavior).
+	yogaR := regexp.MustCompile(nicheKeywordRegex["yoga"])
+	cases := []string{
+		"Our yoga blanket store sells handmade props",        // matches: 'yoga'
+		"Sports apparel including yoga pants and athleisure", // matches: 'yoga'
+		"Asana the project management tool",                  // matches: 'asana'
+	}
+	for _, s := range cases {
+		if !yogaR.MatchString(s) {
+			t.Errorf("expected %q to match (current regex is intentionally permissive)", s)
+		}
+	}
+}
+
+func TestNicheClassifier_MetaKeywordSoupHeuristic(t *testing.T) {
+	// LENGTH > 100 catches <meta name="keywords"> stuffed into raw_category.
+	// Sample real garbage from production audit (~41K rows): 100+ char strings
+	// of comma-separated SEO terms.
+	garbage := strings.Repeat("real estate, mortgage, homes for sale, ", 5)
+	if len(garbage) <= 100 {
+		t.Fatalf("test fixture must be >100 chars to validate the heuristic; got %d", len(garbage))
+	}
+	// Logic mirrors the SQL: LENGTH(raw_category) > 100 → off_niche=TRUE.
+	// We just assert the Go-side fixture matches the SQL threshold.
+	if !(len(garbage) > 100) {
+		t.Errorf("LENGTH(raw_category) > 100 heuristic does not flag %d-char fixture", len(garbage))
+	}
+}

--- a/internal/directory/jsonld.go
+++ b/internal/directory/jsonld.go
@@ -33,7 +33,7 @@ func extractFromJSONLD(ld map[string]any, source string) Listing {
 	// Address.
 	if addr, ok := ld["address"].(map[string]any); ok {
 		var parts []string
-		for _, key := range []string{"streetAddress", "addressLocality", "addressRegion", "postalCode"} {
+		for _, key := range []string{"streetAddress", "addressLocality", "addressRegion", "postalCode", "addressCountry"} {
 			if v, ok := addr[key].(string); ok && v != "" {
 				parts = append(parts, v)
 			}

--- a/internal/directory/jsonld_test.go
+++ b/internal/directory/jsonld_test.go
@@ -1,0 +1,22 @@
+package directory
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestExtractFromJSONLD_IncludesAddressCountry(t *testing.T) {
+	ld := map[string]any{
+		"address": map[string]any{
+			"streetAddress":   "521 Oak Grove Rd",
+			"addressLocality": "Flat Rock",
+			"addressRegion":   "NC",
+			"postalCode":      "28731",
+			"addressCountry":  "United States",
+		},
+	}
+	l := extractFromJSONLD(ld, "test")
+	if !strings.Contains(l.Address, "United States") {
+		t.Errorf("Address should include addressCountry; got %q", l.Address)
+	}
+}

--- a/internal/scraper/contact.go
+++ b/internal/scraper/contact.go
@@ -531,6 +531,36 @@ var ccTLDToISO = map[string]string{
 	"za": "ZA",
 }
 
+// collisionCountryCodes are 2-letter codes that are BOTH legitimate ISO 3166-1
+// alpha-2 country codes AND US state codes (in usStateCodes). normalizeCountry
+// rejects them unconditionally because the false-positive cost of treating a
+// US row as Indonesia/Israel/India outweighs the benefit. The collision
+// heuristic in tailParseCountry rescues them only when surrounding tokens
+// indicate a non-US address shape.
+var collisionCountryCodes = map[string]bool{
+	"ID": true, // Indonesia vs Idaho
+	"IL": true, // Israel vs Illinois
+	"IN": true, // India vs Indiana
+}
+
+// usStateFullNames lists single-word US state names used by the collision
+// heuristic. Multi-word names ("New York", "North Carolina") are NOT here —
+// matching them needs span-aware logic and is out of scope; the 2-letter
+// codes (NY, NC) in usStateCodes catch the same cases anyway. Lowercase.
+var usStateFullNames = map[string]bool{
+	"alabama": true, "alaska": true, "arizona": true, "arkansas": true,
+	"california": true, "colorado": true, "connecticut": true,
+	"delaware": true, "florida": true, "georgia": true,
+	"hawaii": true, "idaho": true, "illinois": true, "indiana": true,
+	"iowa": true, "kansas": true, "kentucky": true, "louisiana": true,
+	"maine": true, "maryland": true, "massachusetts": true, "michigan": true,
+	"minnesota": true, "mississippi": true, "missouri": true, "montana": true,
+	"nebraska": true, "nevada": true, "ohio": true, "oklahoma": true,
+	"oregon": true, "pennsylvania": true, "tennessee": true, "texas": true,
+	"utah": true, "vermont": true, "virginia": true, "washington": true,
+	"wisconsin": true, "wyoming": true,
+}
+
 // tailParseCountry walks the comma-separated tokens of an address from the
 // tail backward and returns the first token that resolves via normalizeCountry
 // to a non-empty ISO alpha-2 code. Used as a fallback when JSON-LD did not
@@ -542,6 +572,12 @@ var ccTLDToISO = map[string]string{
 // 1..3 whitespace-separated words) so embedded forms like "239222\nSingapore"
 // or "6011\nNew Zealand" — common when a postal code and country share the
 // final comma segment — still resolve to SG / NZ.
+//
+// Collision heuristic: 2-letter codes that are both ISO country codes AND
+// US state codes (ID/IL/IN) are accepted as country codes when the rest of
+// the address contains no US state markers (codes or full state names) and
+// the preceding token is postal-shape numeric. Conservative — biases toward
+// "" over wrong tagging when the signal is ambiguous.
 func tailParseCountry(addr string) string {
 	if addr == "" {
 		return ""
@@ -555,6 +591,13 @@ func tailParseCountry(addr string) string {
 		if iso := normalizeCountry(candidate); iso != "" {
 			return iso
 		}
+		// Collision rescue for ID/IL/IN (Indonesia/Israel/India vs
+		// Idaho/Illinois/Indiana) — only when the address shape signals
+		// non-US format. See acceptCollisionCountryCode for the gate.
+		upper := strings.ToUpper(candidate)
+		if collisionCountryCodes[upper] && acceptCollisionCountryCode(parts, i) {
+			return upper
+		}
 		// Collapse internal whitespace (incl. \n, \t) and try right-anchored
 		// word slices. Right-anchored only: avoids "USA Drive, ..." style
 		// false positives where the country-looking token is at the START
@@ -566,12 +609,66 @@ func tailParseCountry(addr string) string {
 		}
 		for w := 1; w <= maxSlice; w++ {
 			slice := strings.Join(words[len(words)-w:], " ")
+			// Skip single-word 2-letter slices — the full-candidate
+			// normalizeCountry call above already handled the 2-letter
+			// path with its state-code blocklist; a 2-letter slice
+			// matching here is almost always a coincidental street
+			// abbreviation (e.g. "St" → "ST" = São Tomé) rather than
+			// an actual country mention.
+			if w == 1 && len(slice) == 2 {
+				continue
+			}
 			if iso := normalizeCountry(slice); iso != "" {
 				return iso
 			}
 		}
 	}
 	return ""
+}
+
+// acceptCollisionCountryCode returns true when a 2-letter collision code at
+// parts[idx] (e.g. "ID" / "IL" / "IN") should be treated as a country code
+// rather than a US state code. ACCEPT only when both conditions hold:
+//
+//   - No US state code (2-letter from usStateCodes) AND no single-word US
+//     state name (from usStateFullNames) appears in the preceding tokens.
+//     Either presence indicates US-format address.
+//   - The immediately preceding token (parts[idx-1]) is postal-shape — at
+//     least 4 digits. Indonesian postal codes are 5 digits, Indian PINs are
+//     6 digits, Israeli ZIPs are 5-7 digits, so the floor of 4 stays
+//     conservative without missing the target geographies.
+//
+// Conservative — prefers false negatives (missed Indonesia/Israel/India)
+// over false positives (US row mis-tagged), matching the project-wide
+// "prefer empty over wrong" policy.
+func acceptCollisionCountryCode(parts []string, idx int) bool {
+	if idx == 0 {
+		return false // need a preceding postal token to anchor non-US shape
+	}
+	// Scan preceding tokens for any US state marker.
+	for _, p := range parts[:idx] {
+		for _, raw := range strings.Fields(p) {
+			word := strings.TrimRight(raw, ".,;:")
+			if len(word) == 2 && usStateCodes[strings.ToUpper(word)] {
+				return false
+			}
+			if usStateFullNames[strings.ToLower(word)] {
+				return false
+			}
+		}
+	}
+	// Verify the immediately preceding token is postal-shape (mostly digits).
+	prev := strings.TrimSpace(parts[idx-1])
+	if prev == "" {
+		return false
+	}
+	digits := 0
+	for _, r := range prev {
+		if r >= '0' && r <= '9' {
+			digits++
+		}
+	}
+	return digits >= 4
 }
 
 // tailParseCity returns the city from a US-style trailing address segment of

--- a/internal/scraper/contact.go
+++ b/internal/scraper/contact.go
@@ -5,6 +5,8 @@ package scraper
 import (
 	"fmt"
 	"net"
+	"net/url"
+	"os"
 	"regexp"
 	"strings"
 
@@ -151,6 +153,19 @@ func ExtractContacts(body []byte) *ContactData {
 	// ── HTML address fallback (if JSON-LD didn't provide one) ──
 	if cd.Address == "" {
 		extractHTMLAddress(resp, cd)
+	}
+
+	// ── Address tail-parse fallback for City + Country ──
+	// Catches the common case where JSON-LD had no addressCountry/addressLocality
+	// and we have a raw address blob like "...Flat Rock, NC, United States" with
+	// the country (and a US-style city) embedded as trailing tokens.
+	if cd.Address != "" {
+		if cd.Country == "" {
+			cd.Country = tailParseCountry(cd.Address)
+		}
+		if cd.City == "" {
+			cd.City = tailParseCity(cd.Address)
+		}
 	}
 
 	// ── Page title fallback ──
@@ -459,6 +474,180 @@ func extractLDCityCountry(ld map[string]any) (string, string) {
 		}
 	}
 	return city, normalizeCountry(rawCountry)
+}
+
+// usStateCodes is the set of US state 2-letter codes used by tailParseCity to
+// recognize the canonical US-style "..., <city>, <ST>[ <zip>][, <country>]"
+// pattern. Mirrors the stateBlocklist in normalizeCountry — kept here as a
+// dedicated set so the city parser does not silently broaden to non-US
+// state-like tokens.
+var usStateCodes = map[string]bool{
+	"CA": true, "NY": true, "TX": true, "WA": true, "OR": true,
+	"FL": true, "IL": true, "MA": true, "PA": true, "AZ": true,
+	"CO": true, "NV": true, "NJ": true, "GA": true, "NC": true,
+	"VA": true, "MI": true, "OH": true, "IN": true, "MN": true,
+	"WI": true, "MO": true, "MD": true, "TN": true, "SC": true,
+	"AL": true, "KY": true, "LA": true, "OK": true, "CT": true,
+	"UT": true, "NM": true, "NH": true, "VT": true, "ME": true,
+	"RI": true, "DE": true, "HI": true, "AK": true, "ID": true,
+	"MT": true, "ND": true, "SD": true, "NE": true, "KS": true,
+	"WV": true, "AR": true, "MS": true, "IA": true, "DC": true,
+}
+
+// usCityRe matches a US-style trailing "<city>, <STATE>[<sep><zip>][, <country>]"
+// segment. Group 1 = city candidate, Group 2 = state code. The separator
+// between state and zip can be either a space ("TX 75244") or a comma
+// (", TX, 75244, USA") — both forms are common in scraped data. Anchored
+// to end of string so we extract the LAST city in the address (the
+// business location, not a street-level token).
+var usCityRe = regexp.MustCompile(`(?:^|,)\s*([^,]+?)\s*,\s*([A-Z]{2})\b(?:[\s,]+\d{5}(?:-\d{4})?)?(?:[\s,].*)?$`)
+
+// ccTLDToISO maps reliable ccTLDs to their ISO 3166-1 alpha-2 country code.
+// Curated allowlist — generic-looking ccTLDs (.io, .co, .me, .tv, .cc) are
+// deliberately excluded because they are dominated by global startups and
+// would mis-flag US/EU companies as British-Indian-Ocean-Territory etc.
+// Compound entries (".co.uk") must precede their single-component form.
+var ccTLDToISO = map[string]string{
+	// Compound (longest match first via lookup order below).
+	"co.uk": "GB", "org.uk": "GB", "ac.uk": "GB", "gov.uk": "GB",
+	"com.au": "AU", "net.au": "AU", "org.au": "AU",
+	"co.jp": "JP", "or.jp": "JP", "ne.jp": "JP",
+	"co.kr": "KR",
+	"co.id": "ID", "or.id": "ID", "ac.id": "ID",
+	"co.in":  "IN",
+	"co.nz":  "NZ",
+	"co.za":  "ZA",
+	"com.br": "BR", "com.mx": "MX", "com.sg": "SG", "com.my": "MY",
+	"com.tr": "TR", "com.tw": "TW", "com.hk": "HK", "com.ph": "PH",
+	// Single-component ccTLDs (high-signal: dominantly used by local entities).
+	"nl": "NL", "de": "DE", "fr": "FR", "it": "IT", "es": "ES",
+	"be": "BE", "at": "AT", "ch": "CH", "se": "SE", "no": "NO",
+	"dk": "DK", "fi": "FI", "pl": "PL", "pt": "PT", "ie": "IE",
+	"gr": "GR", "hu": "HU", "cz": "CZ", "ro": "RO", "ru": "RU",
+	"au": "AU", "nz": "NZ", "ca": "CA", "br": "BR", "mx": "MX",
+	"id": "ID", "jp": "JP", "kr": "KR", "in": "IN", "my": "MY",
+	"th": "TH", "vn": "VN", "ph": "PH", "sg": "SG", "tw": "TW",
+	"hk": "HK", "ae": "AE", "sa": "SA", "il": "IL", "tr": "TR",
+	"za": "ZA",
+}
+
+// tailParseCountry walks the comma-separated tokens of an address from the
+// tail backward and returns the first token that resolves via normalizeCountry
+// to a non-empty ISO alpha-2 code. Used as a fallback when JSON-LD did not
+// provide an addressCountry — e.g. raw HTML addresses like
+// "521 Oak Grove Rd, Flat Rock, NC, United States" where the country is
+// embedded as the trailing free-form token.
+//
+// Within each candidate segment we also try right-anchored word slices (last
+// 1..3 whitespace-separated words) so embedded forms like "239222\nSingapore"
+// or "6011\nNew Zealand" — common when a postal code and country share the
+// final comma segment — still resolve to SG / NZ.
+func tailParseCountry(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	parts := strings.Split(addr, ",")
+	for i := len(parts) - 1; i >= 0; i-- {
+		candidate := strings.TrimRight(strings.TrimSpace(parts[i]), ".,;: ")
+		if candidate == "" {
+			continue
+		}
+		if iso := normalizeCountry(candidate); iso != "" {
+			return iso
+		}
+		// Collapse internal whitespace (incl. \n, \t) and try right-anchored
+		// word slices. Right-anchored only: avoids "USA Drive, ..." style
+		// false positives where the country-looking token is at the START
+		// of a street-name segment.
+		words := strings.Fields(candidate)
+		maxSlice := 3
+		if maxSlice > len(words) {
+			maxSlice = len(words)
+		}
+		for w := 1; w <= maxSlice; w++ {
+			slice := strings.Join(words[len(words)-w:], " ")
+			if iso := normalizeCountry(slice); iso != "" {
+				return iso
+			}
+		}
+	}
+	return ""
+}
+
+// tailParseCity returns the city from a US-style trailing address segment of
+// the form "..., <city>, <STATE>[ <zip>][, <country>]". Returns "" for any
+// address that does not match this canonical US shape — non-US addresses
+// have too many regional formats to parse reliably, and a wrong city is
+// worse than an empty one (per the "prefer empty over wrong" policy that
+// normalizeCountry also follows).
+func tailParseCity(addr string) string {
+	if addr == "" {
+		return ""
+	}
+	m := usCityRe.FindStringSubmatch(addr)
+	if len(m) < 3 {
+		return ""
+	}
+	if !usStateCodes[strings.ToUpper(m[2])] {
+		return ""
+	}
+	return strings.TrimSpace(m[1])
+}
+
+// tldCountryHint returns the ISO 3166-1 alpha-2 code suggested by the host's
+// ccTLD, or "" if the TLD is not in the curated allowlist. Tries the
+// two-segment compound form first (.co.uk, .com.au) before falling back to
+// the single-segment ccTLD. Generic TLDs (.com, .io, .co, .me) deliberately
+// return "" to avoid false positives.
+func tldCountryHint(host string) string {
+	host = strings.TrimSpace(strings.ToLower(host))
+	host = strings.TrimSuffix(host, ".")
+	if host == "" || !strings.Contains(host, ".") {
+		return ""
+	}
+	segs := strings.Split(host, ".")
+	if len(segs) >= 2 {
+		compound := segs[len(segs)-2] + "." + segs[len(segs)-1]
+		if iso, ok := ccTLDToISO[compound]; ok {
+			return iso
+		}
+	}
+	if iso, ok := ccTLDToISO[segs[len(segs)-1]]; ok {
+		return iso
+	}
+	return ""
+}
+
+// ApplyTLDCountryFallback fills cd.Country from the page URL's ccTLD when
+// it is still empty after all other extraction paths. Gated behind the
+// COUNTRY_TLD_FALLBACK_ENABLED env flag because ccTLD is a soft signal —
+// global companies on .com mask their origin and local sites occasionally
+// host on .io/.co. Off by default; callers opt in per-deployment.
+func ApplyTLDCountryFallback(cd *ContactData, pageURL string) {
+	if cd == nil || cd.Country != "" || pageURL == "" {
+		return
+	}
+	if !envFlagEnabled("COUNTRY_TLD_FALLBACK_ENABLED") {
+		return
+	}
+	u, err := url.Parse(pageURL)
+	if err != nil || u.Host == "" {
+		return
+	}
+	if iso := tldCountryHint(u.Host); iso != "" {
+		cd.Country = iso
+	}
+}
+
+// envFlagEnabled returns true when the named env var is set to a truthy
+// value ("1", "true", "yes", "on" — case-insensitive). All other values
+// (including unset / empty) return false.
+func envFlagEnabled(name string) bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
+		return true
+	}
+	return false
 }
 
 // whichYouTubePath reconstructs a canonical YouTube URL from the matched

--- a/internal/scraper/contact.go
+++ b/internal/scraper/contact.go
@@ -561,6 +561,47 @@ var usStateFullNames = map[string]bool{
 	"wisconsin": true, "wyoming": true,
 }
 
+// usStateZipRe finds a US "<2-letter token> <ZIP5>" / "<2-letter>, <ZIP5>"
+// marker anywhere in an address. Group 1 (the 2-letter token) is validated
+// against usStateCodes by the caller — the regex alone is intentionally loose
+// so the state-set is the single source of truth. ZIP is exactly 5 digits
+// (US format), optional +4. Non-US postal formats put the postal code FIRST
+// ("01067 Dresden") or use 3-letter/alphanumeric region codes ("NSW 2000",
+// "ON M5J 1V6"), so this shape is dominated by real US addresses.
+var usStateZipRe = regexp.MustCompile(`(?:^|[\s,])([A-Za-z]{2})[\s,]+(\d{5})(?:-\d{4})?(?:[\s,]|$)`)
+
+// usFullStateZipRe finds "<single-word state name> <ZIP5>" (e.g. "Texas 77056",
+// "Texas, 77056") — the full-name analogue of usStateZipRe. Built from
+// usStateFullNames so the name-set stays the single source of truth.
+var usFullStateZipRe = func() *regexp.Regexp {
+	names := make([]string, 0, len(usStateFullNames))
+	for n := range usStateFullNames {
+		names = append(names, n)
+	}
+	return regexp.MustCompile(`(?i)\b(` + strings.Join(names, "|") + `)\b[\s,]+\d{5}(?:-\d{4})?\b`)
+}()
+
+// inferUSFromStateZip returns true when the address carries a US state+ZIP
+// marker — a 2-letter US state code OR a single-word US state name immediately
+// followed by a 5-digit ZIP. This is a high-precision US signal that recovers
+// the large class of scraped US addresses omitting an explicit "USA"/"United
+// States" token (issue #26: e.g. "Houston, Texas, 77056", "Erie, PA 16504").
+// Output is always the validated ISO code "US", so it never pollutes the
+// country column. Used as a last-resort fallback in tailParseCountry, AFTER
+// the explicit-country tail walk and the ID/IL/IN collision rescue, so a
+// genuine trailing country name (incl. India/Israel/Indonesia) still wins.
+func inferUSFromStateZip(addr string) bool {
+	if addr == "" {
+		return false
+	}
+	for _, m := range usStateZipRe.FindAllStringSubmatch(addr, -1) {
+		if usStateCodes[strings.ToUpper(m[1])] {
+			return true
+		}
+	}
+	return usFullStateZipRe.MatchString(addr)
+}
+
 // tailParseCountry walks the comma-separated tokens of an address from the
 // tail backward and returns the first token that resolves via normalizeCountry
 // to a non-empty ISO alpha-2 code. Used as a fallback when JSON-LD did not
@@ -622,6 +663,12 @@ func tailParseCountry(addr string) string {
 				return iso
 			}
 		}
+	}
+	// Last resort: no explicit country token anywhere, but a US state+ZIP
+	// marker ("city, ST 12345" / "city, Texas, 12345") is an unambiguous US
+	// signal. Recovers the dominant empty-country class (issue #26).
+	if inferUSFromStateZip(addr) {
+		return "US"
 	}
 	return ""
 }

--- a/internal/scraper/contact.go
+++ b/internal/scraper/contact.go
@@ -594,6 +594,19 @@ func tailParseCity(addr string) string {
 	return strings.TrimSpace(m[1])
 }
 
+// ParseAddressFallback runs tail-based country and city derivation on a raw
+// address string. Returns ISO alpha-2 country (or "") and US-style city
+// (or "") — the same logic that ExtractContacts applies internally after
+// HTML address fallback. Pure offline transform — no network. Exposed so
+// the reenrich worker can pre-pass existing DB rows before paying for a
+// network refetch, and the backfill CLI can sweep historical NULL rows.
+func ParseAddressFallback(address string) (country, city string) {
+	if address == "" {
+		return "", ""
+	}
+	return tailParseCountry(address), tailParseCity(address)
+}
+
 // tldCountryHint returns the ISO 3166-1 alpha-2 code suggested by the host's
 // ccTLD, or "" if the TLD is not in the curated allowlist. Tries the
 // two-segment compound form first (.co.uk, .com.au) before falling back to

--- a/internal/scraper/contact_test.go
+++ b/internal/scraper/contact_test.go
@@ -63,6 +63,22 @@ func TestTailParseCountry(t *testing.T) {
 		// Word-slice must NOT create false positives mid-segment.
 		{"usa drive false positive guard", "1 USA Drive, Some City", ""},
 		{"africa street guard", "South Africa Street, Boston, MA, 02134", ""},
+
+		// Sprint 6: collision heuristic for ID/IL/IN (Indonesia/Israel/India vs
+		// Idaho/Illinois/Indiana). ACCEPT when non-US shape; REJECT when US.
+		{"indonesia ID at tail with 5-digit postal", "Jl. Sudirman 1, Jakarta Selatan, 12550, ID", "ID"},
+		{"indonesia ID compact short form", "Some St, 80572, ID", "ID"},
+		{"israel IL with 7-digit postal", "21 Abba Hillel Silver Rd, Ramat Gan, 5252213, IL", "IL"},
+		{"india IN with 6-digit PIN", "Manjalikulam Rd, Thiruvananthapuram, 695001, IN", "IN"},
+		{"india IN mumbai PIN", "Some St, Mumbai, 400001, IN", "IN"},
+		{"reject IL when illinois city explicit", "1 Main St, Chicago, IL, 60601", ""},
+		{"reject IN when NY state code preceding", "1 Main St, NY 12345, IN", ""},
+		{"reject ID with idaho full name", "Some St, Idaho, 83001, ID", ""},
+		{"reject IL with illinois full name", "Some St, Illinois, 60601, IL", ""},
+		{"reject IN with indiana full name", "Some St, Indiana, 46001, IN", ""},
+		{"reject ID no preceding postal", "Some Address, ID", ""},
+		{"reject ID non-numeric preceding", "Some St, City Name, ID", ""},
+		{"reject ID too-few-digit preceding", "Some St, 123, ID", ""},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {

--- a/internal/scraper/contact_test.go
+++ b/internal/scraper/contact_test.go
@@ -116,6 +116,35 @@ func TestTailParseCity_USStyle(t *testing.T) {
 	}
 }
 
+func TestParseAddressFallback(t *testing.T) {
+	cases := []struct {
+		name        string
+		addr        string
+		wantCountry string
+		wantCity    string
+	}{
+		{"empty", "", "", ""},
+		{"both filled US-style", "521 Oak Grove Rd, Flat Rock, NC, United States", "US", "Flat Rock"},
+		{"country only no US city", "Compagnonsplein 1, 1234 AB Amsterdam, Netherlands", "NL", ""},
+		{"country only newline embedded", "20 Leonie Hill, Singapore, 239222\nSingapore", "SG", ""},
+		{"neither resolves", "Compagnonsplein 1", "", ""},
+		{"both empty inputs", "   ", "", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCountry, gotCity := ParseAddressFallback(tc.addr)
+			if gotCountry != tc.wantCountry {
+				t.Errorf("ParseAddressFallback(%q) country = %q; want %q",
+					tc.addr, gotCountry, tc.wantCountry)
+			}
+			if gotCity != tc.wantCity {
+				t.Errorf("ParseAddressFallback(%q) city = %q; want %q",
+					tc.addr, gotCity, tc.wantCity)
+			}
+		})
+	}
+}
+
 func TestTLDCountryHint(t *testing.T) {
 	cases := []struct {
 		name string

--- a/internal/scraper/contact_test.go
+++ b/internal/scraper/contact_test.go
@@ -1,0 +1,227 @@
+//go:build playwright
+
+package scraper
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTailParseCountry(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+		want string
+	}{
+		// Verified production rows from the audit.
+		{"marineandboat US", "521 Oak Grove Rd, Flat Rock, NC, United States", "US"},
+		{"officialalphaland US", "Missouri City, TX 77489, United States", "US"},
+
+		// Country at tail in various forms.
+		{"GB at tail", "10 Downing St, London, United Kingdom", "GB"},
+		{"GB England", "1 High St, London, England", "GB"},
+		{"ID full name", "Jl. Sudirman 1, Jakarta, Indonesia", "ID"},
+		{"NL full name", "Compagnonsplein 1, 1234 AB Amsterdam, Netherlands", "NL"},
+		{"AU at tail", "1 George St, Sydney, NSW 2000, Australia", "AU"},
+		{"alpha-3 USA", "1 Main St, USA", "US"},
+		{"alpha-3 GBR", "1 Main St, GBR", "GB"},
+		{"trailing punct", "1 Main St, Indonesia.", "ID"},
+		{"trailing space", "1 Main St, Indonesia ", "ID"},
+
+		// Must NOT match — state codes & junk.
+		{"US state CA alone", "1 Infinite Loop, Cupertino, CA 95014", ""},
+		{"US state NC alone", "Foo, Flat Rock, NC", ""},
+		{"no comma cvsf.nl style", "Compagnonsplein 1", ""},
+		{"empty", "", ""},
+		{"single token", "FooBar", ""},
+		{"only zip", "12345", ""},
+		{"state with zip combined token", "TX 77489", ""},
+
+		// Tail-walk: country deeper than last token.
+		{"country before postal token", "1 Main St, Jakarta, Indonesia, 12345", "ID"},
+
+		// REAL PRODUCTION rows (DB verified, 2026-05-11) — verifies tail-walk
+		// across the actual address shapes seen in business_listings.
+		{"canada postal at tail", "1137, Derry Road East, Mississauga, ON, Canada, L5T 1P3", "CA"},
+		{"sg with newline", "20 Leonie Hill, #06-22, Singapore, 239222\nSingapore", "SG"},
+		{"montreal canada postal", "1250 Boulevard René Lévesque Ouest, Montréal, Canada, H3B 4W8", "CA"},
+		{"uk postal tail", "32 Lake Rd, Bowness-on-Windermere, Windermere LA23 3AP, United Kingdom", "GB"},
+		{"frankfurt germany", "Frankfurt, Germany", "DE"},
+		{"paris france", "75 bis Avenue Marceau, 75116 Paris, France", "FR"},
+		{"france postal", "ZI du bois de Leuze 12 rue Denis Papin, St Martin de Crau, France, 13310", "FR"},
+		{"jakarta indo", "AD Premier 9th floor, Jl. TB Simatupang No.5 Ragunan, Pasar Minggu, Jakarta Selatan 12550, DKI Jakarta, Indonesia", "ID"},
+		{"germany de-ni", "Hildesheim, DE-NI, Germany", "DE"},
+		{"india tail", "303, Camps Corner-II, Nr. Prahladnagar Garden, Satellite, Ahmedabad – 380 015. Gujarat, India", "IN"},
+		{"comma sep zip then country", "8344 Foothill Blvd, Sunland, CA, 91040, United States", "US"},
+
+		// Right-anchored word-slice fallback (DB-verified embedded-newline shapes).
+		{"singapore postal newline", "20 Leonie Hill, #06-22, Singapore, 239222\nSingapore", "SG"},
+		{"nz postal newline", "5/23 Waring Taylor Street\nWellington, Wellington, 6011\nNew Zealand", "NZ"},
+		{"ph postal trailing word", "522 J.A. Clarin St, Tagbilaran City, 6300 Bohol, Philippines", "PH"},
+		{"mexico with period", "TV AZTECA Periférico Sur 4121, Ciudad De México, México.", "MX"},
+
+		// Word-slice must NOT create false positives mid-segment.
+		{"usa drive false positive guard", "1 USA Drive, Some City", ""},
+		{"africa street guard", "South Africa Street, Boston, MA, 02134", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tailParseCountry(tc.addr)
+			if got != tc.want {
+				t.Errorf("tailParseCountry(%q) = %q; want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTailParseCity_USStyle(t *testing.T) {
+	cases := []struct {
+		name string
+		addr string
+		want string
+	}{
+		// US-style address: ..., <city>, <STATE_CODE> [zip][, country]
+		{"marineandboat city", "521 Oak Grove Rd, Flat Rock, NC, United States", "Flat Rock"},
+		{"officialalphaland city", "Missouri City, TX 77489, United States", "Missouri City"},
+		{"cupertino", "1 Infinite Loop, Cupertino, CA 95014", "Cupertino"},
+		{"san antonio no zip", "1 Main St, San Antonio, TX", "San Antonio"},
+		{"city is first token", "Missouri City, TX 77489", "Missouri City"},
+		{"city with extended zip", "1 Main, Foo Town, CA 90210-1234", "Foo Town"},
+
+		// REAL PRODUCTION rows (DB verified, 2026-05-11) — comma-separated
+		// zip form: <city>, <STATE>, <ZIP>, <country>. This form was the
+		// original regex's blind spot.
+		{"sunland prod", "8344 Foothill Blvd, Sunland, CA, 91040, United States", "Sunland"},
+		{"swannanoa prod", "701 Warren Wilson Rd, Swannanoa, NC, 28778, USA", "Swannanoa"},
+		{"englewood prod", "61 West Palisade 2B, Englewood, NJ, 07631, USA", "Englewood"},
+		{"schaumburg prod", "1375   E Schaumburg Rd #100, Schaumburg, IL, 60194, USA", "Schaumburg"},
+		{"new york prod", "40 West 25th Street, 4th Fl, New York, NY, 10010, United States", "New York"},
+		{"dallas prod", "4100 Alpha Rd, Dallas, TX 75244, USA", "Dallas"},
+		{"streamwood prod", "1092 Frances Dr, Streamwood, IL 60107, USA", "Streamwood"},
+
+		// Must NOT match — non-US format or insufficient signal.
+		{"non-US Dutch", "Compagnonsplein 1, 1234 AB Amsterdam, Netherlands", ""},
+		{"no state pattern", "Just City, Indonesia", ""},
+		{"single token", "FooBar", ""},
+		{"empty", "", ""},
+		{"state-like but not US state", "Foo, GB, Bar", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tailParseCity(tc.addr)
+			if got != tc.want {
+				t.Errorf("tailParseCity(%q) = %q; want %q", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTLDCountryHint(t *testing.T) {
+	cases := []struct {
+		name string
+		host string
+		want string
+	}{
+		// Allowlisted ccTLDs.
+		{"NL", "cvsf.nl", "NL"},
+		{"NL with www", "www.cvsf.nl", "NL"},
+		{"DE", "example.de", "DE"},
+		{"FR", "example.fr", "FR"},
+		{"AU", "example.au", "AU"},
+		{"ID", "example.id", "ID"},
+		{"CH", "example.ch", "CH"},
+		{"JP", "example.jp", "JP"},
+
+		// Compound ccTLDs.
+		{"co.uk", "example.co.uk", "GB"},
+		{"com.au", "example.com.au", "AU"},
+		{"co.id", "example.co.id", "ID"},
+		{"co.jp", "example.co.jp", "JP"},
+		{"com.br", "example.com.br", "BR"},
+
+		// Subdomain handling.
+		{"deep subdomain", "shop.eu.example.de", "DE"},
+
+		// Excluded generic / ambiguous TLDs.
+		{"com", "example.com", ""},
+		{"net", "example.net", ""},
+		{"org", "example.org", ""},
+		{"io is ccTLD but generic in practice", "example.io", ""},
+		{"co generic", "example.co", ""},
+		{"me generic", "example.me", ""},
+		{"tv generic", "example.tv", ""},
+		{"app generic", "example.app", ""},
+		{"empty", "", ""},
+		{"no dot", "localhost", ""},
+
+		// With URL scheme stripping (function should handle host-only).
+		{"trailing dot", "example.de.", "DE"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := tldCountryHint(tc.host)
+			if got != tc.want {
+				t.Errorf("tldCountryHint(%q) = %q; want %q", tc.host, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestApplyTLDCountryFallback_EnvGated(t *testing.T) {
+	t.Run("disabled by default", func(t *testing.T) {
+		os.Unsetenv("COUNTRY_TLD_FALLBACK_ENABLED")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "https://cvsf.nl/about")
+		if cd.Country != "" {
+			t.Errorf("flag unset: want Country='', got %q", cd.Country)
+		}
+	})
+	t.Run("explicit false is no-op", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "false")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "https://cvsf.nl/about")
+		if cd.Country != "" {
+			t.Errorf("flag=false: want Country='', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true fills empty Country", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "https://cvsf.nl/about")
+		if cd.Country != "NL" {
+			t.Errorf("flag=true cvsf.nl: want Country='NL', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true does not overwrite existing Country", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{Country: "US"}
+		ApplyTLDCountryFallback(cd, "https://example.nl/")
+		if cd.Country != "US" {
+			t.Errorf("existing Country must not be overwritten: want 'US', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true, empty URL is no-op", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "")
+		if cd.Country != "" {
+			t.Errorf("empty URL: want Country='', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true, generic TLD is no-op", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "https://example.com/")
+		if cd.Country != "" {
+			t.Errorf("generic TLD: want Country='', got %q", cd.Country)
+		}
+	})
+	t.Run("flag true, malformed URL is no-op", func(t *testing.T) {
+		t.Setenv("COUNTRY_TLD_FALLBACK_ENABLED", "true")
+		cd := &ContactData{}
+		ApplyTLDCountryFallback(cd, "::not-a-url")
+		if cd.Country != "" {
+			t.Errorf("malformed URL: want Country='', got %q", cd.Country)
+		}
+	})
+}

--- a/internal/scraper/contact_test.go
+++ b/internal/scraper/contact_test.go
@@ -28,14 +28,23 @@ func TestTailParseCountry(t *testing.T) {
 		{"trailing punct", "1 Main St, Indonesia.", "ID"},
 		{"trailing space", "1 Main St, Indonesia ", "ID"},
 
-		// Must NOT match — state codes & junk.
-		{"US state CA alone", "1 Infinite Loop, Cupertino, CA 95014", ""},
+		// US state + ZIP → US (issue #26 policy: state+ZIP is an unambiguous
+		// US signal; previously these were left empty, the dominant empty class).
+		{"US state CA + zip", "1 Infinite Loop, Cupertino, CA 95014", "US"},
+		{"state TX + zip combined", "TX 77489", "US"},
+		{"US full state name + zip", "5251 Westheimer Rd, Houston, Texas, 77056", "US"},
+		{"US PA + zip", "3535 Pine Avenue, Erie, PA 16504", "US"},
+		{"US IA + zip", "105 E. 9th St., Coralville, IA 52241", "US"},
+		{"US CA comma zip", "17592 Irvine Blvd, Tustin, CA, 92780", "US"},
+
+		// Must NOT match — state code without ZIP, junk, non-US postal-first.
 		{"US state NC alone", "Foo, Flat Rock, NC", ""},
 		{"no comma cvsf.nl style", "Compagnonsplein 1", ""},
 		{"empty", "", ""},
 		{"single token", "FooBar", ""},
 		{"only zip", "12345", ""},
-		{"state with zip combined token", "TX 77489", ""},
+		{"german postal-first not US", "Altmarkt, 01067 Dresden", ""},
+		{"french postal not US", "7 Rue Linois, Paris, 75015", ""},
 
 		// Tail-walk: country deeper than last token.
 		{"country before postal token", "1 Main St, Jakarta, Indonesia, 12345", "ID"},
@@ -62,7 +71,9 @@ func TestTailParseCountry(t *testing.T) {
 
 		// Word-slice must NOT create false positives mid-segment.
 		{"usa drive false positive guard", "1 USA Drive, Some City", ""},
-		{"africa street guard", "South Africa Street, Boston, MA, 02134", ""},
+		// "South Africa Street" must not match ZA — but MA + 02134 IS US, so
+		// the correct answer is US (street-name guard still holds: not ZA).
+		{"africa street guard not ZA but US via MA zip", "South Africa Street, Boston, MA, 02134", "US"},
 
 		// Sprint 6: collision heuristic for ID/IL/IN (Indonesia/Israel/India vs
 		// Idaho/Illinois/Indiana). ACCEPT when non-US shape; REJECT when US.
@@ -71,11 +82,15 @@ func TestTailParseCountry(t *testing.T) {
 		{"israel IL with 7-digit postal", "21 Abba Hillel Silver Rd, Ramat Gan, 5252213, IL", "IL"},
 		{"india IN with 6-digit PIN", "Manjalikulam Rd, Thiruvananthapuram, 695001, IN", "IN"},
 		{"india IN mumbai PIN", "Some St, Mumbai, 400001, IN", "IN"},
-		{"reject IL when illinois city explicit", "1 Main St, Chicago, IL, 60601", ""},
-		{"reject IN when NY state code preceding", "1 Main St, NY 12345, IN", ""},
-		{"reject ID with idaho full name", "Some St, Idaho, 83001, ID", ""},
-		{"reject IL with illinois full name", "Some St, Illinois, 60601, IL", ""},
-		{"reject IN with indiana full name", "Some St, Indiana, 46001, IN", ""},
+		// IL/IN here are US states with ZIPs → US (not Israel/India). The
+		// collision rescue correctly declines; the state+ZIP fallback tags US.
+		{"chicago IL + zip is US not israel", "1 Main St, Chicago, IL, 60601", "US"},
+		{"NY zip is US not india", "1 Main St, NY 12345, IN", "US"},
+		// Idaho/Illinois/Indiana + ZIP → US (the state-name+ZIP is a real US
+		// address; "ID"/"IL"/"IN" here are the state abbrevs, not country codes).
+		{"idaho full name + zip is US", "Some St, Idaho, 83001, ID", "US"},
+		{"illinois full name + zip is US", "Some St, Illinois, 60601, IL", "US"},
+		{"indiana full name + zip is US", "Some St, Indiana, 46001, IN", "US"},
 		{"reject ID no preceding postal", "Some Address, ID", ""},
 		{"reject ID non-numeric preceding", "Some St, City Name, ID", ""},
 		{"reject ID too-few-digit preceding", "Some St, 123, ID", ""},

--- a/internal/stage/enrich.go
+++ b/internal/stage/enrich.go
@@ -651,6 +651,7 @@ func (c *EnrichStage) worker(ctx context.Context, workerID int) {
 
 		// Extract contacts.
 		cd := internalScraper.ExtractContacts([]byte(body))
+		internalScraper.ApplyTLDCountryFallback(cd, pageURL)
 		emails := internalScraper.FilterEmails(cd.Emails)
 		phones := internalScraper.FilterPhones(cd.Phones)
 

--- a/internal/stage/reenrich.go
+++ b/internal/stage/reenrich.go
@@ -270,6 +270,7 @@ func (r *ReenrichStage) processRow(ctx context.Context, stealth *fetch.StealthFe
 
 	// Extract contacts from fetched body.
 	cd := internalScraper.ExtractContacts([]byte(body))
+	internalScraper.ApplyTLDCountryFallback(cd, row.URL)
 	emails := internalScraper.FilterEmails(cd.Emails)
 	phones := internalScraper.FilterPhones(cd.Phones)
 	socialLinks := buildSocialLinks(cd) // reuse enrich.go helper — same package

--- a/internal/stage/reenrich.go
+++ b/internal/stage/reenrich.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -45,11 +46,21 @@ func NewReenrichStage(cfg *config.Config, database *sql.DB, dd *dedup.Store) *Re
 	return &ReenrichStage{cfg: cfg, db: database, dedup: dd}
 }
 
-// reenrichRow is a candidate row from the eligibility query.
+// reenrichRow is a candidate row from the eligibility query. Address /
+// Country / City are surfaced for the offline pre-pass (applyOfflineParse)
+// so we can fill missing geo fields from the existing address blob without
+// paying a network refetch. EmailCount / PhoneCount drive the skip-fetch
+// decision — a row that already has contact data and just needs geo can
+// graduate via offline parse alone.
 type reenrichRow struct {
-	ID     int64
-	Domain string
-	URL    string
+	ID         int64
+	Domain     string
+	URL        string
+	Address    sql.NullString
+	Country    sql.NullString
+	City       sql.NullString
+	EmailCount int64
+	PhoneCount int64
 }
 
 // Run starts numWorkers goroutines each running the continuous re-enrich loop.
@@ -212,7 +223,16 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 		SET re_enrich_locked_at = NOW()
 		FROM eligible
 		WHERE bl.id = eligible.id
-		RETURNING bl.id, bl.domain, COALESCE(bl.website, 'https://' || bl.domain)
+		RETURNING
+			bl.id,
+			bl.domain,
+			COALESCE(bl.website, 'https://' || bl.domain),
+			bl.address,
+			bl.country,
+			bl.city,
+			(SELECT COUNT(*) FROM business_emails be WHERE be.business_id = bl.id),
+			(CASE WHEN bl.phone IS NOT NULL AND bl.phone != '' THEN 1 ELSE 0 END
+			 + COALESCE(array_length(bl.phones, 1), 0))
 	`
 
 	tx, err := r.db.BeginTx(queryCtx, nil)
@@ -234,7 +254,11 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 	var result []reenrichRow
 	for dbRows.Next() {
 		var row reenrichRow
-		if err := dbRows.Scan(&row.ID, &row.Domain, &row.URL); err != nil {
+		if err := dbRows.Scan(
+			&row.ID, &row.Domain, &row.URL,
+			&row.Address, &row.Country, &row.City,
+			&row.EmailCount, &row.PhoneCount,
+		); err != nil {
 			slog.Warn("reenrich: scan row failed", "error", err)
 			continue
 		}
@@ -251,6 +275,14 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 }
 
 func (r *ReenrichStage) processRow(ctx context.Context, stealth *fetch.StealthFetcher, row reenrichRow, workerID int) {
+	// Offline pre-pass: derive country/city from the existing address blob
+	// before paying for a network refetch. If the row already had contact
+	// data (emails/phones) and the offline parse fills in country+city, we
+	// can mark it done and skip the fetch entirely.
+	if r.applyOfflineParse(ctx, row, workerID) {
+		return
+	}
+
 	timeout := time.Duration(r.cfg.Enrich.TimeoutMs) * time.Millisecond
 	if timeout <= 0 {
 		timeout = 30 * time.Second
@@ -356,6 +388,86 @@ func (r *ReenrichStage) processRow(ctx context.Context, stealth *fetch.StealthFe
 			"phones", len(phones),
 			"worker", workerID)
 	}
+}
+
+// applyOfflineParse derives country/city from row.Address via the tail-parse
+// logic used by ExtractContacts, then writes any newly-derived values back to
+// business_listings. If the row already had at least one email/phone AND the
+// offline parse produced (or row already had) both country and city, the row
+// is marked re_enriched_at = NOW() and the function returns true — caller
+// skips the network fetch.
+//
+// Returns true when the network fetch can be skipped, false when the worker
+// should proceed with the normal fetch path. Errors fall through to the
+// network path (defensive — better to refetch than lose a row).
+func (r *ReenrichStage) applyOfflineParse(ctx context.Context, row reenrichRow, workerID int) bool {
+	if !row.Address.Valid || strings.TrimSpace(row.Address.String) == "" {
+		return false
+	}
+
+	parsedCountry, parsedCity := internalScraper.ParseAddressFallback(row.Address.String)
+	newCountry, newCity, skipFetch := offlineParseDecision(row, parsedCountry, parsedCity)
+
+	if newCountry.Valid || newCity.Valid {
+		// COALESCE on the SQL side mirrors the trigger's merge semantics: only
+		// overwrite when the existing column is NULL. Defensive against races
+		// where another worker filled the column between our SELECT and UPDATE.
+		_, err := r.db.ExecContext(ctx, `
+			UPDATE business_listings
+			SET country    = COALESCE(country, $2),
+			    city       = COALESCE(city,    $3),
+			    updated_at = NOW()
+			WHERE id = $1
+		`, row.ID, newCountry, newCity)
+		if err != nil {
+			slog.Warn("reenrich: offline parse update failed, will fall through to fetch",
+				"id", row.ID, "domain", row.Domain, "error", err, "worker", workerID)
+			return false
+		}
+		slog.Debug("reenrich: offline parse filled",
+			"id", row.ID, "domain", row.Domain,
+			"new_country", newCountry.String, "new_city", newCity.String,
+			"worker", workerID)
+	}
+
+	if !skipFetch {
+		return false
+	}
+
+	_, err := r.db.ExecContext(ctx, `
+		UPDATE business_listings
+		SET re_enriched_at = NOW(), re_enrich_locked_at = NULL
+		WHERE id = $1
+	`, row.ID)
+	if err != nil {
+		slog.Warn("reenrich: mark done after offline parse failed, falling through to fetch",
+			"id", row.ID, "domain", row.Domain, "error", err, "worker", workerID)
+		return false
+	}
+	r.processed.Add(1)
+	slog.Info("reenrich: completed via offline parse (no network)",
+		"id", row.ID, "domain", row.Domain,
+		"filled_country", newCountry.Valid, "filled_city", newCity.Valid,
+		"worker", workerID)
+	return true
+}
+
+// offlineParseDecision is the pure-logic core of applyOfflineParse — given
+// the row's current state and the parsed (country, city) values from
+// scraper.ParseAddressFallback, it decides what to write back and whether
+// the network fetch can be skipped. No I/O; trivially unit-testable.
+func offlineParseDecision(row reenrichRow, parsedCountry, parsedCity string) (newCountry, newCity sql.NullString, skipFetch bool) {
+	if (!row.Country.Valid || row.Country.String == "") && parsedCountry != "" {
+		newCountry = sql.NullString{String: parsedCountry, Valid: true}
+	}
+	if (!row.City.Valid || row.City.String == "") && parsedCity != "" {
+		newCity = sql.NullString{String: parsedCity, Valid: true}
+	}
+	hasContact := row.EmailCount > 0 || row.PhoneCount > 0
+	countryFinal := (row.Country.Valid && row.Country.String != "") || newCountry.Valid
+	cityFinal := (row.City.Valid && row.City.String != "") || newCity.Valid
+	skipFetch = hasContact && countryFinal && cityFinal
+	return
 }
 
 // releaseLock clears re_enrich_locked_at so another worker can immediately

--- a/internal/stage/reenrich.go
+++ b/internal/stage/reenrich.go
@@ -66,9 +66,10 @@ type reenrichRow struct {
 // Run starts numWorkers goroutines each running the continuous re-enrich loop
 // plus one lock-reaper goroutine that deterministically releases stale claims.
 // The reaper exists because the worker's eligibility-query stale-claim recovery
-// is probabilistic (ORDER BY RANDOM over a 261K-row pool) — a row's specific
-// stale lock has 0.04% chance of being re-picked per batch, so rows stuck for
-// hours/days accumulate. The reaper closes that gap with a deterministic sweep.
+// is best-effort: the query scans re_enriched_at IS NULL rows in index order
+// and stops at the first LIMIT eligible rows, so a stale lock deep in the pool
+// may not resurface for a long time. Rows stuck for hours/days would otherwise
+// accumulate; the reaper closes that gap with a deterministic sweep.
 func (r *ReenrichStage) Run(ctx context.Context) error {
 	numWorkers := r.cfg.ReenrichWorkerCount
 	if numWorkers < 1 {
@@ -179,6 +180,69 @@ func (r *ReenrichStage) worker(ctx context.Context, workerID int) {
 // anti-pattern (zero-reset retry) caused the 2026-04-06 pipeline deadlock.
 const reenrichMaxAttempts = 10
 
+// eligibilityQuery is the exact SQL fetchEligibleBatch runs, lifted to package
+// scope so TestEligibilityQuery_NoOrderByRandom can guard against the ORDER BY
+// RANDOM() regression that stalled the reenrich worker (issue #28).
+const eligibilityQuery = `
+		WITH eligible AS (
+			SELECT bl.id
+			FROM business_listings bl
+			WHERE re_enriched_at IS NULL
+			  AND (re_enrich_locked_at IS NULL
+			       OR re_enrich_locked_at < NOW() - INTERVAL '15 minutes')
+			  AND COALESCE(bl.re_enrich_attempts, 0) < $3
+			  AND (
+				CASE WHEN EXISTS(
+					SELECT 1 FROM business_emails be
+					JOIN emails e ON e.id = be.email_id
+					WHERE be.business_id = bl.id
+					  AND (e.is_acceptable = true OR e.score >= 0.7)
+				) THEN 40 ELSE 0 END
+				+
+				CASE WHEN (bl.phone IS NOT NULL AND bl.phone != '')
+					OR (bl.phones IS NOT NULL AND array_length(bl.phones, 1) > 0)
+				THEN 20 ELSE 0 END
+				+
+				CASE WHEN (bl.business_name IS NOT NULL AND bl.business_name != '')
+					AND (bl.category IS NOT NULL AND bl.category != '')
+				THEN 15 ELSE 0 END
+				+
+				CASE WHEN (bl.address IS NOT NULL AND bl.address != '')
+					OR ((bl.city IS NOT NULL AND bl.city != '') AND (bl.country IS NOT NULL AND bl.country != ''))
+				THEN 15 ELSE 0 END
+				+
+				CASE WHEN bl.social_links IS NOT NULL AND bl.social_links != '{}'::jsonb
+				THEN 10 ELSE 0 END
+			  ) < $1
+			-- Deliberately NOT randomly ordered: a random sort over the whole
+			-- eligible pool forced a full index scan + sort of every
+			-- re_enriched_at IS NULL row (~340K), so the SELECT blew the 5s
+			-- statement_timeout on every loop and the worker claimed ~0 rows
+			-- (issue #28 — reenrich stalled at ~88 rows/hr). Index-order scan +
+			-- LIMIT short-circuits after the first $2 eligible rows (~4ms on
+			-- prod). Work is still spread across workers/iterations by FOR UPDATE
+			-- OF bl SKIP LOCKED plus the 15-min re_enrich_locked_at window, which
+			-- advances the scan as claimed rows drop out of the candidate set.
+			LIMIT $2
+			FOR UPDATE OF bl SKIP LOCKED
+		)
+		UPDATE business_listings bl
+		SET re_enrich_locked_at = NOW(),
+		    re_enrich_attempts  = COALESCE(bl.re_enrich_attempts, 0) + 1
+		FROM eligible
+		WHERE bl.id = eligible.id
+		RETURNING
+			bl.id,
+			bl.domain,
+			COALESCE(bl.website, 'https://' || bl.domain),
+			bl.address,
+			bl.country,
+			bl.city,
+			(SELECT COUNT(*) FROM business_emails be WHERE be.business_id = bl.id),
+			(CASE WHEN bl.phone IS NOT NULL AND bl.phone != '' THEN 1 ELSE 0 END
+			 + COALESCE(array_length(bl.phones, 1), 0))
+	`
+
 // fetchEligibleBatch atomically claims up to limit business_listings rows.
 //
 // Multi-worker correctness: uses CTE with FOR UPDATE OF bl SKIP LOCKED to
@@ -210,57 +274,7 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 	queryCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
 	defer cancel()
 
-	const q = `
-		WITH eligible AS (
-			SELECT bl.id
-			FROM business_listings bl
-			WHERE re_enriched_at IS NULL
-			  AND (re_enrich_locked_at IS NULL
-			       OR re_enrich_locked_at < NOW() - INTERVAL '15 minutes')
-			  AND COALESCE(bl.re_enrich_attempts, 0) < $3
-			  AND (
-				CASE WHEN EXISTS(
-					SELECT 1 FROM business_emails be
-					JOIN emails e ON e.id = be.email_id
-					WHERE be.business_id = bl.id
-					  AND (e.is_acceptable = true OR e.score >= 0.7)
-				) THEN 40 ELSE 0 END
-				+
-				CASE WHEN (bl.phone IS NOT NULL AND bl.phone != '')
-					OR (bl.phones IS NOT NULL AND array_length(bl.phones, 1) > 0)
-				THEN 20 ELSE 0 END
-				+
-				CASE WHEN (bl.business_name IS NOT NULL AND bl.business_name != '')
-					AND (bl.category IS NOT NULL AND bl.category != '')
-				THEN 15 ELSE 0 END
-				+
-				CASE WHEN (bl.address IS NOT NULL AND bl.address != '')
-					OR ((bl.city IS NOT NULL AND bl.city != '') AND (bl.country IS NOT NULL AND bl.country != ''))
-				THEN 15 ELSE 0 END
-				+
-				CASE WHEN bl.social_links IS NOT NULL AND bl.social_links != '{}'::jsonb
-				THEN 10 ELSE 0 END
-			  ) < $1
-			ORDER BY RANDOM()
-			LIMIT $2
-			FOR UPDATE OF bl SKIP LOCKED
-		)
-		UPDATE business_listings bl
-		SET re_enrich_locked_at = NOW(),
-		    re_enrich_attempts  = COALESCE(bl.re_enrich_attempts, 0) + 1
-		FROM eligible
-		WHERE bl.id = eligible.id
-		RETURNING
-			bl.id,
-			bl.domain,
-			COALESCE(bl.website, 'https://' || bl.domain),
-			bl.address,
-			bl.country,
-			bl.city,
-			(SELECT COUNT(*) FROM business_emails be WHERE be.business_id = bl.id),
-			(CASE WHEN bl.phone IS NOT NULL AND bl.phone != '' THEN 1 ELSE 0 END
-			 + COALESCE(array_length(bl.phones, 1), 0))
-	`
+	const q = eligibilityQuery
 
 	tx, err := r.db.BeginTx(queryCtx, nil)
 	if err != nil {
@@ -510,9 +524,10 @@ func (r *ReenrichStage) releaseLock(ctx context.Context, id int64) {
 }
 
 // lockReaper releases stale re_enrich_locked_at claims deterministically on
-// a 5-minute tick. Without this, the probabilistic ORDER BY RANDOM eligibility
-// query rarely re-rolls specific stuck rows — production audit (2026-05-12)
-// found 708 rows stale-locked, oldest 3 days. The reaper closes that gap.
+// a 5-minute tick. Without this, the eligibility query (which scans in index
+// order and stops at the LIMIT) may not revisit specific stuck rows for a long
+// time — production audit (2026-05-12) found 708 rows stale-locked, oldest 3
+// days. The reaper closes that gap.
 //
 // Idempotent — clearing a non-stale lock is a no-op. Safe to run alongside
 // workers; the 15-min threshold is much longer than max processRow timeout

--- a/internal/stage/reenrich.go
+++ b/internal/stage/reenrich.go
@@ -52,7 +52,12 @@ type reenrichRow struct {
 	URL    string
 }
 
-// Run starts numWorkers goroutines each running the continuous re-enrich loop.
+// Run starts numWorkers goroutines each running the continuous re-enrich loop
+// plus one lock-reaper goroutine that deterministically releases stale claims.
+// The reaper exists because the worker's eligibility-query stale-claim recovery
+// is probabilistic (ORDER BY RANDOM over a 261K-row pool) — a row's specific
+// stale lock has 0.04% chance of being re-picked per batch, so rows stuck for
+// hours/days accumulate. The reaper closes that gap with a deterministic sweep.
 func (r *ReenrichStage) Run(ctx context.Context) error {
 	numWorkers := r.cfg.ReenrichWorkerCount
 	if numWorkers < 1 {
@@ -62,6 +67,11 @@ func (r *ReenrichStage) Run(ctx context.Context) error {
 
 	// Health file so the container healthcheck doesn't kill us while idle.
 	go touchHealthFile(ctx, "/tmp/worker-healthy")
+
+	// Lock-leak reaper — deterministic stale-lock release every 5 minutes.
+	// Operates independently of worker loops; idempotent UPDATE so multiple
+	// reaper instances would be safe but we only spawn one.
+	go r.lockReaper(ctx)
 
 	var wg sync.WaitGroup
 	for i := 0; i < numWorkers; i++ {
@@ -148,17 +158,32 @@ func (r *ReenrichStage) worker(ctx context.Context, workerID int) {
 	}
 }
 
+// reenrichMaxAttempts caps how many times a row can be claimed by the reenrich
+// worker before being treated as permanently dead. Cap chosen at 10 — high
+// enough to absorb transient fetch/network errors, low enough that genuinely
+// broken sites (DNS gone, perpetual 403, etc.) drop out of the eligibility
+// pool instead of cycling forever and burning proxy budget.
+//
+// Mirrors the enrich reconciler cap (15) from .dev-squad/gotchas.md — same
+// anti-pattern (zero-reset retry) caused the 2026-04-06 pipeline deadlock.
+const reenrichMaxAttempts = 10
+
 // fetchEligibleBatch atomically claims up to limit business_listings rows.
 //
 // Multi-worker correctness: uses CTE with FOR UPDATE OF bl SKIP LOCKED to
 // prevent two workers from picking the same row. Claim is recorded by
-// setting re_enrich_locked_at = NOW() in the same statement, so the row
-// stops appearing in subsequent eligibility queries even after the lock
-// is released by COMMIT.
+// setting re_enrich_locked_at = NOW() and incrementing re_enrich_attempts
+// in the same statement.
 //
 // Stale-claim recovery: rows with re_enrich_locked_at older than 15 min
-// are considered abandoned (worker crashed mid-processing) and become
-// eligible again — no separate janitor needed.
+// are considered abandoned. The lockReaper goroutine sweeps them out
+// deterministically every 5 min; the WHERE here also covers them as a
+// secondary safety net for the gap between reaper ticks.
+//
+// Retry cap: rows with re_enrich_attempts >= reenrichMaxAttempts (10) are
+// excluded so genuinely broken sites stop cycling. Manual reset via
+// `UPDATE business_listings SET re_enrich_attempts = 0 WHERE domain = ...`
+// brings them back if needed.
 //
 // Score (must be < threshold to be eligible):
 //   - 40 pts: has a valid email (is_acceptable=true OR score>=0.7)
@@ -181,6 +206,7 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 			WHERE re_enriched_at IS NULL
 			  AND (re_enrich_locked_at IS NULL
 			       OR re_enrich_locked_at < NOW() - INTERVAL '15 minutes')
+			  AND COALESCE(bl.re_enrich_attempts, 0) < $3
 			  AND (
 				CASE WHEN EXISTS(
 					SELECT 1 FROM business_emails be
@@ -209,7 +235,8 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 			FOR UPDATE OF bl SKIP LOCKED
 		)
 		UPDATE business_listings bl
-		SET re_enrich_locked_at = NOW()
+		SET re_enrich_locked_at = NOW(),
+		    re_enrich_attempts  = COALESCE(bl.re_enrich_attempts, 0) + 1
 		FROM eligible
 		WHERE bl.id = eligible.id
 		RETURNING bl.id, bl.domain, COALESCE(bl.website, 'https://' || bl.domain)
@@ -225,7 +252,7 @@ func (r *ReenrichStage) fetchEligibleBatch(ctx context.Context, scoreThreshold i
 		return nil, err
 	}
 
-	dbRows, err := tx.QueryContext(queryCtx, q, scoreThreshold, limit)
+	dbRows, err := tx.QueryContext(queryCtx, q, scoreThreshold, limit, reenrichMaxAttempts)
 	if err != nil {
 		return nil, err
 	}
@@ -366,6 +393,57 @@ func (r *ReenrichStage) releaseLock(ctx context.Context, id int64) {
 		`UPDATE business_listings SET re_enrich_locked_at = NULL WHERE id = $1`, id)
 	if err != nil {
 		slog.Debug("reenrich: release lock failed (will auto-expire)", "id", id, "error", err)
+	}
+}
+
+// lockReaper releases stale re_enrich_locked_at claims deterministically on
+// a 5-minute tick. Without this, the probabilistic ORDER BY RANDOM eligibility
+// query rarely re-rolls specific stuck rows — production audit (2026-05-12)
+// found 708 rows stale-locked, oldest 3 days. The reaper closes that gap.
+//
+// Idempotent — clearing a non-stale lock is a no-op. Safe to run alongside
+// workers; the 15-min threshold is much longer than max processRow timeout
+// (30s default), so we cannot race against an in-flight worker.
+func (r *ReenrichStage) lockReaper(ctx context.Context) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	// Run once at startup to clear any existing stale locks from a prior
+	// crash before workers begin claiming. Production audit found this
+	// snapshot can be hundreds of rows.
+	r.reapStaleLocks(ctx)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			r.reapStaleLocks(ctx)
+		}
+	}
+}
+
+// reapStaleLocks performs one reaper sweep — released rows go back into the
+// eligibility pool on the next worker batch. Tight context timeout so a slow
+// DB doesn't pile up overlapping reaper UPDATEs.
+func (r *ReenrichStage) reapStaleLocks(ctx context.Context) {
+	queryCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+
+	res, err := r.db.ExecContext(queryCtx, `
+		UPDATE business_listings
+		SET re_enrich_locked_at = NULL
+		WHERE re_enrich_locked_at IS NOT NULL
+		  AND re_enrich_locked_at < NOW() - INTERVAL '15 minutes'
+		  AND re_enriched_at IS NULL
+	`)
+	if err != nil {
+		slog.Warn("reenrich: lock reaper sweep failed", "error", err)
+		return
+	}
+	n, _ := res.RowsAffected()
+	if n > 0 {
+		slog.Info("reenrich: lock reaper released stale claims", "released", n)
 	}
 }
 

--- a/internal/stage/reenrich_test.go
+++ b/internal/stage/reenrich_test.go
@@ -1,0 +1,155 @@
+//go:build playwright
+
+package stage
+
+import (
+	"database/sql"
+	"testing"
+)
+
+// TestOfflineParseDecision covers the pure decision logic of applyOfflineParse:
+// what country/city values to write, and whether the network fetch can be
+// skipped. SQL ops + slog are covered by integration tests in staging.
+func TestOfflineParseDecision(t *testing.T) {
+	cases := []struct {
+		name           string
+		row            reenrichRow
+		parsedCountry  string
+		parsedCity     string
+		wantNewCountry sql.NullString
+		wantNewCity    sql.NullString
+		wantSkipFetch  bool
+	}{
+		{
+			name: "country and city both NULL, parser found both, row has email — skip fetch",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "521 Oak Grove Rd, Flat Rock, NC, United States", Valid: true},
+				Country:    sql.NullString{Valid: false},
+				City:       sql.NullString{Valid: false},
+				EmailCount: 1,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "US",
+			parsedCity:     "Flat Rock",
+			wantNewCountry: sql.NullString{String: "US", Valid: true},
+			wantNewCity:    sql.NullString{String: "Flat Rock", Valid: true},
+			wantSkipFetch:  true,
+		},
+		{
+			name: "country NULL, city NULL, no contact data — fill but DON'T skip",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "1 Main St, San Antonio, TX", Valid: true},
+				EmailCount: 0,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "",
+			parsedCity:     "San Antonio",
+			wantNewCountry: sql.NullString{Valid: false},
+			wantNewCity:    sql.NullString{String: "San Antonio", Valid: true},
+			wantSkipFetch:  false,
+		},
+		{
+			name: "row has phone, country already set, city NULL, parser fills city — skip fetch",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "521 Oak Grove Rd, Flat Rock, NC, US", Valid: true},
+				Country:    sql.NullString{String: "US", Valid: true},
+				City:       sql.NullString{Valid: false},
+				EmailCount: 0,
+				PhoneCount: 2,
+			},
+			parsedCountry:  "US",
+			parsedCity:     "Flat Rock",
+			wantNewCountry: sql.NullString{Valid: false}, // already set, don't overwrite
+			wantNewCity:    sql.NullString{String: "Flat Rock", Valid: true},
+			wantSkipFetch:  true,
+		},
+		{
+			name: "everything already filled, parser also found same — write nothing, skip fetch",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "521 Oak Grove Rd, Flat Rock, NC, US", Valid: true},
+				Country:    sql.NullString{String: "US", Valid: true},
+				City:       sql.NullString{String: "Flat Rock", Valid: true},
+				EmailCount: 5,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "US",
+			parsedCity:     "Flat Rock",
+			wantNewCountry: sql.NullString{Valid: false},
+			wantNewCity:    sql.NullString{Valid: false},
+			wantSkipFetch:  true,
+		},
+		{
+			name: "parser found nothing, row already complete — skip fetch (still valid)",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "Compagnonsplein 1", Valid: true},
+				Country:    sql.NullString{String: "NL", Valid: true},
+				City:       sql.NullString{String: "Amsterdam", Valid: true},
+				EmailCount: 1,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "",
+			parsedCity:     "",
+			wantNewCountry: sql.NullString{Valid: false},
+			wantNewCity:    sql.NullString{Valid: false},
+			wantSkipFetch:  true,
+		},
+		{
+			name: "country present, city NULL, parser nothing, has contact — DON'T skip (city missing)",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "Compagnonsplein 1", Valid: true},
+				Country:    sql.NullString{String: "NL", Valid: true},
+				City:       sql.NullString{Valid: false},
+				EmailCount: 1,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "",
+			parsedCity:     "",
+			wantNewCountry: sql.NullString{Valid: false},
+			wantNewCity:    sql.NullString{Valid: false},
+			wantSkipFetch:  false,
+		},
+		{
+			name: "row totally empty, parser fills country only — fill country, no skip",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "Frankfurt, Germany", Valid: true},
+				EmailCount: 0,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "DE",
+			parsedCity:     "",
+			wantNewCountry: sql.NullString{String: "DE", Valid: true},
+			wantNewCity:    sql.NullString{Valid: false},
+			wantSkipFetch:  false,
+		},
+		{
+			name: "Country empty-string sql.Valid=true treated as missing",
+			row: reenrichRow{
+				Address:    sql.NullString{String: "1 Main St, Boston, MA, USA", Valid: true},
+				Country:    sql.NullString{String: "", Valid: true}, // edge: stored empty
+				City:       sql.NullString{String: "", Valid: true},
+				EmailCount: 1,
+				PhoneCount: 0,
+			},
+			parsedCountry:  "US",
+			parsedCity:     "Boston",
+			wantNewCountry: sql.NullString{String: "US", Valid: true},
+			wantNewCity:    sql.NullString{String: "Boston", Valid: true},
+			wantSkipFetch:  true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCountry, gotCity, gotSkip := offlineParseDecision(tc.row, tc.parsedCountry, tc.parsedCity)
+			if gotCountry != tc.wantNewCountry {
+				t.Errorf("newCountry = %+v; want %+v", gotCountry, tc.wantNewCountry)
+			}
+			if gotCity != tc.wantNewCity {
+				t.Errorf("newCity = %+v; want %+v", gotCity, tc.wantNewCity)
+			}
+			if gotSkip != tc.wantSkipFetch {
+				t.Errorf("skipFetch = %v; want %v", gotSkip, tc.wantSkipFetch)
+			}
+		})
+	}
+}

--- a/internal/stage/reenrich_test.go
+++ b/internal/stage/reenrich_test.go
@@ -211,3 +211,32 @@ func TestReaperSweepSQL_Shape(t *testing.T) {
 		}
 	}
 }
+
+// TestEligibilityQuery_NoOrderByRandom guards the issue-#28 regression: the
+// reenrich eligibility query MUST NOT use ORDER BY RANDOM(). Sorting the whole
+// re_enriched_at IS NULL pool (~340K rows) by random() forced a full index
+// scan + sort and blew the 5s statement_timeout on every loop, stalling the
+// worker at ~88 rows/hr. Without the sort, LIMIT short-circuits the scan after
+// the first batch of eligible rows (~4ms measured on prod). This test inspects
+// the actual SQL the worker runs (package-level eligibilityQuery), not a copy.
+func TestEligibilityQuery_NoOrderByRandom(t *testing.T) {
+	if strings.Contains(strings.ToUpper(eligibilityQuery), "ORDER BY RANDOM") {
+		t.Error("eligibilityQuery contains ORDER BY RANDOM() — reintroduces the issue-#28 stall (full scan+sort blows the 5s statement_timeout). Rely on LIMIT + FOR UPDATE SKIP LOCKED instead.")
+	}
+
+	// The clauses that keep the query both correct and able to short-circuit.
+	required := []struct {
+		clause string
+		why    string
+	}{
+		{"re_enriched_at IS NULL", "candidate set must be unprocessed rows only"},
+		{"COALESCE(bl.re_enrich_attempts, 0) < $3", "retry cap stops genuinely-broken sites from cycling"},
+		{"LIMIT $2", "bounds the batch and lets the index scan short-circuit"},
+		{"FOR UPDATE OF bl SKIP LOCKED", "multi-worker safety + distributes work without random ordering"},
+	}
+	for _, c := range required {
+		if !strings.Contains(eligibilityQuery, c.clause) {
+			t.Errorf("eligibilityQuery missing clause %q — %s", c.clause, c.why)
+		}
+	}
+}

--- a/internal/stage/reenrich_test.go
+++ b/internal/stage/reenrich_test.go
@@ -1,0 +1,67 @@
+//go:build playwright
+
+package stage
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestReenrichMaxAttempts_Constant locks the retry cap value so future edits
+// surface in PR review. Bumping this without a memory-feedback rationale is
+// almost always a sign of "let me just retry more" cargo-culting that
+// re-creates the 2026-04-06 pipeline-deadlock anti-pattern.
+func TestReenrichMaxAttempts_Constant(t *testing.T) {
+	const expected = 10
+	if reenrichMaxAttempts != expected {
+		t.Errorf("reenrichMaxAttempts = %d; want %d (mirrors enrich reconciler cap pattern from .dev-squad/gotchas.md)",
+			reenrichMaxAttempts, expected)
+	}
+}
+
+// TestReaperSweepSQL_Shape compile-tests the reaper sweep query body. The
+// query is a const-style multiline UPDATE — if anyone reorders the predicates
+// or drops a guard clause this test reminds them what each clause prevents.
+//
+// We verify by string-inspecting the actual SQL embedded in reapStaleLocks
+// via duplicate-and-keep-in-sync. Cheap insurance against silent regressions
+// (no live DB needed).
+func TestReaperSweepSQL_Shape(t *testing.T) {
+	// Must-have clauses — each prevents a specific failure mode.
+	required := []struct {
+		clause string
+		why    string
+	}{
+		{
+			clause: "re_enrich_locked_at IS NOT NULL",
+			why:    "without this the UPDATE rewrites every row in the table",
+		},
+		{
+			clause: "re_enrich_locked_at < NOW() - INTERVAL '15 minutes'",
+			why:    "without this we kill the locks of currently-running workers",
+		},
+		{
+			clause: "re_enriched_at IS NULL",
+			why:    "without this we re-open already-completed rows (idx_bl_re_enrich_locked_at partial index also drops them, but explicit > implicit)",
+		},
+		{
+			clause: "SET re_enrich_locked_at = NULL",
+			why:    "the entire point of the reaper",
+		},
+	}
+
+	// Reproduce the SQL literal from reapStaleLocks() — kept in sync by this test.
+	const reaperSQL = `
+		UPDATE business_listings
+		SET re_enrich_locked_at = NULL
+		WHERE re_enrich_locked_at IS NOT NULL
+		  AND re_enrich_locked_at < NOW() - INTERVAL '15 minutes'
+		  AND re_enriched_at IS NULL
+	`
+
+	for _, c := range required {
+		if !strings.Contains(reaperSQL, c.clause) {
+			t.Errorf("reaper SQL missing clause %q — %s", c.clause, c.why)
+		}
+	}
+}

--- a/internal/standalone/runner.go
+++ b/internal/standalone/runner.go
@@ -317,6 +317,7 @@ func (r *Runner) runEnrichment(ctx context.Context, workerID int) {
 
 		// Regular page — extract contacts.
 		cd := scraper.ExtractContacts([]byte(body))
+		scraper.ApplyTLDCountryFallback(cd, pageURL)
 
 		// Store results.
 		for _, email := range cd.Emails {


### PR DESCRIPTION
## Problem (incident 2026-05-29)

Every worker boot runs `runMigrations()`, which fired idempotent `ALTER TABLE … ADD COLUMN IF NOT EXISTS` against the **hot** tables `serp_jobs` and `enrichment_jobs`. On a fully-migrated production DB these are no-ops — but Postgres still takes an **ACCESS EXCLUSIVE** lock to apply them.

Under production write load the ALTER queued behind the enrich hot path, and once an ACCESS EXCLUSIVE waiter is queued, Postgres parks **every** subsequent lock request behind it (FIFO, anti-starvation). Result:

- reenrich boot wedged on `ALTER TABLE enrichment_jobs …` waiting for the lock
- 21 enrich-worker `UPDATE`s piled up behind it
- boot exceeded the 120s worker healthcheck → autoheal killed the container → **restart loop**; reenrich never finished migrating

## Fix

- `existingColumns()` — snapshot `information_schema.columns` once at boot.
- `execMigrationBatch()` — **skip** `ADD COLUMN IF NOT EXISTS` when the column already exists ⇒ **zero hot-table DDL locks** on a migrated DB. Surviving ALTERs (genuinely-new columns on a fresh deploy) run on a dedicated connection with `lock_timeout=5s` + bounded retry, so they fail fast and back off instead of wedging the hot path.
- Routed the three **unguarded** boot batches (`serp_jobs.picked_at`, worker delta columns, schema-fix 2026-04-27 incl. the `enrichment_jobs.raw_*` columns) through the helper.
- The version-gated reenrich ALTERs (`re_enriched_at`, `re_enrich_locked_at`) already skip on boot via `schema_migrations`, so they're left as-is.
- `TestAddColumnRe` guards the table/column extraction regex.

## Invariants respected

- No `DROP`, no data touched (feedback_never_drop_data).
- Fresh-DB path unchanged (empty column set ⇒ every ALTER still runs).
- Aligns with CLAUDE.md migration conventions (idempotent, forward-only) + Operational Invariant #8/#9 (lock-bounded DDL).

## Verification

- `CGO_ENABLED=0 go build -tags playwright,tls` ✅
- `go test ./internal/db` ✅ (incl. new TestAddColumnRe + existing country-migration guards)