### PR TITLE
fix(yogaalliance): early-stop per-center sweep (fixes 2h plateau stall)

### DIFF
--- a/cmd/yogaalliance/main.go
+++ b/cmd/yogaalliance/main.go
@@ -654,9 +654,16 @@ func enumerateSchools(c *http.Client, total, limit int) []schoolRec {
 			out = append(out, rec)
 		}
 	}
-	// paginate one location (empty addr = global) up to 120 pages.
+	// paginate one location (empty addr = global) up to 120 pages. Results are
+	// distance-sorted, so a center's NEW schools cluster in the early pages; once
+	// we hit 3 consecutive all-duplicate pages the center is exhausted (its far
+	// rows belong to other centers) — stop early instead of grinding ~80 pages of
+	// dupes. This is the fix for the 2h/plateau stall: dup-heavy overlapping metros
+	// finish in a few pages. The global pass never trips it (every page is new).
 	sweep := func(lat, lng float64, addr, country string) {
+		zeroNew := 0
 		for page := 1; page <= 120; page++ {
+			before := len(out)
 			recs, err := fetchSchoolPage(c, searchParams(lat, lng, addr, country, schoolPageSize, page))
 			if err != nil {
 				log.Printf("  sweep %q page %d: %v — stopping this location (may undercount it)", addr, page, err)
@@ -666,6 +673,13 @@ func enumerateSchools(c *http.Client, total, limit int) []schoolRec {
 				break
 			}
 			add(recs)
+			if len(out) == before {
+				if zeroNew++; zeroNew >= 3 {
+					break
+				}
+			} else {
+				zeroNew = 0
+			}
 			if limit > 0 && len(out) >= limit {
 				return
 			}


### PR DESCRIPTION
## Problem
The school sweep (#34) plateaued: **2h in, 45/132 centers, stuck at 2825/6858**. Each center paginated up to ~80 pages even when every result was a duplicate — online schools + overlapping dense metros re-appear at the top of every distance-sorted search, so dup-heavy US metros wasted ~80 API calls each adding 0 new schools, and the sweep never reached the productive international centers.

## Fix
Stop a center after **3 consecutive all-duplicate pages**. A center's NEW schools cluster in its early (nearest) pages; far rows belong to other centers. Dup-heavy metros now finish in a few pages → the sweep reaches international centers fast. Global pass unaffected (every page is new, never trips the early-stop).

## Verification
`go build`+`vet` OK. Redeploying the fixed binary + rerunning the crawl; final school count reported on completion.