### PR TITLE
fix(api,reenrich): make keyset cursor reachable (#32) + honest reenrich health (#28)

### DIFF
--- a/internal/api/cursor_offset_test.go
+++ b/internal/api/cursor_offset_test.go
@@ -1,0 +1,127 @@
+package api
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	pq "github.com/lib/pq"
+)
+
+// Issue #32 Bug 3: OFFSET responses never emitted a next_cursor, so a client
+// could not bootstrap into keyset mode. offsetNextCursor is the helper that
+// decides whether (and what) cursor to hand back from an OFFSET response.
+func TestOffsetNextCursor(t *testing.T) {
+	tests := []struct {
+		name     string
+		sort     string
+		page     int
+		perPage  int
+		total    int
+		returned int
+		lastID   int64
+		wantSet  bool
+	}{
+		{
+			name: "id desc default, more rows remain -> cursor offered",
+			sort: "", page: 1, perPage: 3, total: 100, returned: 3, lastID: 4280383,
+			wantSet: true,
+		},
+		{
+			name: "explicit id_desc, more rows remain -> cursor offered",
+			sort: "id_desc", page: 2, perPage: 50, total: 1000, returned: 50, lastID: 777,
+			wantSet: true,
+		},
+		{
+			name: "last page (no more rows) -> no cursor",
+			sort: "", page: 10, perPage: 10, total: 100, returned: 10, lastID: 5,
+			wantSet: false,
+		},
+		{
+			name: "empty page -> no cursor",
+			sort: "", page: 50, perPage: 10, total: 100, returned: 0, lastID: 0,
+			wantSet: false,
+		},
+		{
+			name: "non-id sort -> no cursor (keyset is id-keyed only)",
+			sort: "updated_desc", page: 1, perPage: 3, total: 100, returned: 3, lastID: 9,
+			wantSet: false,
+		},
+		{
+			name: "id_asc -> no cursor (cursor walks id DESC)",
+			sort: "id_asc", page: 1, perPage: 3, total: 100, returned: 3, lastID: 9,
+			wantSet: false,
+		},
+		{
+			name: "count unknown but full page -> cursor offered (Bug 2 forward path)",
+			sort: "", page: 1, perPage: 3, total: -1, returned: 3, lastID: 4280383,
+			wantSet: true,
+		},
+		{
+			name: "count unknown and partial page -> no cursor",
+			sort: "", page: 1, perPage: 50, total: -1, returned: 12, lastID: 4280383,
+			wantSet: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := offsetNextCursor(tt.sort, tt.page, tt.perPage, tt.total, tt.returned, tt.lastID)
+			if tt.wantSet {
+				if got == "" {
+					t.Fatalf("expected a cursor, got empty")
+				}
+				id, err := decodeCursor(got)
+				if err != nil {
+					t.Fatalf("offered cursor is not decodable: %v", err)
+				}
+				if id != tt.lastID {
+					t.Fatalf("cursor id = %d, want %d", id, tt.lastID)
+				}
+			} else if got != "" {
+				t.Fatalf("expected no cursor, got %q", got)
+			}
+		})
+	}
+}
+
+func TestIsIDDescOrder(t *testing.T) {
+	for _, s := range []string{"", "id_desc"} {
+		if !isIDDescOrder(s) {
+			t.Errorf("isIDDescOrder(%q) = false, want true", s)
+		}
+	}
+	for _, s := range []string{"id_asc", "updated_desc", "created_asc", "garbage"} {
+		if isIDDescOrder(s) {
+			t.Errorf("isIDDescOrder(%q) = true, want false", s)
+		}
+	}
+}
+
+// Issue #32 bonus: sort=id_desc must not 500 — it must resolve to a valid,
+// keyset-consistent ORDER BY bl.id DESC.
+func TestResultsOrderBy_IDDescExplicit(t *testing.T) {
+	if got := resultsOrderBy("id_desc"); got != "ORDER BY bl.id DESC" {
+		t.Fatalf("resultsOrderBy(id_desc) = %q, want ORDER BY bl.id DESC", got)
+	}
+}
+
+// Issue #32 fix #3: a deep OFFSET that blows the statement timeout must be
+// classified so the handler can return a clean 4xx instead of a generic 500.
+func TestIsStatementTimeout(t *testing.T) {
+	if !isStatementTimeout(context.DeadlineExceeded) {
+		t.Error("context.DeadlineExceeded should classify as timeout")
+	}
+	if !isStatementTimeout(&pq.Error{Code: "57014"}) {
+		t.Error("pq 57014 (query_canceled) should classify as timeout")
+	}
+	if !isStatementTimeout(errors.New("pq: canceling statement due to statement timeout")) {
+		t.Error("statement timeout error string should classify as timeout")
+	}
+	if isStatementTimeout(nil) {
+		t.Error("nil must not classify as timeout")
+	}
+	if isStatementTimeout(errors.New("syntax error at or near")) {
+		t.Error("unrelated error must not classify as timeout")
+	}
+}

