### PR TITLE
feat(yogaalliance): crawl RYS schools (standalone listings + contacts) via directory API

### DIFF
--- a/cmd/yogaalliance/main.go
+++ b/cmd/yogaalliance/main.go
@@ -43,6 +43,7 @@ import (
 	"encoding/json"
 	"flag"
 	"fmt"
+	"html"
 	"io"
 	"log"
 	"net/http"
@@ -68,6 +69,16 @@ const (
 	methodSchool  = "getSchoolDetails"
 	methodTeacher = "getTeacherDetails"
 	srcTag        = "yogaalliance"
+
+	// Directory search controller (YaDirectorySearchController). fetchSchoolRecords
+	// with EMPTY location fields returns ALL published RYS schools globally (~6.8K),
+	// paginated; max pageSize is 25 (50+ errors). fetchSchoolRecordsCount gives the
+	// total. Discovered via the /directory page network calls (2026-05-29).
+	classSchoolSearch   = "@udd/01pTR000001kCE3"
+	methodSchoolRecords = "fetchSchoolRecords"
+	methodSchoolCount   = "fetchSchoolRecordsCount"
+	schoolPageSize      = 25
+	schoolSrcTag        = "yogaalliance-school"
 )
 
 var (
@@ -142,8 +153,8 @@ func main() {
 	dsn := flag.String("dsn", os.Getenv("POSTGRES_DSN"), "Postgres DSN (default $POSTGRES_DSN)")
 	flag.Parse()
 
-	if *mode != "teacher" {
-		log.Fatalf("only -mode teacher is supported (account sitemap is mostly non-school households; schools come via teacher teachingHistory)")
+	if *mode != "teacher" && *mode != "school" {
+		log.Fatalf("-mode must be 'teacher' or 'school'")
 	}
 
 	var db *sql.DB
@@ -166,11 +177,16 @@ func main() {
 
 	outPath := *out
 	if outPath == "" && !*doInsert {
-		outPath = "teachers.csv"
+		outPath = *mode + "s.csv"
 	}
 
 	client := newClient()
 	bootstrap(client)
+
+	if *mode == "school" {
+		runSchools(client, db, *conc, *limit, outPath)
+		return
+	}
 
 	var ids []string
 	if *idsFile != "" {
@@ -434,7 +450,310 @@ func upsertTeacher(db *sql.DB, t *teacher) error {
 
 func clean(s string) string {
 	s = tagsRe.ReplaceAllString(s, " ")
+	s = html.UnescapeString(s) // decode &amp; &#39; etc. (entity bug, 2026-05-29)
 	return strings.TrimSpace(spacesRe.ReplaceAllString(s, " "))
+}
+
+// ---- School crawl (RYS directory) ----
+
+type schoolListResp struct {
+	ReturnValue []schoolRec `json:"returnValue"`
+}
+type schoolRec struct {
+	Id            string `json:"Id"`
+	DirectoryName string `json:"directoryName"`
+	Address       string `json:"address"`
+	Website       string `json:"schoolWebsite"`
+	Designation   string `json:"schoolDesignation"`
+	ParentName    string `json:"parentName"`
+}
+type schoolDetailResp struct {
+	ReturnValue struct {
+		Id            string `json:"Id"`
+		DirectoryName string `json:"directoryName"`
+		Address       string `json:"address"`
+		Website       string `json:"schoolWebsite"`
+		Email         string `json:"schoolEmail"`
+		Instagram     string `json:"schoolInstagram"`
+		Facebook      string `json:"schoolFacebook"`
+		Twitter       string `json:"schoolTwitter"`
+		Biography     string `json:"biography"`
+		Designation   string `json:"schoolDesignation"`
+		ParentName    string `json:"parentName"`
+		Languages     string `json:"languages"`
+		TypesOfYoga   string `json:"typesOfYogaTaught"`
+	} `json:"returnValue"`
+}
+type school struct {
+	id, name, address, website, email string
+	instagram, facebook, twitter, bio string
+	designation, parentName, yoga     string
+}
+
+// searchParams builds the fetchSchoolRecords/Count param map. Empty location =>
+// global (all published RYS schools); page* only used by the records call.
+func searchParams(pageSize, pageNumber int) map[string]any {
+	return map[string]any{
+		"schoolId": "", "schoolGoogleAddress": "", "schoolLatitude": 0, "schoolLongitude": 0,
+		"schoolStreet": "", "schoolCity": "", "schoolState": "", "schoolCountry": "",
+		"searchRadius": 50, "name": "", "designation": "",
+		"onlineServices": false, "closedCaptioning": false,
+		"selectedDesignations": []any{}, "selectedTrainingFormats": []any{},
+		"offerScholarship": false, "offerExchangePrograms": false,
+		"acceptsMyCAA": false, "acceptsGiBill": false,
+		"ratings": []any{}, "typesOfYoga": []any{}, "language": "",
+		"sortDirection": "ASC", "pageSize": pageSize, "pageNumber": pageNumber, "SearchFlag": true,
+	}
+}
+
+func apexPOST(c *http.Client, class, method string, params map[string]any) ([]byte, error) {
+	reqBody, _ := json.Marshal(apexReq{Classname: class, Method: method, Params: params})
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		req, _ := http.NewRequest("POST", apexURL, bytes.NewReader(reqBody))
+		req.Header.Set("User-Agent", userAgent)
+		req.Header.Set("Content-Type", "application/json; charset=utf-8")
+		resp, err := c.Do(req)
+		if err != nil {
+			lastErr = err
+			time.Sleep(time.Duration(attempt+1) * 500 * time.Millisecond)
+			continue
+		}
+		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
+		if resp.StatusCode != 200 {
+			lastErr = fmt.Errorf("status %d", resp.StatusCode)
+			time.Sleep(time.Duration(attempt+1) * 400 * time.Millisecond)
+			continue
+		}
+		return body, nil
+	}
+	return nil, lastErr
+}
+
+func fetchSchoolCount(c *http.Client) int {
+	body, err := apexPOST(c, classSchoolSearch, methodSchoolCount, searchParams(schoolPageSize, 1))
+	if err != nil {
+		return 0
+	}
+	var r struct {
+		ReturnValue int `json:"returnValue"`
+	}
+	json.Unmarshal(body, &r)
+	return r.ReturnValue
+}
+
+// fetchSchoolList paginates the global RYS directory and returns unique school
+// records (deduped by Id). limit caps the count (0 = all).
+func fetchSchoolList(c *http.Client, limit int) []schoolRec {
+	seen := map[string]bool{}
+	var out []schoolRec
+	for page := 1; ; page++ {
+		body, err := apexPOST(c, classSchoolSearch, methodSchoolRecords, searchParams(schoolPageSize, page))
+		if err != nil {
+			log.Printf("  school list page %d: %v", page, err)
+			break
+		}
+		var r schoolListResp
+		if json.Unmarshal(body, &r) != nil || len(r.ReturnValue) == 0 {
+			break
+		}
+		for _, rec := range r.ReturnValue {
+			if rec.Id == "" || seen[rec.Id] {
+				continue
+			}
+			seen[rec.Id] = true
+			out = append(out, rec)
+		}
+		if page%20 == 0 {
+			log.Printf("  enumerated %d unique schools (page %d)", len(out), page)
+		}
+		if limit > 0 && len(out) >= limit {
+			out = out[:limit]
+			break
+		}
+	}
+	return out
+}
+
+// fetchSchool merges the list record with getSchoolDetails (email/social/bio).
+func fetchSchool(c *http.Client, rec schoolRec) *school {
+	s := &school{
+		id: rec.Id, name: clean(rec.DirectoryName), address: clean(rec.Address),
+		website: strings.TrimSpace(rec.Website), designation: clean(rec.Designation),
+		parentName: clean(rec.ParentName),
+	}
+	body, err := apexPOST(c, classSchool, methodSchool, map[string]any{"schoolId": rec.Id})
+	if err == nil {
+		var d schoolDetailResp
+		if json.Unmarshal(body, &d) == nil && d.ReturnValue.Id != "" {
+			v := d.ReturnValue
+			if clean(v.DirectoryName) != "" {
+				s.name = clean(v.DirectoryName)
+			}
+			if clean(v.Address) != "" {
+				s.address = clean(v.Address)
+			}
+			if strings.TrimSpace(v.Website) != "" {
+				s.website = strings.TrimSpace(v.Website)
+			}
+			s.email = strings.TrimSpace(v.Email)
+			s.instagram = strings.TrimSpace(v.Instagram)
+			s.facebook = strings.TrimSpace(v.Facebook)
+			s.twitter = strings.TrimSpace(v.Twitter)
+			s.bio = clean(v.Biography)
+			s.yoga = clean(v.TypesOfYoga)
+		}
+	}
+	return s
+}
+
+func (s *school) row() []string {
+	return []string{s.id, s.name, s.email, s.address, s.website, s.instagram, s.facebook, s.twitter, s.designation, s.parentName, s.yoga}
+}
+
+func runSchools(c *http.Client, db *sql.DB, conc, limit int, outPath string) {
+	total := fetchSchoolCount(c)
+	log.Printf("yogaalliance: school — directory reports %d published RYS schools globally", total)
+	recs := fetchSchoolList(c, limit)
+	log.Printf("yogaalliance: school — %d unique schools to fetch (concurrency=%d, insert=%v, csv=%q)", len(recs), conc, db != nil, outPath)
+
+	var w *csv.Writer
+	var csvMu sync.Mutex
+	if outPath != "" {
+		f, err := os.Create(outPath)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer f.Close()
+		w = csv.NewWriter(f)
+		defer w.Flush()
+		w.Write([]string{"id", "name", "email", "address", "website", "instagram", "facebook", "twitter", "designation", "parent_name", "yoga_types"})
+	}
+
+	var done, ok, withEmail, withWeb, inserted int64
+	jobs := make(chan schoolRec, conc*2)
+	var wg sync.WaitGroup
+	for i := 0; i < conc; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for rec := range jobs {
+				s := fetchSchool(c, rec)
+				n := atomic.AddInt64(&done, 1)
+				if s != nil && s.name != "" {
+					atomic.AddInt64(&ok, 1)
+					if s.email != "" {
+						atomic.AddInt64(&withEmail, 1)
+					}
+					if s.website != "" {
+						atomic.AddInt64(&withWeb, 1)
+					}
+					if w != nil {
+						csvMu.Lock()
+						w.Write(s.row())
+						if n%200 == 0 {
+							w.Flush()
+						}
+						csvMu.Unlock()
+					}
+					if db != nil {
+						if err := upsertSchool(db, s); err != nil {
+							log.Printf("  upsert school %s failed: %v", s.id, err)
+						} else {
+							atomic.AddInt64(&inserted, 1)
+						}
+					}
+				}
+				if n%200 == 0 {
+					log.Printf("  progress: %d/%d done, %d ok, %d web, %d email, %d inserted",
+						n, len(recs), atomic.LoadInt64(&ok), atomic.LoadInt64(&withWeb), atomic.LoadInt64(&withEmail), atomic.LoadInt64(&inserted))
+				}
+			}
+		}()
+	}
+	for _, rec := range recs {
+		jobs <- rec
+	}
+	close(jobs)
+	wg.Wait()
+	if w != nil {
+		w.Flush()
+	}
+	log.Printf("DONE schools: %d fetched, %d ok, %d with website, %d with email, %d inserted", done, ok, withWeb, withEmail, inserted)
+}
+
+// upsertSchool writes one RYS school as a standalone listing (category
+// yogaalliance-school), synthetic unique domain "<id>.rys.yogaalliance.org",
+// real studio site in website, socials in social_links.
+func upsertSchool(db *sql.DB, s *school) error {
+	domain := strings.ToLower(s.id) + ".rys.yogaalliance.org"
+	profileURL := "https://app.yogaalliance.org/schoolpublicprofile?id=" + s.id
+
+	social := map[string]string{}
+	if s.instagram != "" {
+		social["instagram"] = s.instagram
+	}
+	if s.facebook != "" {
+		social["facebook"] = s.facebook
+	}
+	if s.twitter != "" {
+		social["twitter"] = s.twitter
+	}
+	socialJSON, _ := json.Marshal(social)
+
+	var bizID int64
+	err := db.QueryRow(`
+		INSERT INTO business_listings
+		  (domain, url, business_name, contact_name, address, description,
+		   social_links, niche_category, off_niche, category, website, created_at, updated_at)
+		VALUES ($1,$2,$3,'',NULLIF($4,''),NULLIF($5,''),
+		   $6::jsonb,'yoga',false,'yogaalliance-school',NULLIF($7,''),NOW(),NOW())
+		ON CONFLICT (domain) DO UPDATE SET
+		  business_name = COALESCE(NULLIF(EXCLUDED.business_name,''), business_listings.business_name),
+		  address       = COALESCE(NULLIF(EXCLUDED.address,''), business_listings.address),
+		  social_links  = EXCLUDED.social_links,
+		  website       = COALESCE(NULLIF(EXCLUDED.website,''), business_listings.website),
+		  description   = COALESCE(NULLIF(EXCLUDED.description,''), business_listings.description),
+		  niche_category = 'yoga', off_niche = false, category = 'yogaalliance-school',
+		  updated_at = NOW()
+		RETURNING id`,
+		domain, profileURL, s.name, s.address, s.bio, string(socialJSON), s.website,
+	).Scan(&bizID)
+	if err != nil {
+		return fmt.Errorf("business_listings upsert: %w", err)
+	}
+
+	if s.email == "" {
+		return nil
+	}
+	at := strings.LastIndex(s.email, "@")
+	if at < 1 {
+		return nil
+	}
+	emailDomain := strings.ToLower(s.email[at+1:])
+	localPart := s.email[:at]
+
+	var emailID int64
+	err = db.QueryRow(`
+		INSERT INTO emails (email, domain, local_part, free_email, created_at)
+		VALUES ($1,$2,$3,$4,NOW())
+		ON CONFLICT (email) DO UPDATE SET domain = EXCLUDED.domain
+		RETURNING id`,
+		strings.ToLower(s.email), emailDomain, localPart, freeMail[emailDomain],
+	).Scan(&emailID)
+	if err != nil {
+		return fmt.Errorf("emails upsert: %w", err)
+	}
+
+	_, err = db.Exec(`
+		INSERT INTO business_emails (business_id, email_id, source)
+		VALUES ($1,$2,$3) ON CONFLICT (business_id, email_id) DO NOTHING`,
+		bizID, emailID, schoolSrcTag)
+	if err != nil {
+		return fmt.Errorf("business_emails link: %w", err)
+	}
+	return nil
 }
 
 func httpGet(c *http.Client, url string) []byte {


### PR DESCRIPTION
## What
Adds `-mode school` to the YogaAlliance crawler so **schools/studios** land as standalone `business_listings` with their own contacts — complementing the 76K teachers already imported.

## How (discovered by inspecting the /directory page network calls)
- **`fetchSchoolRecords`** (class `@udd/01pTR000001kCE3`) with **empty location** returns **all published RYS schools globally (~6,858)**, paginated (max pageSize 25). `fetchSchoolRecordsCount` gives the total.
- **`getSchoolDetails`** on those *real* RYS IDs returns full contact: `schoolWebsite` (real studio site), `schoolEmail`, `schoolInstagram/Facebook/Twitter`, address, biography, designation.
- Note: the sitemap `account-*.xml` IDs reject `getSchoolDetails` (tested 0/190 — they're household accounts); only directory-search IDs are valid. That's why `-mode school` was previously disabled.

## DB mapping (no migration)
- `business_listings`: synthetic unique domain `<id>.rys.yogaalliance.org`, `business_name`=school, real site in `website`, socials in `social_links`, `address`, `category='yogaalliance-school'`, `niche_category='yoga'`, `off_niche=false`.
- `emails` + `business_emails` (source `yogaalliance-school`) when the school published an email.

## Bonus
`clean()` now `html.UnescapeString` — fixes the `&amp;` entity bug seen in teacher names.

## Verification
`go build`+`vet` OK. Smoke test (`-limit 8 -insert` on prod): 8/8 inserted, 6 with website, 6 with email; rows verified (World Yoga Center→anusarayoga.com, Peachtree Yoga→peachtreeyoga.com, etc., global coverage).