--- a/internal/api/v2_handlers_results.go
+++ b/internal/api/v2_handlers_results.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
@@ -113,6 +114,58 @@ func resultsOrderBy(sort string) string {
 	}
 }
 
+// isIDDescOrder reports whether the OFFSET ordering is keyset-compatible with
+// the cursor (which walks bl.id DESC). Only the default order and the explicit
+// id_desc alias qualify — any other sort would make an id-keyed cursor skip or
+// duplicate rows, so we must not hand one out.
+func isIDDescOrder(sort string) bool {
+	return sort == "" || sort == "id_desc"
+}
+
+// offsetNextCursor decides whether an OFFSET-mode response can hand the client
+// a keyset cursor to escape deep-OFFSET timeouts (issue #32, Bug 3 — keyset was
+// previously unreachable because no next_cursor was ever emitted). Returns the
+// opaque cursor, or "" when keyset is not offerable for this page.
+//
+// The cursor is keyed on bl.id DESC, so it is only valid when the page itself
+// is ordered id-descending (isIDDescOrder). When the filtered total is known we
+// offer a cursor only if rows remain after this page; when the count failed
+// (total < 0 — issue #32 Bug 2) we offer one whenever the page came back full,
+// so a consumer with an unreliable total still has a forward path.
+func offsetNextCursor(sort string, page, perPage, total, returned int, lastID int64) string {
+	if returned == 0 || !isIDDescOrder(sort) {
+		return ""
+	}
+	more := false
+	if total >= 0 {
+		more = page*perPage < total
+	} else {
+		more = returned >= perPage
+	}
+	if !more {
+		return ""
+	}
+	return encodeCursor(lastID)
+}
+
+// isStatementTimeout reports whether err is a Postgres statement_timeout / query
+// cancellation (or the request-context deadline firing). Used to map a deep
+// OFFSET scan that blew the timeout to a clean 4xx (offset_too_deep) instead of
+// a generic 500 (issue #32, fix #3).
+func isStatementTimeout(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) {
+		return true
+	}
+	var pqErr *pq.Error
+	if errors.As(err, &pqErr) {
+		return pqErr.Code == "57014" // query_canceled (raised by statement_timeout)
+	}
+	return strings.Contains(strings.ToLower(err.Error()), "statement timeout")
+}
+
 // handleV2ListResults returns paginated business listings with full email info.
 // Two-query strategy: listings first, then batch email fetch.
 func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
@@ -203,6 +256,16 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 
 	rows, err := s.db.QueryContext(ctx, dataQuery, args...)
 	if err != nil {
+		// A deep OFFSET scan that blows the statement timeout used to surface as
+		// a generic 500 (issue #32, Bug 1). Return a clean 4xx pointing the
+		// client at keyset pagination instead — the next_cursor emitted on a
+		// shallower page is the supported escape hatch.
+		if !useCursor && offset > 0 && isStatementTimeout(err) {
+			slog.Warn("v2: results OFFSET timed out — advising keyset cursor", "offset", offset, "error", err)
+			writeV2Error(w, http.StatusBadRequest, "offset_too_deep",
+				"this page is too deep to fetch by offset under load; switch to keyset pagination using the next_cursor returned on a shallower page")
+			return
+		}
 		slog.Error("v2: list error", "error", err)
 		writeV2Error(w, http.StatusInternalServerError, "internal_error", "failed to fetch results")
 		return
@@ -329,7 +392,16 @@ func (s *Server) handleV2ListResults(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeV2Paginated(w, listings, total, page, perPage)
+	// OFFSET mode: emit a keyset next_cursor alongside the pagination meta so a
+	// client can switch off OFFSET before it hits the deep-page timeout (issue
+	// #32, fix #1 — previously keyset was unreachable). Empty (omitted) when the
+	// sort isn't id-keyed or there are no further rows.
+	var lastID int64
+	if len(listings) > 0 {
+		lastID = listings[len(listings)-1].ID
+	}
+	nextCursor := offsetNextCursor(q.Get("sort"), page, perPage, total, len(listings), lastID)
+	writeV2PaginatedCursor(w, listings, total, page, perPage, nextCursor)
 }
 
 // handleV2ResultsStats returns clear, unambiguous stats for results.

--- a/internal/api/v2_response.go
+++ b/internal/api/v2_response.go
@@ -26,6 +26,10 @@ type PaginationMeta struct {
 	Total      int  `json:"total"`
 	TotalPages int  `json:"total_pages"`
 	TotalKnown bool `json:"total_known"`
+	// NextCursor lets an OFFSET-mode consumer switch to keyset pagination to
+	// escape deep-page timeouts (issue #32). Omitted when keyset isn't offerable
+	// for this page (non-id sort, or no further rows).
+	NextCursor string `json:"next_cursor,omitempty"`
 }
 
 // SingleResponse wraps single-object endpoints.
@@ -49,6 +53,13 @@ type ErrorDetail struct {
 // see spec-compliant non-negative values plus an explicit signal that
 // pagination math is unreliable.
 func writeV2Paginated(w http.ResponseWriter, data any, total, page, perPage int) {
+	writeV2PaginatedCursor(w, data, total, page, perPage, "")
+}
+
+// writeV2PaginatedCursor is writeV2Paginated plus an optional keyset next_cursor
+// in the meta (issue #32). An empty nextCursor is omitted from the JSON, so
+// existing OFFSET consumers see an unchanged envelope.
+func writeV2PaginatedCursor(w http.ResponseWriter, data any, total, page, perPage int, nextCursor string) {
 	known := total >= 0
 	if !known {
 		total = 0
@@ -67,6 +78,7 @@ func writeV2Paginated(w http.ResponseWriter, data any, total, page, perPage int)
 			Total:      total,
 			TotalPages: totalPages,
 			TotalKnown: known,
+			NextCursor: nextCursor,
 		},
 	})
 }

--- a/internal/stage/health.go
+++ b/internal/stage/health.go
@@ -10,9 +10,28 @@ import (
 
 // touchHealthFile periodically touches a file to signal container health.
 // Docker healthcheck reads the file's mtime to determine if the worker is alive.
-func touchHealthFile(ctx context.Context, path string) {
+//
+// Optional probes make the signal honest (Operational Invariant #7): if any
+// probe reports false the file is NOT refreshed, so its mtime goes stale and
+// the container healthcheck eventually fails. This lets a worker that is up but
+// not doing useful work (e.g. reenrich whose eligibility query times out every
+// loop — issue #28) surface to autoheal instead of reporting "healthy" forever.
+// With no probes the behavior is unchanged: always healthy. Recovery is
+// automatic — once the probes pass again the next tick refreshes the file.
+func touchHealthFile(ctx context.Context, path string, probes ...func() bool) {
+	healthy := func() bool {
+		for _, p := range probes {
+			if p != nil && !p() {
+				return false
+			}
+		}
+		return true
+	}
+
 	// Touch immediately on startup.
-	os.WriteFile(path, []byte("ok"), 0644)
+	if healthy() {
+		os.WriteFile(path, []byte("ok"), 0644)
+	}
 
 	ticker := time.NewTicker(30 * time.Second)
 	defer ticker.Stop()
@@ -23,7 +42,9 @@ func touchHealthFile(ctx context.Context, path string) {
 			os.Remove(path)
 			return
 		case <-ticker.C:
-			os.WriteFile(path, []byte("ok"), 0644)
+			if healthy() {
+				os.WriteFile(path, []byte("ok"), 0644)
+			}
 		}
 	}
 }

--- a/internal/stage/reenrich.go
+++ b/internal/stage/reenrich.go
@@ -39,6 +39,13 @@ type ReenrichStage struct {
 
 	processed atomic.Int64
 	found     atomic.Int64
+
+	// eligFailures counts consecutive eligibility-query failures across all
+	// workers. Reset to 0 on any successful claim (issue #28 — the worker used
+	// to time out on every loop yet report "healthy", silently producing ~0
+	// rows). When this crosses reenrichMaxConsecutiveEligFailures the health
+	// probe reports degraded so the container healthcheck can stop lying.
+	eligFailures atomic.Int64
 }
 
 // NewReenrichStage creates a new ReenrichStage.
@@ -78,7 +85,10 @@ func (r *ReenrichStage) Run(ctx context.Context) error {
 	slog.Info("reenrich: starting workers", "count", numWorkers, "min_score", r.cfg.ReenrichScore)
 
 	// Health file so the container healthcheck doesn't kill us while idle.
-	go touchHealthFile(ctx, "/tmp/worker-healthy")
+	// The probe lets the file go stale once eligibility queries have been
+	// failing in a row (issue #28) — an idle-but-working reenrich stays healthy,
+	// a stalled one (every query timing out) eventually fails its healthcheck.
+	go touchHealthFile(ctx, "/tmp/worker-healthy", r.healthy)
 
 	// Lock-leak reaper — deterministic stale-lock release every 5 minutes.
 	// Operates independently of worker loops; idempotent UPDATE so multiple
@@ -131,7 +141,16 @@ func (r *ReenrichStage) worker(ctx context.Context, workerID int) {
 			if ctx.Err() != nil {
 				return
 			}
-			slog.Warn("reenrich: eligibility query failed", "worker", workerID, "error", err)
+			fails := r.eligFailures.Add(1)
+			slog.Warn("reenrich: eligibility query failed",
+				"worker", workerID, "error", err, "consecutive_failures", fails)
+			if fails >= reenrichMaxConsecutiveEligFailures {
+				// Surface the stall instead of hiding behind a green healthcheck
+				// (issue #28). touchHealthFile sees healthy()==false and stops
+				// refreshing /tmp/worker-healthy, so autoheal restarts us.
+				slog.Error("reenrich: eligibility query failing repeatedly — reporting degraded health",
+					"worker", workerID, "consecutive_failures", fails)
+			}
 			select {
 			case <-ctx.Done():
 				return
@@ -139,6 +158,9 @@ func (r *ReenrichStage) worker(ctx context.Context, workerID int) {
 			}
 			continue
 		}
+		// Query succeeded (even if it returned zero rows) — the worker is not
+		// stalled, so clear the degraded-health counter.
+		r.recordEligibilitySuccess()
 
 		if len(rows) == 0 {
 			// No eligible rows — sleep and retry.
@@ -179,6 +201,33 @@ func (r *ReenrichStage) worker(ctx context.Context, workerID int) {
 // Mirrors the enrich reconciler cap (15) from .dev-squad/gotchas.md — same
 // anti-pattern (zero-reset retry) caused the 2026-04-06 pipeline deadlock.
 const reenrichMaxAttempts = 10
+
+// reenrichMaxConsecutiveEligFailures is how many back-to-back eligibility-query
+// failures the worker tolerates before the health probe reports degraded.
+// Each failure is followed by a 15s back-off, so 5 ≈ 75s of total failure
+// before we let the health file go stale — long enough to ride out a transient
+// DB blip, short enough that a genuinely stalled worker (issue #28) surfaces to
+// autoheal instead of hiding behind a green healthcheck (Operational Invariant
+// #7: fail-open paths must signal).
+const reenrichMaxConsecutiveEligFailures = 5
+
+// recordEligibilitySuccess clears the consecutive-failure counter after any
+// successful eligibility query (including one that legitimately returns zero
+// eligible rows — that means the query ran, the worker is not stalled).
+func (r *ReenrichStage) recordEligibilitySuccess() { r.eligFailures.Store(0) }
+
+// recordEligibilityFailure increments the consecutive-failure counter after an
+// eligibility query error (statement timeout, etc.).
+func (r *ReenrichStage) recordEligibilityFailure() { r.eligFailures.Add(1) }
+
+// healthy reports whether the reenrich worker is doing useful work. It returns
+// false once eligibility queries have failed reenrichMaxConsecutiveEligFailures
+// times in a row, so touchHealthFile stops refreshing the health file and the
+// container healthcheck eventually fails — making the silent-degradation in
+// issue #28 visible to autoheal.
+func (r *ReenrichStage) healthy() bool {
+	return r.eligFailures.Load() < reenrichMaxConsecutiveEligFailures
+}
 
 // eligibilityQuery is the exact SQL fetchEligibleBatch runs, lifted to package
 // scope so TestEligibilityQuery_NoOrderByRandom can guard against the ORDER BY

--- a/internal/stage/reenrich_test.go
+++ b/internal/stage/reenrich_test.go
@@ -240,3 +240,38 @@ func TestEligibilityQuery_NoOrderByRandom(t *testing.T) {
 		}
 	}
 }
+
+// TestReenrichHealthGate covers the honest-healthcheck logic (issue #28, fix #4):
+// the worker stays healthy while eligibility queries succeed (even with zero
+// rows), and only reports degraded after reenrichMaxConsecutiveEligFailures
+// consecutive failures — at which point touchHealthFile stops refreshing the
+// health file so autoheal can restart the stalled worker.
+func TestReenrichHealthGate(t *testing.T) {
+	r := &ReenrichStage{}
+
+	if !r.healthy() {
+		t.Fatal("a fresh worker must report healthy")
+	}
+
+	// Failures just below the threshold keep it healthy.
+	for i := 0; i < reenrichMaxConsecutiveEligFailures-1; i++ {
+		r.recordEligibilityFailure()
+	}
+	if !r.healthy() {
+		t.Fatalf("worker should still be healthy after %d failures (threshold %d)",
+			reenrichMaxConsecutiveEligFailures-1, reenrichMaxConsecutiveEligFailures)
+	}
+
+	// One more failure crosses the threshold -> degraded.
+	r.recordEligibilityFailure()
+	if r.healthy() {
+		t.Fatalf("worker should report degraded after %d consecutive failures",
+			reenrichMaxConsecutiveEligFailures)
+	}
+
+	// A single success resets the counter — the worker is doing work again.
+	r.recordEligibilitySuccess()
+	if !r.healthy() {
+		t.Fatal("a successful eligibility query must reset health to healthy")
+	}
+}


### PR DESCRIPTION
Fixes the remaining, still-open parts of **#32** and **#28**. The cursor-pagination infrastructure and the reenrich `ORDER BY RANDOM()` removal already landed on `main`; this PR closes the gaps that left those fixes ineffective in production.

## #32 — `/api/v2/results`: keyset cursor was unreachable

A consumer walking a filtered result set hit deep-OFFSET 500s and had **no working keyset alternative** because no `next_cursor` was ever emitted in OFFSET mode (issue Bug 3).

- **Emit `next_cursor` in OFFSET responses** (`meta.next_cursor`), not just in cursor mode — the headline unblock (issue fix #1). The consumer's defensive cursor opt-in starts working the moment this ships, no further consumer change needed. Offered only when the page is id-DESC ordered (default / `sort=id_desc`), since the cursor is keyed on `bl.id`. When the count query failed (`total_known:false`, Bug 2) a cursor is still offered on a full page so there's always a forward path.
- **`offset_too_deep` (400) instead of generic 500** when a deep OFFSET blows the statement timeout (issue fix #3), pointing the client at keyset.
- **Explicit `id_desc`** case in the sort whitelist so `sort=id_desc` is deterministic and keyset-consistent (issue bonus).

## #28 — reenrich reported "healthy" while stalled

The `ORDER BY RANDOM()` full-sort that blew the 5s `statement_timeout` every loop is already gone from `main`. This PR adds the **honest healthcheck** the issue asked for (fix #4 / Operational Invariant #7):

- `touchHealthFile` now accepts optional health probes; a degraded probe stops refreshing `/tmp/worker-healthy`, so the container healthcheck fails and autoheal restarts the stalled worker. serp/enrich callers are unchanged (no probe).
- reenrich tracks **consecutive eligibility-query failures** and reports degraded after 5 in a row (~75s of back-off). Any successful query (even zero rows) resets it — **self-healing**: if the query recovers before the health window lapses, no restart happens.

### On the index (issue fix #2)
**Deliberately not adding one.** The existing partial index `idx_bl_re_enriched_at … WHERE re_enriched_at IS NULL` already covers exactly the ~340K candidate set, and the query no longer sorts, so a second partial index on `(id)` gives the planner no benefit while adding write-cost on a hot, trigger-written table. The real residual cost — the per-row correlated `EXISTS` in the completeness score — is not index-addressable without a precomputed completeness flag (a larger schema+trigger change, out of scope here). Happy to add that as a follow-up if we want to drive the scan cost down further as the backlog grows.

## Tests
- `offsetNextCursor` matrix (id-order gating, more-rows logic, count-unknown forward path)
- `isStatementTimeout` classification (pq 57014 / context deadline / message)
- `resultsOrderBy(id_desc)`
- reenrich health gate (stays healthy below threshold, degrades at threshold, resets on success)

`go build/vet/test -tags playwright ./...` green.

Closes #32
Closes #28